### PR TITLE
Fix CI powershell exitcode negation

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -76,4 +76,4 @@ jobs:
       run: python3 tests/tools/ffmpeg.py --threads 2 tests/conformance/passed
 
     - name: Negative test
-      run: python3 tests/tools/ffmpeg.py --threads 2 tests/conformance/failed; if ( $? -eq $True ) { throw }
+      run: python3 tests/tools/ffmpeg.py --threads 2 tests/conformance/failed; if ( $LASTEXITCODE -ne 0 ) { exit 0 } else { exit 1 }


### PR DESCRIPTION
Fix negation of the exitcode for the expected-to-fail tests on the Windows CI runner.

* Check `$LASTEXITCODE` rather than `$?`
* Produce an error/success explicitly with `exit` rather than by throwing or not throwing
* Test code ≠ 0 rather than = 1