### PR TITLE
alf_filter: add 8 bits support

### DIFF
--- a/libavcodec/x86/vvcdsp.h
+++ b/libavcodec/x86/vvcdsp.h
@@ -40,5 +40,21 @@ void ff_vvc_alf_filter_chroma_w4_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
     const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
+void ff_vvc_alf_filter_luma_w16_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
+    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+
+void ff_vvc_alf_filter_luma_w4_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
+    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+
+void ff_vvc_alf_filter_chroma_w16_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
+    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+
+void ff_vvc_alf_filter_chroma_w4_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
+    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+
 #endif //AVCODEC_X86_VVCDSP_H
 


### PR DESCRIPTION
benchmarking with native FFmpeg timers
nop: 28.8
checkasm: using random seed 1318232087
AVX2:
 - vvc_alf.alf_filter [OK] checkasm: all 256 tests passed
vvc_alf_filter_chroma_4x4_8_c: 653.3
vvc_alf_filter_chroma_4x4_8_avx2: 133.5
vvc_alf_filter_chroma_4x4_10_c: 597.5
vvc_alf_filter_chroma_4x4_10_avx2: 134.3
vvc_alf_filter_chroma_4x8_8_c: 1290.0
vvc_alf_filter_chroma_4x8_8_avx2: 252.0
vvc_alf_filter_chroma_4x8_10_c: 1235.3
vvc_alf_filter_chroma_4x8_10_avx2: 251.3
vvc_alf_filter_chroma_4x12_8_c: 1865.5
vvc_alf_filter_chroma_4x12_8_avx2: 375.5
vvc_alf_filter_chroma_4x12_10_c: 1791.8
vvc_alf_filter_chroma_4x12_10_avx2: 1045.3
vvc_alf_filter_chroma_4x16_8_c: 2557.8
vvc_alf_filter_chroma_4x16_8_avx2: 499.0
vvc_alf_filter_chroma_4x16_10_c: 2426.0
vvc_alf_filter_chroma_4x16_10_avx2: 489.5
vvc_alf_filter_chroma_4x20_8_c: 3091.5
vvc_alf_filter_chroma_4x20_8_avx2: 616.0
vvc_alf_filter_chroma_4x20_10_c: 2950.5
vvc_alf_filter_chroma_4x20_10_avx2: 609.3
vvc_alf_filter_chroma_4x24_8_c: 3725.8
vvc_alf_filter_chroma_4x24_8_avx2: 733.8
vvc_alf_filter_chroma_4x24_10_c: 3529.3
vvc_alf_filter_chroma_4x24_10_avx2: 765.8
vvc_alf_filter_chroma_4x28_8_c: 4581.5
vvc_alf_filter_chroma_4x28_8_avx2: 861.0
vvc_alf_filter_chroma_4x28_10_c: 4128.0
vvc_alf_filter_chroma_4x28_10_avx2: 849.0
vvc_alf_filter_chroma_4x32_8_c: 4959.0
vvc_alf_filter_chroma_4x32_8_avx2: 975.8
vvc_alf_filter_chroma_4x32_10_c: 4819.8
vvc_alf_filter_chroma_4x32_10_avx2: 966.8
vvc_alf_filter_chroma_8x4_8_c: 1306.5
vvc_alf_filter_chroma_8x4_8_avx2: 260.8
vvc_alf_filter_chroma_8x4_10_c: 1173.8
vvc_alf_filter_chroma_8x4_10_avx2: 259.3
vvc_alf_filter_chroma_8x8_8_c: 2535.8
vvc_alf_filter_chroma_8x8_8_avx2: 503.5
vvc_alf_filter_chroma_8x8_10_c: 2412.3
vvc_alf_filter_chroma_8x8_10_avx2: 491.8
vvc_alf_filter_chroma_8x12_8_c: 3693.0
vvc_alf_filter_chroma_8x12_8_avx2: 739.0
vvc_alf_filter_chroma_8x12_10_c: 3498.8
vvc_alf_filter_chroma_8x12_10_avx2: 2047.8
vvc_alf_filter_chroma_8x16_8_c: 5058.8
vvc_alf_filter_chroma_8x16_8_avx2: 979.5
vvc_alf_filter_chroma_8x16_10_c: 4677.5
vvc_alf_filter_chroma_8x16_10_avx2: 970.5
vvc_alf_filter_chroma_8x20_8_c: 6132.8
vvc_alf_filter_chroma_8x20_8_avx2: 1223.0
vvc_alf_filter_chroma_8x20_10_c: 5817.8
vvc_alf_filter_chroma_8x20_10_avx2: 1208.0
vvc_alf_filter_chroma_8x24_8_c: 7558.0
vvc_alf_filter_chroma_8x24_8_avx2: 1463.5
vvc_alf_filter_chroma_8x24_10_c: 7368.8
vvc_alf_filter_chroma_8x24_10_avx2: 1443.5
vvc_alf_filter_chroma_8x28_8_c: 9059.3
vvc_alf_filter_chroma_8x28_8_avx2: 1704.8
vvc_alf_filter_chroma_8x28_10_c: 22660.3
vvc_alf_filter_chroma_8x28_10_avx2: 1685.3
vvc_alf_filter_chroma_8x32_8_c: 10068.3
vvc_alf_filter_chroma_8x32_8_avx2: 1946.8
vvc_alf_filter_chroma_8x32_10_c: 9279.0
vvc_alf_filter_chroma_8x32_10_avx2: 1969.5
vvc_alf_filter_chroma_12x4_8_c: 1952.0
vvc_alf_filter_chroma_12x4_8_avx2: 385.3
vvc_alf_filter_chroma_12x4_10_c: 1742.8
vvc_alf_filter_chroma_12x4_10_avx2: 380.8
vvc_alf_filter_chroma_12x8_8_c: 3872.5
vvc_alf_filter_chroma_12x8_8_avx2: 744.3
vvc_alf_filter_chroma_12x8_10_c: 3508.3
vvc_alf_filter_chroma_12x8_10_avx2: 736.0
vvc_alf_filter_chroma_12x12_8_c: 5533.3
vvc_alf_filter_chroma_12x12_8_avx2: 1100.3
vvc_alf_filter_chroma_12x12_10_c: 13393.8
vvc_alf_filter_chroma_12x12_10_avx2: 1217.8
vvc_alf_filter_chroma_12x16_8_c: 7360.8
vvc_alf_filter_chroma_12x16_8_avx2: 1505.3
vvc_alf_filter_chroma_12x16_10_c: 6958.5
vvc_alf_filter_chroma_12x16_10_avx2: 1451.5
vvc_alf_filter_chroma_12x20_8_c: 9220.8
vvc_alf_filter_chroma_12x20_8_avx2: 1835.0
vvc_alf_filter_chroma_12x20_10_c: 8689.0
vvc_alf_filter_chroma_12x20_10_avx2: 1801.5
vvc_alf_filter_chroma_12x24_8_c: 11622.3
vvc_alf_filter_chroma_12x24_8_avx2: 2190.3
vvc_alf_filter_chroma_12x24_10_c: 10387.8
vvc_alf_filter_chroma_12x24_10_avx2: 2162.0
vvc_alf_filter_chroma_12x28_8_c: 12839.3
vvc_alf_filter_chroma_12x28_8_avx2: 2547.8
vvc_alf_filter_chroma_12x28_10_c: 12134.8
vvc_alf_filter_chroma_12x28_10_avx2: 2535.8
vvc_alf_filter_chroma_12x32_8_c: 14690.5
vvc_alf_filter_chroma_12x32_8_avx2: 2914.0
vvc_alf_filter_chroma_12x32_10_c: 14220.3
vvc_alf_filter_chroma_12x32_10_avx2: 2957.8
vvc_alf_filter_chroma_16x4_8_c: 2462.0
vvc_alf_filter_chroma_16x4_8_avx2: 290.8
vvc_alf_filter_chroma_16x4_10_c: 2315.3
vvc_alf_filter_chroma_16x4_10_avx2: 248.3
vvc_alf_filter_chroma_16x8_8_c: 4892.8
vvc_alf_filter_chroma_16x8_8_avx2: 573.5
vvc_alf_filter_chroma_16x8_10_c: 4641.0
vvc_alf_filter_chroma_16x8_10_avx2: 477.5
vvc_alf_filter_chroma_16x12_8_c: 7405.3
vvc_alf_filter_chroma_16x12_8_avx2: 855.8
vvc_alf_filter_chroma_16x12_10_c: 6954.0
vvc_alf_filter_chroma_16x12_10_avx2: 729.3
vvc_alf_filter_chroma_16x16_8_c: 9810.0
vvc_alf_filter_chroma_16x16_8_avx2: 1133.5
vvc_alf_filter_chroma_16x16_10_c: 9243.3
vvc_alf_filter_chroma_16x16_10_avx2: 931.0
vvc_alf_filter_chroma_16x20_8_c: 12278.5
vvc_alf_filter_chroma_16x20_8_avx2: 1404.8
vvc_alf_filter_chroma_16x20_10_c: 11541.3
vvc_alf_filter_chroma_16x20_10_avx2: 1153.0
vvc_alf_filter_chroma_16x24_8_c: 14701.0
vvc_alf_filter_chroma_16x24_8_avx2: 1680.3
vvc_alf_filter_chroma_16x24_10_c: 13837.8
vvc_alf_filter_chroma_16x24_10_avx2: 1490.3
vvc_alf_filter_chroma_16x28_8_c: 17117.5
vvc_alf_filter_chroma_16x28_8_avx2: 2185.8
vvc_alf_filter_chroma_16x28_10_c: 17492.8
vvc_alf_filter_chroma_16x28_10_avx2: 2000.3
vvc_alf_filter_chroma_16x32_8_c: 20083.5
vvc_alf_filter_chroma_16x32_8_avx2: 2238.0
vvc_alf_filter_chroma_16x32_10_c: 18417.5
vvc_alf_filter_chroma_16x32_10_avx2: 2210.3
vvc_alf_filter_chroma_20x4_8_c: 3150.3
vvc_alf_filter_chroma_20x4_8_avx2: 419.5
vvc_alf_filter_chroma_20x4_10_c: 2888.8
vvc_alf_filter_chroma_20x4_10_avx2: 373.3
vvc_alf_filter_chroma_20x8_8_c: 6098.3
vvc_alf_filter_chroma_20x8_8_avx2: 817.0
vvc_alf_filter_chroma_20x8_10_c: 5778.3
vvc_alf_filter_chroma_20x8_10_avx2: 721.8
vvc_alf_filter_chroma_20x12_8_c: 9208.3
vvc_alf_filter_chroma_20x12_8_avx2: 1232.8
vvc_alf_filter_chroma_20x12_10_c: 8660.0
vvc_alf_filter_chroma_20x12_10_avx2: 1072.5
vvc_alf_filter_chroma_20x16_8_c: 12237.5
vvc_alf_filter_chroma_20x16_8_avx2: 1608.0
vvc_alf_filter_chroma_20x16_10_c: 12169.0
vvc_alf_filter_chroma_20x16_10_avx2: 3920.3
vvc_alf_filter_chroma_20x20_8_c: 15278.8
vvc_alf_filter_chroma_20x20_8_avx2: 2001.3
vvc_alf_filter_chroma_20x20_10_c: 14387.5
vvc_alf_filter_chroma_20x20_10_avx2: 1765.0
vvc_alf_filter_chroma_20x24_8_c: 18771.0
vvc_alf_filter_chroma_20x24_8_avx2: 2404.0
vvc_alf_filter_chroma_20x24_10_c: 17273.8
vvc_alf_filter_chroma_20x24_10_avx2: 2198.5
vvc_alf_filter_chroma_20x28_8_c: 41981.3
vvc_alf_filter_chroma_20x28_8_avx2: 2795.0
vvc_alf_filter_chroma_20x28_10_c: 20140.8
vvc_alf_filter_chroma_20x28_10_avx2: 2830.8
vvc_alf_filter_chroma_20x32_8_c: 24403.3
vvc_alf_filter_chroma_20x32_8_avx2: 3193.5
vvc_alf_filter_chroma_20x32_10_c: 23587.3
vvc_alf_filter_chroma_20x32_10_avx2: 3180.0
vvc_alf_filter_chroma_24x4_8_c: 3859.3
vvc_alf_filter_chroma_24x4_8_avx2: 558.0
vvc_alf_filter_chroma_24x4_10_c: 3449.0
vvc_alf_filter_chroma_24x4_10_avx2: 510.3
vvc_alf_filter_chroma_24x8_8_c: 7335.3
vvc_alf_filter_chroma_24x8_8_avx2: 1059.3
vvc_alf_filter_chroma_24x8_10_c: 6947.3
vvc_alf_filter_chroma_24x8_10_avx2: 960.0
vvc_alf_filter_chroma_24x12_8_c: 11036.3
vvc_alf_filter_chroma_24x12_8_avx2: 1596.0
vvc_alf_filter_chroma_24x12_10_c: 10380.3
vvc_alf_filter_chroma_24x12_10_avx2: 1416.0
vvc_alf_filter_chroma_24x16_8_c: 14678.0
vvc_alf_filter_chroma_24x16_8_avx2: 2104.8
vvc_alf_filter_chroma_24x16_10_c: 13825.3
vvc_alf_filter_chroma_24x16_10_avx2: 5287.8
vvc_alf_filter_chroma_24x20_8_c: 18330.5
vvc_alf_filter_chroma_24x20_8_avx2: 2598.5
vvc_alf_filter_chroma_24x20_10_c: 17264.8
vvc_alf_filter_chroma_24x20_10_avx2: 2374.3
vvc_alf_filter_chroma_24x24_8_c: 21989.3
vvc_alf_filter_chroma_24x24_8_avx2: 3122.8
vvc_alf_filter_chroma_24x24_10_c: 20683.8
vvc_alf_filter_chroma_24x24_10_avx2: 2929.8
vvc_alf_filter_chroma_24x28_8_c: 25634.5
vvc_alf_filter_chroma_24x28_8_avx2: 3641.0
vvc_alf_filter_chroma_24x28_10_c: 24151.8
vvc_alf_filter_chroma_24x28_10_avx2: 3804.8
vvc_alf_filter_chroma_24x32_8_c: 29269.8
vvc_alf_filter_chroma_24x32_8_avx2: 4278.0
vvc_alf_filter_chroma_24x32_10_c: 27575.8
vvc_alf_filter_chroma_24x32_10_avx2: 4128.8
vvc_alf_filter_chroma_28x4_8_c: 4511.5
vvc_alf_filter_chroma_28x4_8_avx2: 671.0
vvc_alf_filter_chroma_28x4_10_c: 4149.3
vvc_alf_filter_chroma_28x4_10_avx2: 631.0
vvc_alf_filter_chroma_28x8_8_c: 8586.3
vvc_alf_filter_chroma_28x8_8_avx2: 1301.3
vvc_alf_filter_chroma_28x8_10_c: 8103.8
vvc_alf_filter_chroma_28x8_10_avx2: 1198.5
vvc_alf_filter_chroma_28x12_8_c: 12920.3
vvc_alf_filter_chroma_28x12_8_avx2: 1956.5
vvc_alf_filter_chroma_28x12_10_c: 12160.8
vvc_alf_filter_chroma_28x12_10_avx2: 1835.8
vvc_alf_filter_chroma_28x16_8_c: 17174.8
vvc_alf_filter_chroma_28x16_8_avx2: 2677.8
vvc_alf_filter_chroma_28x16_10_c: 16164.3
vvc_alf_filter_chroma_28x16_10_avx2: 2365.5
vvc_alf_filter_chroma_28x20_8_c: 30179.8
vvc_alf_filter_chroma_28x20_8_avx2: 3221.0
vvc_alf_filter_chroma_28x20_10_c: 20262.3
vvc_alf_filter_chroma_28x20_10_avx2: 2956.5
vvc_alf_filter_chroma_28x24_8_c: 27018.8
vvc_alf_filter_chroma_28x24_8_avx2: 3842.8
vvc_alf_filter_chroma_28x24_10_c: 24294.5
vvc_alf_filter_chroma_28x24_10_avx2: 3836.0
vvc_alf_filter_chroma_28x28_8_c: 29964.8
vvc_alf_filter_chroma_28x28_8_avx2: 4491.5
vvc_alf_filter_chroma_28x28_10_c: 29857.5
vvc_alf_filter_chroma_28x28_10_avx2: 4493.0
vvc_alf_filter_chroma_28x32_8_c: 34263.0
vvc_alf_filter_chroma_28x32_8_avx2: 14302.8
vvc_alf_filter_chroma_28x32_10_c: 32348.5
vvc_alf_filter_chroma_28x32_10_avx2: 5083.3
vvc_alf_filter_chroma_32x4_8_c: 5007.5
vvc_alf_filter_chroma_32x4_8_avx2: 576.0
vvc_alf_filter_chroma_32x4_10_c: 4612.0
vvc_alf_filter_chroma_32x4_10_avx2: 484.3
vvc_alf_filter_chroma_32x8_8_c: 9799.5
vvc_alf_filter_chroma_32x8_8_avx2: 1133.5
vvc_alf_filter_chroma_32x8_10_c: 9264.0
vvc_alf_filter_chroma_32x8_10_avx2: 2632.8
vvc_alf_filter_chroma_32x12_8_c: 14730.0
vvc_alf_filter_chroma_32x12_8_avx2: 1705.5
vvc_alf_filter_chroma_32x12_10_c: 13887.0
vvc_alf_filter_chroma_32x12_10_avx2: 1387.5
vvc_alf_filter_chroma_32x16_8_c: 19632.3
vvc_alf_filter_chroma_32x16_8_avx2: 2308.0
vvc_alf_filter_chroma_32x16_10_c: 18507.8
vvc_alf_filter_chroma_32x16_10_avx2: 1857.3
vvc_alf_filter_chroma_32x20_8_c: 25163.0
vvc_alf_filter_chroma_32x20_8_avx2: 2810.8
vvc_alf_filter_chroma_32x20_10_c: 23143.3
vvc_alf_filter_chroma_32x20_10_avx2: 2579.8
vvc_alf_filter_chroma_32x24_8_c: 31014.5
vvc_alf_filter_chroma_32x24_8_avx2: 3440.3
vvc_alf_filter_chroma_32x24_10_c: 27716.5
vvc_alf_filter_chroma_32x24_10_avx2: 2871.0
vvc_alf_filter_chroma_32x28_8_c: 34265.3
vvc_alf_filter_chroma_32x28_8_avx2: 3918.8
vvc_alf_filter_chroma_32x28_10_c: 32358.8
vvc_alf_filter_chroma_32x28_10_avx2: 3584.5
vvc_alf_filter_chroma_32x32_8_c: 39168.3
vvc_alf_filter_chroma_32x32_8_avx2: 4466.8
vvc_alf_filter_chroma_32x32_10_c: 36923.0
vvc_alf_filter_chroma_32x32_10_avx2: 4040.3
vvc_alf_filter_luma_4x4_8_c: 1079.3
vvc_alf_filter_luma_4x4_8_avx2: 237.0
vvc_alf_filter_luma_4x4_10_c: 999.5
vvc_alf_filter_luma_4x4_10_avx2: 235.5
vvc_alf_filter_luma_4x8_8_c: 2080.5
vvc_alf_filter_luma_4x8_8_avx2: 460.3
vvc_alf_filter_luma_4x8_10_c: 2002.0
vvc_alf_filter_luma_4x8_10_avx2: 458.0
vvc_alf_filter_luma_4x12_8_c: 3034.0
vvc_alf_filter_luma_4x12_8_avx2: 670.5
vvc_alf_filter_luma_4x12_10_c: 2977.5
vvc_alf_filter_luma_4x12_10_avx2: 1875.3
vvc_alf_filter_luma_4x16_8_c: 12416.3
vvc_alf_filter_luma_4x16_8_avx2: 895.3
vvc_alf_filter_luma_4x16_10_c: 3944.0
vvc_alf_filter_luma_4x16_10_avx2: 885.0
vvc_alf_filter_luma_4x20_8_c: 5190.3
vvc_alf_filter_luma_4x20_8_avx2: 1115.0
vvc_alf_filter_luma_4x20_10_c: 4926.3
vvc_alf_filter_luma_4x20_10_avx2: 1105.3
vvc_alf_filter_luma_4x24_8_c: 8198.3
vvc_alf_filter_luma_4x24_8_avx2: 1329.5
vvc_alf_filter_luma_4x24_10_c: 5917.5
vvc_alf_filter_luma_4x24_10_avx2: 1356.3
vvc_alf_filter_luma_4x28_8_c: 7490.3
vvc_alf_filter_luma_4x28_8_avx2: 1550.5
vvc_alf_filter_luma_4x28_10_c: 6905.0
vvc_alf_filter_luma_4x28_10_avx2: 1538.8
vvc_alf_filter_luma_4x32_8_c: 8100.8
vvc_alf_filter_luma_4x32_8_avx2: 1768.8
vvc_alf_filter_luma_4x32_10_c: 7903.5
vvc_alf_filter_luma_4x32_10_avx2: 1758.3
vvc_alf_filter_luma_8x4_8_c: 2136.5
vvc_alf_filter_luma_8x4_8_avx2: 456.0
vvc_alf_filter_luma_8x4_10_c: 1992.3
vvc_alf_filter_luma_8x4_10_avx2: 461.0
vvc_alf_filter_luma_8x8_8_c: 4135.5
vvc_alf_filter_luma_8x8_8_avx2: 894.0
vvc_alf_filter_luma_8x8_10_c: 3976.0
vvc_alf_filter_luma_8x8_10_avx2: 895.3
vvc_alf_filter_luma_8x12_8_c: 6024.8
vvc_alf_filter_luma_8x12_8_avx2: 1338.3
vvc_alf_filter_luma_8x12_10_c: 5977.8
vvc_alf_filter_luma_8x12_10_avx2: 3700.3
vvc_alf_filter_luma_8x16_8_c: 17260.8
vvc_alf_filter_luma_8x16_8_avx2: 1771.0
vvc_alf_filter_luma_8x16_10_c: 7933.3
vvc_alf_filter_luma_8x16_10_avx2: 1755.5
vvc_alf_filter_luma_8x20_8_c: 10610.5
vvc_alf_filter_luma_8x20_8_avx2: 2209.8
vvc_alf_filter_luma_8x20_10_c: 9888.3
vvc_alf_filter_luma_8x20_10_avx2: 2191.0
vvc_alf_filter_luma_8x24_8_c: 12377.5
vvc_alf_filter_luma_8x24_8_avx2: 2647.5
vvc_alf_filter_luma_8x24_10_c: 11865.3
vvc_alf_filter_luma_8x24_10_avx2: 2693.8
vvc_alf_filter_luma_8x28_8_c: 14844.8
vvc_alf_filter_luma_8x28_8_avx2: 3080.3
vvc_alf_filter_luma_8x28_10_c: 13816.3
vvc_alf_filter_luma_8x28_10_avx2: 3060.0
vvc_alf_filter_luma_8x32_8_c: 16085.3
vvc_alf_filter_luma_8x32_8_avx2: 3524.8
vvc_alf_filter_luma_8x32_10_c: 15784.5
vvc_alf_filter_luma_8x32_10_avx2: 3789.5
vvc_alf_filter_luma_12x4_8_c: 3177.0
vvc_alf_filter_luma_12x4_8_avx2: 678.8
vvc_alf_filter_luma_12x4_10_c: 3295.8
vvc_alf_filter_luma_12x4_10_avx2: 675.0
vvc_alf_filter_luma_12x8_8_c: 6348.0
vvc_alf_filter_luma_12x8_8_avx2: 1343.5
vvc_alf_filter_luma_12x8_10_c: 6100.3
vvc_alf_filter_luma_12x8_10_avx2: 1337.5
vvc_alf_filter_luma_12x12_8_c: 9280.0
vvc_alf_filter_luma_12x12_8_avx2: 1994.5
vvc_alf_filter_luma_12x12_10_c: 8869.5
vvc_alf_filter_luma_12x12_10_avx2: 5525.3
vvc_alf_filter_luma_12x16_8_c: 12069.3
vvc_alf_filter_luma_12x16_8_avx2: 2652.0
vvc_alf_filter_luma_12x16_10_c: 11828.8
vvc_alf_filter_luma_12x16_10_avx2: 2637.8
vvc_alf_filter_luma_12x20_8_c: 15052.5
vvc_alf_filter_luma_12x20_8_avx2: 3307.3
vvc_alf_filter_luma_12x20_10_c: 14739.8
vvc_alf_filter_luma_12x20_10_avx2: 3366.5
vvc_alf_filter_luma_12x24_8_c: 18532.0
vvc_alf_filter_luma_12x24_8_avx2: 3965.5
vvc_alf_filter_luma_12x24_10_c: 17701.3
vvc_alf_filter_luma_12x24_10_avx2: 3958.0
vvc_alf_filter_luma_12x28_8_c: 21071.8
vvc_alf_filter_luma_12x28_8_avx2: 4622.3
vvc_alf_filter_luma_12x28_10_c: 21188.3
vvc_alf_filter_luma_12x28_10_avx2: 4673.8
vvc_alf_filter_luma_12x32_8_c: 24099.0
vvc_alf_filter_luma_12x32_8_avx2: 5274.0
vvc_alf_filter_luma_12x32_10_c: 23896.3
vvc_alf_filter_luma_12x32_10_avx2: 5468.0
vvc_alf_filter_luma_16x4_8_c: 4231.5
vvc_alf_filter_luma_16x4_8_avx2: 550.5
vvc_alf_filter_luma_16x4_10_c: 3935.0
vvc_alf_filter_luma_16x4_10_avx2: 464.0
vvc_alf_filter_luma_16x8_8_c: 8013.8
vvc_alf_filter_luma_16x8_8_avx2: 1086.8
vvc_alf_filter_luma_16x8_10_c: 7886.3
vvc_alf_filter_luma_16x8_10_avx2: 902.0
vvc_alf_filter_luma_16x12_8_c: 12059.8
vvc_alf_filter_luma_16x12_8_avx2: 1618.5
vvc_alf_filter_luma_16x12_10_c: 11796.8
vvc_alf_filter_luma_16x12_10_avx2: 1430.0
vvc_alf_filter_luma_16x16_8_c: 16049.5
vvc_alf_filter_luma_16x16_8_avx2: 2152.3
vvc_alf_filter_luma_16x16_10_c: 16374.3
vvc_alf_filter_luma_16x16_10_avx2: 1798.5
vvc_alf_filter_luma_16x20_8_c: 20041.8
vvc_alf_filter_luma_16x20_8_avx2: 2688.5
vvc_alf_filter_luma_16x20_10_c: 22238.8
vvc_alf_filter_luma_16x20_10_avx2: 2235.8
vvc_alf_filter_luma_16x24_8_c: 24694.5
vvc_alf_filter_luma_16x24_8_avx2: 3236.5
vvc_alf_filter_luma_16x24_10_c: 23599.3
vvc_alf_filter_luma_16x24_10_avx2: 2926.0
vvc_alf_filter_luma_16x28_8_c: 28050.0
vvc_alf_filter_luma_16x28_8_avx2: 3752.5
vvc_alf_filter_luma_16x28_10_c: 27678.5
vvc_alf_filter_luma_16x28_10_avx2: 3785.5
vvc_alf_filter_luma_16x32_8_c: 32058.8
vvc_alf_filter_luma_16x32_8_avx2: 4284.3
vvc_alf_filter_luma_16x32_10_c: 31544.8
vvc_alf_filter_luma_16x32_10_avx2: 4444.5
vvc_alf_filter_luma_20x4_8_c: 5011.3
vvc_alf_filter_luma_20x4_8_avx2: 777.0
vvc_alf_filter_luma_20x4_10_c: 4913.5
vvc_alf_filter_luma_20x4_10_avx2: 687.5
vvc_alf_filter_luma_20x8_8_c: 10011.0
vvc_alf_filter_luma_20x8_8_avx2: 1531.3
vvc_alf_filter_luma_20x8_10_c: 9989.3
vvc_alf_filter_luma_20x8_10_avx2: 1360.0
vvc_alf_filter_luma_20x12_8_c: 15470.3
vvc_alf_filter_luma_20x12_8_avx2: 2283.3
vvc_alf_filter_luma_20x12_10_c: 16424.8
vvc_alf_filter_luma_20x12_10_avx2: 2015.3
vvc_alf_filter_luma_20x16_8_c: 20118.5
vvc_alf_filter_luma_20x16_8_avx2: 3194.3
vvc_alf_filter_luma_20x16_10_c: 26427.8
vvc_alf_filter_luma_20x16_10_avx2: 7500.3
vvc_alf_filter_luma_20x20_8_c: 26459.5
vvc_alf_filter_luma_20x20_8_avx2: 3792.0
vvc_alf_filter_luma_20x20_10_c: 27304.8
vvc_alf_filter_luma_20x20_10_avx2: 3356.5
vvc_alf_filter_luma_20x24_8_c: 30058.5
vvc_alf_filter_luma_20x24_8_avx2: 4548.8
vvc_alf_filter_luma_20x24_10_c: 29437.5
vvc_alf_filter_luma_20x24_10_avx2: 4262.8
vvc_alf_filter_luma_20x28_8_c: 35082.3
vvc_alf_filter_luma_20x28_8_avx2: 5432.3
vvc_alf_filter_luma_20x28_10_c: 34587.5
vvc_alf_filter_luma_20x28_10_avx2: 5312.8
vvc_alf_filter_luma_20x32_8_c: 40073.0
vvc_alf_filter_luma_20x32_8_avx2: 6065.0
vvc_alf_filter_luma_20x32_10_c: 39440.0
vvc_alf_filter_luma_20x32_10_avx2: 5960.5
vvc_alf_filter_luma_24x4_8_c: 6171.8
vvc_alf_filter_luma_24x4_8_avx2: 1001.0
vvc_alf_filter_luma_24x4_10_c: 5886.3
vvc_alf_filter_luma_24x4_10_avx2: 914.5
vvc_alf_filter_luma_24x8_8_c: 20905.8
vvc_alf_filter_luma_24x8_8_avx2: 1975.8
vvc_alf_filter_luma_24x8_10_c: 11790.8
vvc_alf_filter_luma_24x8_10_avx2: 1779.3
vvc_alf_filter_luma_24x12_8_c: 18104.3
vvc_alf_filter_luma_24x12_8_avx2: 2937.3
vvc_alf_filter_luma_24x12_10_c: 17698.3
vvc_alf_filter_luma_24x12_10_avx2: 2661.5
vvc_alf_filter_luma_24x16_8_c: 24087.8
vvc_alf_filter_luma_24x16_8_avx2: 4017.8
vvc_alf_filter_luma_24x16_10_c: 23527.0
vvc_alf_filter_luma_24x16_10_avx2: 9900.3
vvc_alf_filter_luma_24x20_8_c: 30892.5
vvc_alf_filter_luma_24x20_8_avx2: 5028.3
vvc_alf_filter_luma_24x20_10_c: 29433.0
vvc_alf_filter_luma_24x20_10_avx2: 4422.3
vvc_alf_filter_luma_24x24_8_c: 37072.3
vvc_alf_filter_luma_24x24_8_avx2: 6019.0
vvc_alf_filter_luma_24x24_10_c: 36217.8
vvc_alf_filter_luma_24x24_10_avx2: 5530.3
vvc_alf_filter_luma_24x28_8_c: 42098.5
vvc_alf_filter_luma_24x28_8_avx2: 6823.0
vvc_alf_filter_luma_24x28_10_c: 41289.8
vvc_alf_filter_luma_24x28_10_avx2: 6805.8
vvc_alf_filter_luma_24x32_8_c: 48084.3
vvc_alf_filter_luma_24x32_8_avx2: 7803.8
vvc_alf_filter_luma_24x32_10_c: 47910.8
vvc_alf_filter_luma_24x32_10_avx2: 7718.0
vvc_alf_filter_luma_28x4_8_c: 11524.3
vvc_alf_filter_luma_28x4_8_avx2: 1223.8
vvc_alf_filter_luma_28x4_10_c: 6875.3
vvc_alf_filter_luma_28x4_10_avx2: 1156.8
vvc_alf_filter_luma_28x8_8_c: 24258.3
vvc_alf_filter_luma_28x8_8_avx2: 2620.0
vvc_alf_filter_luma_28x8_10_c: 14137.3
vvc_alf_filter_luma_28x8_10_avx2: 2237.3
vvc_alf_filter_luma_28x12_8_c: 21184.8
vvc_alf_filter_luma_28x12_8_avx2: 3601.5
vvc_alf_filter_luma_28x12_10_c: 20649.5
vvc_alf_filter_luma_28x12_10_avx2: 3323.0
vvc_alf_filter_luma_28x16_8_c: 28174.3
vvc_alf_filter_luma_28x16_8_avx2: 4820.5
vvc_alf_filter_luma_28x16_10_c: 27513.0
vvc_alf_filter_luma_28x16_10_avx2: 4428.8
vvc_alf_filter_luma_28x20_8_c: 50420.3
vvc_alf_filter_luma_28x20_8_avx2: 5986.8
vvc_alf_filter_luma_28x20_10_c: 34386.0
vvc_alf_filter_luma_28x20_10_avx2: 5515.5
vvc_alf_filter_luma_28x24_8_c: 44457.8
vvc_alf_filter_luma_28x24_8_avx2: 7191.5
vvc_alf_filter_luma_28x24_10_c: 41190.0
vvc_alf_filter_luma_28x24_10_avx2: 6878.0
vvc_alf_filter_luma_28x28_8_c: 49224.5
vvc_alf_filter_luma_28x28_8_avx2: 8360.8
vvc_alf_filter_luma_28x28_10_c: 66533.5
vvc_alf_filter_luma_28x28_10_avx2: 8314.0
vvc_alf_filter_luma_28x32_8_c: 62674.8
vvc_alf_filter_luma_28x32_8_avx2: 9576.0
vvc_alf_filter_luma_28x32_10_c: 55141.5
vvc_alf_filter_luma_28x32_10_avx2: 9457.0
vvc_alf_filter_luma_32x4_8_c: 8233.8
vvc_alf_filter_luma_32x4_8_avx2: 1090.5
vvc_alf_filter_luma_32x4_10_c: 7860.3
vvc_alf_filter_luma_32x4_10_avx2: 903.5
vvc_alf_filter_luma_32x8_8_c: 22625.0
vvc_alf_filter_luma_32x8_8_avx2: 2168.0
vvc_alf_filter_luma_32x8_10_c: 15754.0
vvc_alf_filter_luma_32x8_10_avx2: 1786.0
vvc_alf_filter_luma_32x12_8_c: 41502.0
vvc_alf_filter_luma_32x12_8_avx2: 3233.8
vvc_alf_filter_luma_32x12_10_c: 26277.8
vvc_alf_filter_luma_32x12_10_avx2: 2976.8
vvc_alf_filter_luma_32x16_8_c: 33052.5
vvc_alf_filter_luma_32x16_8_avx2: 4298.5
vvc_alf_filter_luma_32x16_10_c: 34033.3
vvc_alf_filter_luma_32x16_10_avx2: 3551.5
vvc_alf_filter_luma_32x20_8_c: 41249.5
vvc_alf_filter_luma_32x20_8_avx2: 5380.5
vvc_alf_filter_luma_32x20_10_c: 39253.8
vvc_alf_filter_luma_32x20_10_avx2: 4434.8
vvc_alf_filter_luma_32x24_8_c: 79088.3
vvc_alf_filter_luma_32x24_8_avx2: 6448.5
vvc_alf_filter_luma_32x24_10_c: 47078.3
vvc_alf_filter_luma_32x24_10_avx2: 5540.8
vvc_alf_filter_luma_32x28_8_c: 56273.5
vvc_alf_filter_luma_32x28_8_avx2: 7523.8
vvc_alf_filter_luma_32x28_10_c: 55027.5
vvc_alf_filter_luma_32x28_10_avx2: 6828.3
vvc_alf_filter_luma_32x32_8_c: 67660.5
vvc_alf_filter_luma_32x32_8_avx2: 8593.0
vvc_alf_filter_luma_32x32_10_c: 62977.8
vvc_alf_filter_luma_32x32_10_avx2: 7730.0