### PR TITLE
Continuous integration job for Windows/MSVC

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -54,7 +54,7 @@ jobs:
         path: main
 
     - name: Build
-      run: ./FFVS-Project-Generator/project_generator.exe --enable-gpl --enable-version3 --disable-bzlib --disable-iconv --disable-zlib --disable-lzma --disable-sdl --toolchain=msvc --rootdir=main
+      run: .\FFVS-Project-Generator\project_generate.exe --enable-gpl --enable-version3 --disable-bzlib --disable-iconv --disable-zlib --disable-lzma --disable-sdl --toolchain=msvc --rootdir=main
 
     - name: Download Bitstream
       uses: actions/checkout@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -34,10 +34,10 @@ jobs:
       run: cd .. && git clone https://github.com/ffvvc/tests.git tests
 
     - name: Unit test
-      run: cd .. && python3 tests/tools/ffmpeg.py tests/conformance/passed
+      run: cd .. && python3 tests/tools/ffmpeg.py --threads 4 tests/conformance/passed
 
     - name: Negative test
-      run: cd .. && python3 tests/tools/ffmpeg.py tests/conformance/failed || true
+      run: cd .. && python3 tests/tools/ffmpeg.py --threads 4 tests/conformance/failed || true
 
   windows:
     name: Windows.MSVC
@@ -73,7 +73,7 @@ jobs:
         path: tests
 
     - name: Unit test
-      run: python3 tests/tools/ffmpeg.py tests/conformance/passed
+      run: python3 tests/tools/ffmpeg.py --threads 2 tests/conformance/passed
 
     - name: Negative test
-      run: python3 tests/tools/ffmpeg.py tests/conformance/failed; if ( $? -eq $True ) { throw }
+      run: python3 tests/tools/ffmpeg.py --threads 2 tests/conformance/failed; if ( $? -eq $True ) { throw }

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -12,7 +12,7 @@ env:
 jobs:
 
   linux:
