### PR TITLE
Change win32 compat `atomic_compare_exchange_strong` to  match C11 spec

### DIFF
--- a/compat/atomics/win32/stdatomic.h
+++ b/compat/atomics/win32/stdatomic.h
@@ -101,14 +101,8 @@ do {                                    \
 #define atomic_exchange_explicit(object, desired, order) \
     atomic_exchange(object, desired)
 
-static inline int atomic_compare_exchange_strong(intptr_t *object, intptr_t *expected,
-                                                 intptr_t desired)
-{
-    intptr_t old = *expected;
-    *expected = (intptr_t)InterlockedCompareExchangePointer(
-        (PVOID *)object, (PVOID)desired, (PVOID)old);
-    return *expected == old;
-}
+#define atomic_compare_exchange_strong(object, expected, desired)              \
+    (InterlockedCompareExchangePointer((PVOID *) object, (PVOID) desired, *((PVOID *) expected)) == *((PVOID *) expected))
 
 #define atomic_compare_exchange_strong_explicit(object, expected, desired, success, failure) \
     atomic_compare_exchange_strong(object, expected, desired)

--- a/compat/atomics/win32/stdatomic.h
+++ b/compat/atomics/win32/stdatomic.h
@@ -101,8 +101,15 @@ do {                                    \
 #define atomic_exchange_explicit(object, desired, order) \
     atomic_exchange(object, desired)
 
-#define atomic_compare_exchange_strong(object, expected, desired)              \
-    (InterlockedCompareExchangePointer((PVOID *) object, (PVOID) desired, *((PVOID *) expected)) == *((PVOID *) expected))
+#define atomic_compare_exchange_strong(object, expected, desired)                                              \
+    (sizeof(*object) == 2 ?                                                                                    \
+        InterlockedCompareExchange16((SHORT *) object, (SHORT) desired, *((SHORT *) expected)) == *expected    \
+    : sizeof(*object) == 4 ?                                                                                   \
+        InterlockedCompareExchange((LONG *) object, (LONG) desired, *((LONG *) expected)) == *expected         \
+    : sizeof(*object) == 8 ?                                                                                   \
+        InterlockedCompareExchange64((LONG64 *) object, (LONG64) desired, *((LONG64 *) expected)) == *expected \
+    : 0)
+
 
 #define atomic_compare_exchange_strong_explicit(object, expected, desired, success, failure) \
     atomic_compare_exchange_strong(object, expected, desired)

--- a/libavcodec/vvc_thread.c
+++ b/libavcodec/vvc_thread.c
@@ -569,11 +569,7 @@ int ff_vvc_task_run(Task *_t, void *local_context, void *user_data)
 
     if (!atomic_load(&ft->ret)) {
         if ((ret = run[t->type](s, lc, t)) < 0) {
-#ifdef WIN32
-            intptr_t zero = 0;
-#else
             int zero = 0;
-#endif
             atomic_compare_exchange_strong(&ft->ret, &zero, ret);
         }
     }


### PR DESCRIPTION
As a preface, `vvc_thread.c` is the only place in the entire FFmpeg codebase which uses `atomic_compare_*` so hopefully this isn't too risky a change – it feels like a daunting place to make one. The change to `compat/atomics/win32/stdatomic.h` probably belongs upstream but I thought I'd get it checked here first considering this is the only place where it will matter at the moment.

Previously, [OS-dependent code](https://github.com/ffvvc/FFmpeg/compare/main...frankplow:atomic-compare-compat?expand=1#diff-78541e21410448cbda0d65a10c6d253d3ba7b9be0bf9ef1404583da7b82f66f8L572) was needed to use `atomic_compare_exchange_strong`. This was causing issues with cross-compilation. This was necessary because the [definition of the function in the win32 atomic compatibility header](https://github.com/ffvvc/FFmpeg/compare/main...frankplow:atomic-compare-compat?expand=1#diff-402651b93ef3515030c1f81ac8780ca8bd26b195db4409525d714411bb37a7b2L104) did not match the C11 specification. The C11 spec describes the function as
```c
_Bool atomic_compare_exchange_strong(volatile A *object, C *expected, C desired)
```
where
* `A` is an atomic type
* `C` is its non-atomic counterpart

In FFmpeg's win32 atomic compatibility header, all atomic types are `intptr_t`s. `atomic_compare_exchange_strong` was defined as an inline function with the prototype
```c
static inline int atomic_compare_exchange_strong(intptr_t *object, intptr_t *expected, intptr_t desired)
```
which only matches the C11 specification for `atomic_intptr_t` - both `object` and `expected` are essentially `A`.

The new prototype is much more relaxed, it uses a macro to take *any* pointer `object` and `expected` and *any* `desired`. This is more relaxed than the C11 specification - it makes no assertions that `A` is atomic nor that `A` and `C` are counterparts. I figure this is better than the previous prototype though as it doesn't require OS-specific code to use the function every time and any mistakes will still be flagged when compiling with gcc for Linux (which is much more common than Windows/MSVC during development I imagine).

Its implementation uses [`InterlockedCompareExchangePointer`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-interlockedcompareexchangepointer)), which works with 64-bit operands on a 64-bit system and 32-bit operands on a 32-bit system. This is not the same as the C11 `atomic_compare_exchange_strong` – this takes arbitrarily-sized arguments. For this reason, the function currently produces a build warning:
```
warning C4312: 'type cast': conversion from 'int' to 'PVOID' of greater size
```
Should this instead be implemented with a switch statement on the size of the type to the Window's API's sized arguments e.g. [`InterlockedCompareExchange64`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-interlockedcompareexchange64)?

I believe this PR will supersede #56 and close #37.