### PR TITLE
Change Win32

### DIFF
--- a/libavcodec/vvc_thread.c
+++ b/libavcodec/vvc_thread.c
@@ -569,7 +569,7 @@ int ff_vvc_task_run(Task *_t, void *local_context, void *user_data)
 
     if (!atomic_load(&ft->ret)) {
         if ((ret = run[t->type](s, lc, t)) < 0) {
-#ifdef WIN32
+#ifndef WIN32
             intptr_t zero = 0;
 #else
             int zero = 0;


### PR DESCRIPTION
```
In file included from vvcdec.h:27,
                 from vvc_thread.h:26,
                 from vvc_thread.c:23:
vvc_thread.c: In function 'ff_vvc_task_run':
vvc_thread.c:577:13: error: size mismatch in argument 2 of '__atomic_compare_exchange'
  577 |             atomic_compare_exchange_strong(&ft->ret, &zero, ret);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```