### PR TITLE
executor.c: Refactor to use two queues.

### DIFF
--- a/libavcodec/executor.c
+++ b/libavcodec/executor.c
@@ -35,10 +35,12 @@ struct Executor {
     uint8_t *local_contexts;
     int thread_count;
 
-    pthread_mutex_t lock;
+    pthread_mutex_t notready_lock;
+    pthread_mutex_t ready_lock;
     pthread_cond_t cond;
     int die;
-    Task *tasks;
+    Task *notready_tasks;
+    Task *ready_tasks;
 };
 
 static void remove_task(Task **prev, Task *t)
@@ -53,37 +55,62 @@ static void add_task(Task **prev, Task *t)
     *prev   = t;
 }
 
+static void update_tasks(Executor *e)
+{
+    Task *task_buff = NULL;
+    Task **prev;
+    Task *t = NULL;
+    TaskCallbacks *cb = &e->cb;
+    pthread_mutex_lock(&e->notready_lock);
+    prev = &e->notready_tasks;
+    while(*prev){
+        if (cb->ready(*prev, cb->user_data)) {
+            t = *prev;
+            remove_task(prev,t);
+            add_task(&task_buff,t);
+        }else
+            prev=&(*prev)->next;
+    }
+    pthread_mutex_unlock(&e->notready_lock);
+    if(task_buff){
+        pthread_mutex_lock(&e->ready_lock);
+        do{
+            t = task_buff;
+            for (prev = &e->ready_tasks; *prev && cb->priority_higher(*prev, t); prev = &(*prev)->next)
+                /* nothing */;
+            remove_task(&task_buff,t);
+            add_task(prev,t);
+            pthread_cond_signal(&e->cond);
+        }while(task_buff);
+        pthread_mutex_unlock(&e->ready_lock);
+    }
+}
+
 static void *executor_worker_task(void *data)
 {
     ThreadInfo *ti = (ThreadInfo*)data;
     Executor *e = ti->e;
     void *lc       = e->local_contexts + ti->idx * e->cb.local_context_size;
-    Task **prev;
     TaskCallbacks *cb = &e->cb;
 
-    pthread_mutex_lock(&e->lock);
+    pthread_mutex_lock(&e->ready_lock);
     while (1) {
-        Task* t = NULL;
+        Task* t = e->ready_tasks;
         if (e->die) break;
 
-        for (prev = &e->tasks; *prev; prev = &(*prev)->next) {
-            if (cb->ready(*prev, cb->user_data)) {
-                t = *prev;
-                break;
-            }
-        }
         if (t) {
             //found one task
-            remove_task(prev, t);
-            pthread_mutex_unlock(&e->lock);
+            remove_task(&e->ready_tasks, t);
+            pthread_mutex_unlock(&e->ready_lock);
             cb->run(t, lc, cb->user_data);
-            pthread_mutex_lock(&e->lock);
+            update_tasks(e);
+            pthread_mutex_lock(&e->ready_lock);
         } else {
             //no task in one loop
-            pthread_cond_wait(&e->cond, &e->lock);
+            pthread_cond_wait(&e->cond, &e->ready_lock);
         }
     }
-    pthread_mutex_unlock(&e->lock);
+    pthread_mutex_unlock(&e->ready_lock);
     return NULL;
 }
 
@@ -111,13 +138,16 @@ Executor* ff_executor_alloc(const TaskCallbacks *cb, int thread_count)
         ti->idx = i;
     }
 
-    ret = pthread_mutex_init(&e->lock, NULL);
+    ret = pthread_mutex_init(&e->ready_lock, NULL);
     if (ret)
         goto free_threads;
+    ret = pthread_mutex_init(&e->notready_lock, NULL);
+    if (ret)
+        goto destroy_ready_lock;
 
     ret = pthread_cond_init(&e->cond, NULL);
     if (ret)