-    name: ${{ matrix.os }}.${{ matrix.compiler.compiler }}
+    name: Linux.${{ matrix.compiler.compiler }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,5 +36,33 @@ jobs:
     - name: Unit test
       run: cd .. && python3 tests/tools/ffmpeg.py tests/conformance/passed
 
-    - name: Negtive test
+    - name: Negative test
       run: cd .. && python3 tests/tools/ffmpeg.py tests/conformance/failed || true
+
+  windows:
+    name: Windows.MSVC
+    runs-on: windows-latest
+
+    steps:
+    - name: Get FFVS-Project-Generator
+      uses: Invoke-WebRequest -Uri https://github.com/ShiftMediaProject/FFVS-Project-Generator/releases/download/1.11.6/FFVS-Project-Generator_1.11.6_x64.zip -OutFile FFVS-Project-Generator.zip; Expand-Archive FFVS-Project-Generator.zip
+
+    - name: Get repository
+      uses: actions/checkout@v3
+      with:
+        path: main
+
+    - name: Build
+      uses: ./FFVS-Project-Generator/project_generator.exe --enable-gpl --enable-version3 --disable-bzlib --disable-iconv --disable-zlib --disable-lzma --disable-sdl --toolchain=msvc --rootdir=main
+
+    - name: Download Bitstream
+      uses: actions/checkout@v3
+      with:
+        repository: ffvvc/tests
+        path: tests
+
+    - name: Unit test
+      run: python3 tests/tools/ffmpeg.py tests/conformance/passed
+
+    - name: Negative test
+      run: python3 tests/tools/ffmpeg.py tests/conformance/failed || true

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -45,6 +45,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: Set up MSVC
+      uses: ilammy/msvc-dev-cmd@v1
+
     - name: Get FFVS-Project-Generator
       run: Invoke-WebRequest -Uri https://github.com/ShiftMediaProject/FFVS-Project-Generator/releases/download/1.11.6/FFVS-Project-Generator_1.11.6_x64.zip -OutFile FFVS-Project-Generator.zip; Expand-Archive FFVS-Project-Generator.zip
 
@@ -54,7 +57,7 @@ jobs:
         path: main
 
     - name: Build
-      run: .\FFVS-Project-Generator\project_generate.exe --enable-gpl --enable-version3 --disable-bzlib --disable-iconv --disable-zlib --disable-lzma --disable-sdl --toolchain=msvc --rootdir=main
+      run: .\FFVS-Project-Generator\project_generate.exe --rootdir=main --enable-ffmpeg --disable-everything --enable-decoder=vvc --enable-parser=vvc --enable-demuxer=vvc --enable-protocol=file --enable-protocol=pipe --enable-encoder=rawvideo --enable-muxer=rawvideo --enable-muxer=md5
 
     - name: Download Bitstream
       uses: actions/checkout@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Get FFVS-Project-Generator
-      uses: Invoke-WebRequest -Uri https://github.com/ShiftMediaProject/FFVS-Project-Generator/releases/download/1.11.6/FFVS-Project-Generator_1.11.6_x64.zip -OutFile FFVS-Project-Generator.zip; Expand-Archive FFVS-Project-Generator.zip
+      run: Invoke-WebRequest -Uri https://github.com/ShiftMediaProject/FFVS-Project-Generator/releases/download/1.11.6/FFVS-Project-Generator_1.11.6_x64.zip -OutFile FFVS-Project-Generator.zip; Expand-Archive FFVS-Project-Generator.zip
 
     - name: Get repository
       uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
         path: main
 
     - name: Build
-      uses: ./FFVS-Project-Generator/project_generator.exe --enable-gpl --enable-version3 --disable-bzlib --disable-iconv --disable-zlib --disable-lzma --disable-sdl --toolchain=msvc --rootdir=main
+      run: ./FFVS-Project-Generator/project_generator.exe --enable-gpl --enable-version3 --disable-bzlib --disable-iconv --disable-zlib --disable-lzma --disable-sdl --toolchain=msvc --rootdir=main
 
     - name: Download Bitstream
       uses: actions/checkout@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -43,7 +43,7 @@ jobs:
     name: Windows.MSVC
     runs-on: windows-latest
     env:
-      FFMPEG_PATH: msvc\bin
+      FFMPEG_PATH: msvc\bin\x64\ffmpeg.exe
 
     steps:
     - name: Set up MSVC
@@ -61,10 +61,10 @@ jobs:
         path: src/main
 
     - name: Generate visual studio project
-      run: .\FFVS-Project-Generator\project_generate.exe --rootdir=src/main --enable-ffmpeg --disable-everything --enable-decoder=vvc --enable-parser=vvc --enable-demuxer=vvc --enable-protocol=file --enable-protocol=pipe --enable-encoder=rawvideo --enable-muxer=rawvideo --enable-muxer=md5
+      run: .\FFVS-Project-Generator\project_generate.exe --rootdir=src/main --disable-everything --enable-ffmpeg  --enable-decoder=vvc --enable-parser=vvc --enable-demuxer=vvc --enable-protocol=file --enable-protocol=pipe --enable-encoder=rawvideo --enable-muxer=rawvideo --enable-muxer=md5
 
     - name: Build
-      run: msbuild src\main\SMP\ffmpeg.sln
+      run: msbuild -p:Configuration="Release" src\main\SMP\ffmpeg.sln
 
     - name: Download Bitstream
       uses: actions/checkout@v3
@@ -76,4 +76,4 @@ jobs:
       run: python3 tests/tools/ffmpeg.py tests/conformance/passed
 
     - name: Negative test
-      run: python3 tests/tools/ffmpeg.py tests/conformance/failed || true
+      run: python3 tests/tools/ffmpeg.py tests/conformance/failed; if ( $? -eq $True ) { throw }

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -7,11 +7,8 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-env:
-  FFMPEG_PATH: FFmpeg/ffmpeg
 
 jobs:
-
   linux:
     name: Linux.${{ matrix.compiler.compiler }}
     strategy:
@@ -20,6 +17,8 @@ jobs:
         compiler:
           - { compiler: GNU,  CC: gcc }
           - { compiler: LLVM, CC: clang}
+    env:
+      FFMPEG_PATH: FFmpeg/ffmpeg
 
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +42,8 @@ jobs:
   windows:
     name: Windows.MSVC
     runs-on: windows-latest
+    env:
+      FFMPEG_PATH: msvc\bin
 
     steps:
     - name: Set up MSVC
@@ -51,13 +52,19 @@ jobs:
     - name: Get FFVS-Project-Generator
       run: Invoke-WebRequest -Uri https://github.com/ShiftMediaProject/FFVS-Project-Generator/releases/download/1.11.6/FFVS-Project-Generator_1.11.6_x64.zip -OutFile FFVS-Project-Generator.zip; Expand-Archive FFVS-Project-Generator.zip
 
+    - name: Get NASM
+      run: Invoke-WebRequest -Uri https://github.com/ShiftMediaProject/VSNASM/releases/download/0.9/VSNASM.zip -OutFile VSNASM.zip; Expand-Archive VSNASM.zip; Start-Process .\VSNASM\install_script.bat
+
     - name: Get repository
       uses: actions/checkout@v3
       with:
-        path: main
+        path: src/main
+
+    - name: Generate visual studio project
+      run: .\FFVS-Project-Generator\project_generate.exe --rootdir=src/main --enable-ffmpeg --disable-everything --enable-decoder=vvc --enable-parser=vvc --enable-demuxer=vvc --enable-protocol=file --enable-protocol=pipe --enable-encoder=rawvideo --enable-muxer=rawvideo --enable-muxer=md5
 
     - name: Build
-      run: .\FFVS-Project-Generator\project_generate.exe --rootdir=main --enable-ffmpeg --disable-everything --enable-decoder=vvc --enable-parser=vvc --enable-demuxer=vvc --enable-protocol=file --enable-protocol=pipe --enable-encoder=rawvideo --enable-muxer=rawvideo --enable-muxer=md5
+      run: msbuild src\main\SMP\ffmpeg.sln
 
     - name: Download Bitstream
       uses: actions/checkout@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   FFMPEG_PATH: FFmpeg/ffmpeg


### PR DESCRIPTION
This PR adds CI for windows using [FFVS-Project-Generator](https://github.com/ShiftMediaProject/FFVS-Project-Generator). The steps are generally similar to the existing linux CI jobs, with one significant difference: as FFVS-Project-Generator does not currently support disabling assembly optimisations (see ShiftMediaProject/FFVS-Project-Generator#62), the Windows build is currently performed with assembly enabled and assembled using NASM.

One test (LTRP_A_ERICSSON_3) is actually [failing right now](https://github.com/frankplow/FFmpeg/actions/runs/4499236849/jobs/7916843917), and due to a mismatch rather than a timeout. I don't believe this is an issue with the CI configuration however. I would imagine the issue is in the assembly optimisations, rather than some OS/compiler-specific idiosyncrasy.

The solution generated by FFVS-Project-Generator feels a little fragile to me as I was setting this up. I had to do a fair bit of fiddling – some of the flags are interpreted slightly differently to the `./configure` script etc. I think in the long-term it may be better to perform MSVC builds using MSYS, which is also [recommended in the FFmpeg compilation guide](https://trac.ffmpeg.org/wiki/CompilationGuide/MSVC). This would also allow a matrix of compilers on windows as MinGW's Windows gcc could also be used. For now though, FFVS-Project-Generator seems to be working as a quick-and-dirty solution.

This PR will close #33.