### PR TITLE
Add checkasm to CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -130,7 +130,7 @@ jobs:
       run: ./configure ${{ matrix.compiler.flags }} ${{ matrix.assembler.flags }} ${{ env.configure_flags }} || (tail ffbuild/config.log; false)
 
     - name: Build
-      run: make -j checkasm
+      run: make checkasm
 
     - name: Run tests
       run: ./tests/checkasm/checkasm


### PR DESCRIPTION
This PR adds checkasm to the GitHub Actions workflow using a Windows runner. At the minute, the [test is failing](https://github.com/frankplow/FFmpeg/actions/runs/4714065453/jobs/8360173070) with `failed to preserve register`. Not sure if this is something we can work around? The same configure flags work fine on my local machine

This PR will close #63.