-        goto destroy_lock;
+        goto destroy_notready_lock;
 
     for (i = 0; i < thread_count; i++) {
         ThreadInfo *ti = e->threads + i;
@@ -129,15 +159,17 @@ Executor* ff_executor_alloc(const TaskCallbacks *cb, int thread_count)
     return e;
 
 join_threads:
-    pthread_mutex_lock(&e->lock);
+    pthread_mutex_lock(&e->ready_lock);
     e->die = 1;
     pthread_cond_broadcast(&e->cond);
-    pthread_mutex_unlock(&e->lock);
+    pthread_mutex_unlock(&e->ready_lock);
     for (j = 0; j < i; j++)
         pthread_join(e->threads[j].thread, NULL);
     pthread_cond_destroy(&e->cond);
-destroy_lock:
-    pthread_mutex_destroy(&e->lock);
+destroy_notready_lock:
+    pthread_mutex_destroy(&e->notready_lock);
+destroy_ready_lock:
+    pthread_mutex_destroy(&e->ready_lock);
 free_threads:
     av_free(e->threads);
 free_contexts:
@@ -155,15 +187,16 @@ void ff_executor_free(Executor **executor)
     e = *executor;
 
     //singal die
-    pthread_mutex_lock(&e->lock);
+    pthread_mutex_lock(&e->ready_lock);
     e->die = 1;
     pthread_cond_broadcast(&e->cond);
-    pthread_mutex_unlock(&e->lock);
+    pthread_mutex_unlock(&e->ready_lock);
 
     for (int i = 0; i < e->thread_count; i++)
         pthread_join(e->threads[i].thread, NULL);
     pthread_cond_destroy(&e->cond);
-    pthread_mutex_destroy(&e->lock);
+    pthread_mutex_destroy(&e->ready_lock);
+    pthread_mutex_destroy(&e->notready_lock);
 
     av_free(e->threads);
     av_free(e->local_contexts);
@@ -176,17 +209,25 @@ void ff_executor_execute(Executor *e, Task *t)
     TaskCallbacks *cb = &e->cb;
     Task **prev;
 
-    pthread_mutex_lock(&e->lock);
-    for (prev = &e->tasks; *prev && cb->priority_higher(*prev, t); prev = &(*prev)->next)
-        /* nothing */;
-    add_task(prev, t);
-    pthread_cond_signal(&e->cond);
-    pthread_mutex_unlock(&e->lock);
+    if (cb->ready(t, cb->user_data)) {
+        pthread_mutex_lock(&e->ready_lock);
+        for (prev = &e->ready_tasks; *prev && cb->priority_higher(*prev, t); prev = &(*prev)->next)
+            /* nothing */;
+        add_task(prev, t);
+        pthread_cond_signal(&e->cond);
+        pthread_mutex_unlock(&e->ready_lock);
+    }else{
+        pthread_mutex_lock(&e->notready_lock);
+        for (prev = &e->notready_tasks; *prev && cb->priority_higher(*prev, t); prev = &(*prev)->next)
+            /* nothing */;
+        add_task(prev, t);
+        pthread_mutex_unlock(&e->notready_lock);
+    }
 }
 
 void ff_executor_wakeup(Executor *e)
 {
-    pthread_mutex_lock(&e->lock);
+    pthread_mutex_lock(&e->ready_lock);
     pthread_cond_broadcast(&e->cond);
-    pthread_mutex_unlock(&e->lock);
+    pthread_mutex_unlock(&e->ready_lock);
 }


### PR DESCRIPTION
Implement #50
The queue is divided in two, one for ready and the other for not ready tasks, it use a new lock for the new queue.
In ff_executor_execute the ready status is checked to decide in what queue to insert, and only use pthread_cond_signal for the ready queue.
To update the not_ready queue a new function called update_tasks is executed after each runned task.
In update_tasks the lock of notready_tasks is acquired while iterating the queue, checking the ready status and removing the tasks from the queue and adding to a temporal queue called task_buff used as buffer to save the tasks to add to the ready queue, after the iteration task_buff is checked to see if there are task to add, if there are tasks the ready_lock is acquired and for each task we use priority to find when to insert it.
Result of executing the conformance tests:
`total = 211, passed = 211, failed = 0, skipped = 0`
`total = 62, passed = 0, failed = 3, skipped = 59`
I tried to using `perf record python3 tests/tools/ffmpeg.py --threads 1 tests/performance` to see a difference in __pthread_mutex_lock but in my machine i see:
`0,08%  ffmpeg_g  [kernel.kallsyms]  [k] native_queued_spin_lock_slowpath.part.0`
I'm not sure if i'm executing an incorrect command or if my CPU or Linux Kernel is causing the difference, so i don't have information on how efficient is my code to reduce schedule cost.