### PR TITLE
libavcodec/vvc_filter: Fix unintialized memory region at  lc->sao_buffer

### DIFF
--- a/libavcodec/vvc_filter.c
+++ b/libavcodec/vvc_filter.c
@@ -249,6 +249,10 @@ void ff_vvc_sao_filter(VVCLocalContext *lc, int x, int y)
                                SAO_APPLIED);
                     copy_pixel(dst1 + pos, src1[src_idx] + pos, sh);
                 }
+            } else {
+                int left = 1 - left_edge;
+                uint8_t *dst1 = dst - dst_stride - (left << sh);
+                memset(dst1, 0, (2 + width) << sh);
             }
             if (!bottom_edge) {
                 int left = 1 - left_edge;


### PR DESCRIPTION
Valgrind reports an error of unintialized value at vvcdsp_template.c:200. The error is fixed by memsetting the lc->sao_buffer.