### PR TITLE
Do alf filter on a CTU instead of 32x32 block.

### DIFF
--- a/libavcodec/vvc_ctu.h
+++ b/libavcodec/vvc_ctu.h
@@ -288,6 +288,7 @@ struct VVCLocalContext {
     DECLARE_ALIGNED(32, uint8_t, sao_buffer)[(MAX_CTU_SIZE + 2 * SAO_PADDING_SIZE) * EDGE_EMU_BUFFER_STRIDE * 2];
     DECLARE_ALIGNED(32, uint8_t, alf_buffer_luma)[(MAX_CTU_SIZE + 2 * ALF_PADDING_SIZE) * EDGE_EMU_BUFFER_STRIDE * 2];
     DECLARE_ALIGNED(32, uint8_t, alf_buffer_chroma)[(MAX_CTU_SIZE + 2 * ALF_PADDING_SIZE) * EDGE_EMU_BUFFER_STRIDE * 2];
+    DECLARE_ALIGNED(32, int32_t, alf_gradient_tmp)[ALF_GRADIENT_SIZE * ALF_GRADIENT_SIZE * ALF_NUM_DIR];
 
     struct {
         int sbt_num_fourths_tb0;                ///< SbtNumFourthsTb0

--- a/libavcodec/vvc_filter.c
+++ b/libavcodec/vvc_filter.c
@@ -1197,8 +1197,11 @@ static void alf_filter_luma(VVCLocalContext *lc, uint8_t *_dst, const uint8_t *_
     const int ps                = fc->ps.sps->pixel_shift;
     const int vb_pos            = _vb_pos - y0;
     const int no_vb_height      = height > vb_pos ? vb_pos - ALF_VB_POS_ABOVE_LUMA : height;
-    int8_t coeff[ALF_SUBBLOCK_FILTER_SIZE];
-    int16_t clip[ALF_SUBBLOCK_FILTER_SIZE];
+    int8_t *coeff               = (int8_t*)lc->tmp;
+    int16_t *clip               = (int16_t *)lc->tmp1;
+
+    av_assert0(ALF_SUBBLOCK_FILTER_SIZE <= sizeof(lc->tmp));
+    av_assert0(ALF_SUBBLOCK_FILTER_SIZE * sizeof(int16_t) <= sizeof(lc->tmp1));
 
     for (int y = 0; y < no_vb_height; y += ALF_SUBBLOCK_SIZE) {
         for (int x = 0; x < width; x += ALF_SUBBLOCK_SIZE) {

--- a/libavcodec/vvc_filter.c
+++ b/libavcodec/vvc_filter.c
@@ -1168,6 +1168,9 @@ static void alf_get_coeff_and_clip(VVCLocalContext *lc, int8_t *coeff, int16_t *
     const int8_t  *coeff_set;
     const uint8_t *clip_idx_set;
     const uint8_t *class_to_filt;
+    const int size = width * height / ALF_BLOCK_SIZE / ALF_BLOCK_SIZE;
+    int class_idx[ALF_SUBBLOCK_SIZE / ALF_BLOCK_SIZE * ALF_SUBBLOCK_SIZE / ALF_BLOCK_SIZE];
+    int transpose_idx[ALF_SUBBLOCK_SIZE / ALF_BLOCK_SIZE * ALF_SUBBLOCK_SIZE / ALF_BLOCK_SIZE];
 
     if (alf->ctb_filt_set_idx_y < 16) {
         coeff_set = &ff_vvc_alf_fix_filt_coeff[0][0];
@@ -1180,9 +1183,9 @@ static void alf_get_coeff_and_clip(VVCLocalContext *lc, int8_t *coeff, int16_t *
         clip_idx_set = aps->luma_clip_idx;
         class_to_filt = ff_vvc_alf_aps_class_to_filt_map;
     }
-    fc->vvcdsp.alf.get_coeff_and_clip(coeff, clip, src, src_stride, width, height,
-        vb_pos, coeff_set, clip_idx_set, class_to_filt);
-
+    fc->vvcdsp.alf.classify(class_idx, transpose_idx, src, src_stride, width, height, vb_pos);
+    fc->vvcdsp.alf.recon_coeff_and_clip(coeff, clip, class_idx, transpose_idx, size,
+        coeff_set, clip_idx_set, class_to_filt);
 }
 
 static void alf_filter_luma(VVCLocalContext *lc, uint8_t *_dst, const uint8_t *_src,

--- a/libavcodec/vvc_filter.c
+++ b/libavcodec/vvc_filter.c
@@ -1183,7 +1183,8 @@ static void alf_get_coeff_and_clip(VVCLocalContext *lc, int8_t *coeff, int16_t *
         clip_idx_set = aps->luma_clip_idx;
         class_to_filt = ff_vvc_alf_aps_class_to_filt_map;
     }
-    fc->vvcdsp.alf.classify(class_idx, transpose_idx, src, src_stride, width, height, vb_pos);
+    fc->vvcdsp.alf.classify(class_idx, transpose_idx, src, src_stride, width, height,
+        vb_pos, lc->alf_gradient_tmp);
     fc->vvcdsp.alf.recon_coeff_and_clip(coeff, clip, class_idx, transpose_idx, size,
         coeff_set, clip_idx_set, class_to_filt);
 }

--- a/libavcodec/vvc_filter_template.c
+++ b/libavcodec/vvc_filter_template.c
@@ -645,7 +645,7 @@ static void FUNC(alf_classify)(int *class_idx, int *transpose_idx,
     const uint8_t *_src, const ptrdiff_t _src_stride, const int width, const int height,
     const int vb_pos)
 {
-    int gradient[ALF_NUM_DIR][ALF_GRADIENT_SIZE][ALF_GRADIENT_SIZE] = {0};
+    int gradient[ALF_GRADIENT_SIZE][ALF_GRADIENT_SIZE][ALF_NUM_DIR];
 
     const int h = height + ALF_GRADIENT_BORDER * 2;
     const int w = width  + ALF_GRADIENT_BORDER * 2;
@@ -680,10 +680,10 @@ static void FUNC(alf_classify)(int *class_idx, int *transpose_idx,
             const pixel *b1  = s3 + x + 1;
             const int val1   = (*p1) << 1;
 
-            gradient[ALF_DIR_VERT] [yg][xg] = FFABS(val0 - *a0 - *b0) + FFABS(val1 - *a1 - *b1);
-            gradient[ALF_DIR_HORZ] [yg][xg] = FFABS(val0 - *(p0 - 1) - *(p0 + 1)) + FFABS(val1 - *(p1 - 1) - *(p1 + 1));
-            gradient[ALF_DIR_DIGA0][yg][xg] = FFABS(val0 - *(a0 - 1) - *(b0 + 1)) + FFABS(val1 - *(a1 - 1) - *(b1 + 1));
-            gradient[ALF_DIR_DIGA1][yg][xg] = FFABS(val0 - *(a0 + 1) - *(b0 - 1)) + FFABS(val1 - *(a1 + 1) - *(b1 - 1));
+            gradient[yg][xg][ALF_DIR_VERT]  = FFABS(val0 - *a0 - *b0) + FFABS(val1 - *a1 - *b1);
+            gradient[yg][xg][ALF_DIR_HORZ]  = FFABS(val0 - *(p0 - 1) - *(p0 + 1)) + FFABS(val1 - *(p1 - 1) - *(p1 + 1));
+            gradient[yg][xg][ALF_DIR_DIGA0] = FFABS(val0 - *(a0 - 1) - *(b0 + 1)) + FFABS(val1 - *(a1 - 1) - *(b1 + 1));
+            gradient[yg][xg][ALF_DIR_DIGA1] = FFABS(val0 - *(a0 + 1) - *(b0 - 1)) + FFABS(val1 - *(a1 + 1) - *(b1 - 1));
         }
     }
 
@@ -706,10 +706,10 @@ static void FUNC(alf_classify)(int *class_idx, int *transpose_idx,
             //todo: optimize this
             for (int i = start; i < end; i++) {
                 for (int j = 0; j < size; j++) {
-                    sum[ALF_DIR_VERT]  += gradient[ALF_DIR_VERT][yg + i][xg + j];
-                    sum[ALF_DIR_HORZ]  += gradient[ALF_DIR_HORZ][yg + i][xg + j];
-                    sum[ALF_DIR_DIGA0] += gradient[ALF_DIR_DIGA0][yg + i][xg + j];
-                    sum[ALF_DIR_DIGA1] += gradient[ALF_DIR_DIGA1][yg + i][xg + j];
+                    sum[ALF_DIR_VERT]  += gradient[yg + i][xg + j][ALF_DIR_VERT];
+                    sum[ALF_DIR_HORZ]  += gradient[yg + i][xg + j][ALF_DIR_HORZ];
+                    sum[ALF_DIR_DIGA0] += gradient[yg + i][xg + j][ALF_DIR_DIGA0];
+                    sum[ALF_DIR_DIGA1] += gradient[yg + i][xg + j][ALF_DIR_DIGA1];
                 }
             }
             FUNC(alf_get_idx)(class_idx, transpose_idx, sum, ac);

--- a/libavcodec/vvc_filter_template.c
+++ b/libavcodec/vvc_filter_template.c
@@ -662,7 +662,7 @@ static void FUNC(alf_reconstruct_coeff_and_clip)(int8_t *coeff, int16_t *clip, c
 }
 
 static void FUNC(alf_get_coeff_and_clip)(int8_t *coeff, int16_t *clip,
-    const uint8_t *_src, ptrdiff_t src_stride, const int x0, const int y0, const int width, const int height,
+    const uint8_t *_src, ptrdiff_t src_stride, const int width, const int height,
     const int vb_pos, const int8_t *coeff_set, const uint8_t *clip_idx_set, const uint8_t *class_to_filt)
 {
     int gradient[ALF_NUM_DIR][ALF_GRADIENT_SIZE][ALF_GRADIENT_SIZE] = {0};
@@ -681,9 +681,9 @@ static void FUNC(alf_get_coeff_and_clip)(int8_t *coeff, int16_t *clip,
         const pixel *s2  = s1 + src_stride;
         const pixel *s3  = s2 + src_stride;
 
-        if (y0 + y == vb_pos)          //above
+        if (y == vb_pos)          //above
             s3 = s2;
-        else if (y0 + y == vb_pos + ALF_GRADIENT_BORDER)
+        else if (y == vb_pos + ALF_GRADIENT_BORDER)
             s0 = s1;
 
         for (int x = 0; x < w; x += ALF_GRADIENT_STEP) {
@@ -711,10 +711,10 @@ static void FUNC(alf_get_coeff_and_clip)(int8_t *coeff, int16_t *clip,
         int start = 0;
         int end   = (ALF_BLOCK_SIZE + ALF_GRADIENT_BORDER * 2) / ALF_GRADIENT_STEP;
         int ac    = 2;
-        if (y0 + y + ALF_BLOCK_SIZE == vb_pos) {
+        if (y + ALF_BLOCK_SIZE == vb_pos) {
             end -= ALF_GRADIENT_BORDER / ALF_GRADIENT_STEP;
             ac = 3;
-        } else if (y0 + y == vb_pos) {
+        } else if (y == vb_pos) {
             start += ALF_GRADIENT_BORDER / ALF_GRADIENT_STEP;
             ac = 3;
         }

--- a/libavcodec/vvc_filter_template.c
+++ b/libavcodec/vvc_filter_template.c
@@ -581,8 +581,6 @@ static void FUNC(alf_filter_cc)(uint8_t *_dst, ptrdiff_t dst_stride, const uint8
     }
 }
 
-#define ALF_GRADIENT_STEP   2
-
 #define ALF_DIR_VERT        0
 #define ALF_DIR_HORZ        1
 #define ALF_DIR_DIGA0       2
@@ -749,7 +747,6 @@ static void FUNC(alf_recon_coeff_and_clip)(int8_t *coeff, int16_t *clip,
     }
 }
 
-#undef ALF_GRADIENT_STEP
 #undef ALF_DIR_HORZ
 #undef ALF_DIR_VERT
 #undef ALF_DIR_DIGA0

--- a/libavcodec/vvcdec.h
+++ b/libavcodec/vvcdec.h
@@ -105,6 +105,10 @@
 #define ALF_VB_POS_ABOVE_LUMA       4
 #define ALF_VB_POS_ABOVE_CHROMA     2
 
+#define ALF_GRADIENT_BORDER         2
+#define ALF_GRADIENT_SIZE           ((ALF_SUBBLOCK_SIZE + ALF_GRADIENT_BORDER * 2) / 2)
+#define ALF_NUM_DIR                 4
+
 #define EDGE_EMU_BUFFER_STRIDE (MAX_PB_SIZE + 32)
 
 #define AFFINE_MIN_BLOCK_SIZE 4

--- a/libavcodec/vvcdec.h
+++ b/libavcodec/vvcdec.h
@@ -96,17 +96,15 @@
 #define ALF_PADDING_SIZE      8
 #define ALF_BLOCK_SIZE        4
 
-//local size to save stack memroy
-#define ALF_SUBBLOCK_SIZE    32
-
 #define ALF_BORDER_LUMA       3
 #define ALF_BORDER_CHROMA     2
 
 #define ALF_VB_POS_ABOVE_LUMA       4
 #define ALF_VB_POS_ABOVE_CHROMA     2
 
+#define ALF_GRADIENT_STEP           2
 #define ALF_GRADIENT_BORDER         2
-#define ALF_GRADIENT_SIZE           ((ALF_SUBBLOCK_SIZE + ALF_GRADIENT_BORDER * 2) / 2)
+#define ALF_GRADIENT_SIZE           ((MAX_CU_SIZE + ALF_GRADIENT_BORDER * 2) / ALF_GRADIENT_STEP)
 #define ALF_NUM_DIR                 4
 
 #define EDGE_EMU_BUFFER_STRIDE (MAX_PB_SIZE + 32)

--- a/libavcodec/vvcdsp.h
+++ b/libavcodec/vvcdsp.h
@@ -189,8 +189,11 @@ typedef struct VVCALFDSPContext {
     void (*filter_cc)(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *luma, ptrdiff_t luma_stride,
         int width, int height, int hs, int vs, const int8_t *filter, int vb_pos);
 
-    void (*get_coeff_and_clip)(int8_t *coeff, int16_t *clip,
-        const uint8_t *src, ptrdiff_t src_stride, int width, int height, int vb_pos,
+    void (*classify)(int *class_idx, int *transpose_idx,
+        const uint8_t *src, ptrdiff_t src_stride, int width, int height, int vb_pos);
+
+    void (*recon_coeff_and_clip)(int8_t *coeff, int16_t *clip,
+        const int *class_idx, const int *transpose_idx, int size,
         const int8_t *coeff_set, const uint8_t *clip_idx_set, const uint8_t *class_to_filt);
 } VVCALFDSPContext;
 

--- a/libavcodec/vvcdsp.h
+++ b/libavcodec/vvcdsp.h
@@ -190,7 +190,8 @@ typedef struct VVCALFDSPContext {
         int width, int height, int hs, int vs, const int8_t *filter, int vb_pos);
 
     void (*classify)(int *class_idx, int *transpose_idx,
-        const uint8_t *src, ptrdiff_t src_stride, int width, int height, int vb_pos);
+        const uint8_t *src, ptrdiff_t src_stride, int width, int height,
+        int vb_pos, int *gradient_tmp);
 
     void (*recon_coeff_and_clip)(int8_t *coeff, int16_t *clip,
         const int *class_idx, const int *transpose_idx, int size,

--- a/libavcodec/vvcdsp.h
+++ b/libavcodec/vvcdsp.h
@@ -190,7 +190,7 @@ typedef struct VVCALFDSPContext {
         int width, int height, int hs, int vs, const int8_t *filter, int vb_pos);
 
     void (*get_coeff_and_clip)(int8_t *coeff, int16_t *clip,
-        const uint8_t *src, ptrdiff_t src_stride, int x0, int y0, int width, int height, int vb_pos,
+        const uint8_t *src, ptrdiff_t src_stride, int width, int height, int vb_pos,
         const int8_t *coeff_set, const uint8_t *clip_idx_set, const uint8_t *class_to_filt);
 } VVCALFDSPContext;
 

--- a/tests/checkasm/vvc_alf.c
+++ b/tests/checkasm/vvc_alf.c
@@ -33,9 +33,9 @@
 static const uint32_t pixel_mask[3] = { 0xffffffff, 0x03ff03ff, 0x0fff0fff };
 
 #define SIZEOF_PIXEL ((bit_depth + 7) / 8)
-#define PIXEL_STRIDE (ALF_SUBBLOCK_SIZE + 2 * ALF_PADDING_SIZE)
+#define PIXEL_STRIDE (MAX_CU_SIZE + 2 * ALF_PADDING_SIZE)
 #define BUF_SIZE (PIXEL_STRIDE * (MAX_CTU_SIZE + 3 * 2) * 2) //+3 * 2 for top and bottom row, *2 for high bit depth
-#define LUMA_PARAMS_SIZE (ALF_SUBBLOCK_SIZE / 4 * ALF_SUBBLOCK_SIZE / 4 * ALF_NUM_COEFF_LUMA)
+#define LUMA_PARAMS_SIZE (MAX_CU_SIZE * MAX_CU_SIZE / ALF_BLOCK_SIZE / ALF_BLOCK_SIZE * ALF_NUM_COEFF_LUMA)
 
 #define randomize_buffers(buf0, buf1, size)                 \
     do {                                                    \
@@ -86,8 +86,8 @@ static void check_alf_filter(VVCDSPContext *c, const int bit_depth)
     randomize_buffers2(filter, LUMA_PARAMS_SIZE, 1);
     randomize_buffers2(clip, LUMA_PARAMS_SIZE, 0);
 
-    for (int h = 4; h <= ALF_SUBBLOCK_SIZE; h += 4) {
-        for (int w = 4; w <= ALF_SUBBLOCK_SIZE; w += 4) {
+    for (int h = 4; h <= MAX_CU_SIZE; h += 4) {
+        for (int w = 4; w <= MAX_CU_SIZE; w += 4) {
             if (check_func(c->alf.filter[LUMA], "vvc_alf_filter_luma_%dx%d_%d", w, h, bit_depth)) {
                 memset(dst0, 0, BUF_SIZE);
                 memset(dst1, 0, BUF_SIZE);


### PR DESCRIPTION
This is based on a review comment from Ronald 

> 2023-02-26 21:18:40     @BBB    Nuo: hi!
> 2023-02-26 21:18:49     @BBB    Nuo: C code is similar to your C code: https://code.videolan.org/videolan/dav1d/-/blob/master/src/loopfilter_tmpl.c
> 2023-02-26 21:19:20     @BBB    the h26x code tends to be a bit more complex because of the adaptive parameters (coded in bitstream, or based on q, etc.)
> 2023-02-26 21:19:25     @BBB    but the per-pixel stuff is not super-different
> 2023-02-26 21:20:06     @BBB    if you look at the loops below, you'll see the intended use by the simd, it's fairly obvious: do super-big blocks with many parameters to use the vector size as efficiently as possible
> 2023-02-26 21:20:29     @BBB    e.g. https://code.videolan.org/videolan/dav1d/-/blob/master/src/x86/loopfilter_avx2.asm
> 2023-02-26 21:20:34     @BBB    there's an avx512 variant also
> 2023-02-26 21:21:23     @BBB    using stack is ok. we tend to believe stack is bad, but it's all a balance. if you can double the block size with little increase in actual instructions, it's super-ok
> 2023-02-26 21:21:41     @BBB    you want to do 16-32 pixels per 32byte vector register
> 2023-02-26 21:21:45     -->     rvalue (~rvalue@user/rvalue) has joined #ffmpeg-devel
> 2023-02-26 21:22:49     @BBB    (and yes, you'll see that we always focus more on the "how much more faster can we get it", rather than "how much faster is it already" - it means it takes a bit longer but the end result is usually better)
> 2023-02-26 21:24:04     @BBB    let me know if you need explanation of the av1 deblock algo, it's implicit in the code so if you're unfamiliar with it, it can be confusing. and best to read the code bottom-up, i.e. start at the wrapper function at the bottom before moving to the macro on-top so it's clear how the m\
> acro is meant to be used
> 2023-02-26 21:26:43     Nuo     Great! this really helpfu. Let me read the code firstly. Will ping you if I have questions. Thank you very much.

But we did not find so much benefit from the test result. it may be related to implementation. Let us revisit it after other assembly code is ready.
clip | before | after | delta
-- | -- | -- | --
RitualDance_1920x1080_60_10_420_32_LD.26 | 43| 44 | 2.3%
RitualDance_1920x1080_60_10_420_37_RA.266 | 48 | 48 | 0%
Tango2_3840x2160_60_10_420_27_LD.266 | 10 | 10 | 0%
