### PR TITLE
CI - Build FFmpeg in ffvvc-test job using a single thread

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -73,7 +73,7 @@ jobs:
       run: cd FFmpeg && ./configure ${{ matrix.compiler.flags }} ${{ matrix.assembler.flags }} ${{ env.configure_flags }} || (tail ffbuild/config.log; false)
 
     - name: Build
-      run: cd FFmpeg && make -j
+      run: cd FFmpeg && make
 
     - name: Get tests
       uses: actions/checkout@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -85,7 +85,7 @@ jobs:
       run: python3 tests/tools/ffmpeg.py --threads ${{ matrix.os.runner_threads }} --ffmpeg-path=./FFmpeg/ffmpeg tests/conformance/passed
 
     - name: Negative test
-      run: python3 tests/tools/ffmpeg.py --threads ${{ env.runner_threads }} --ffmpeg-path=./FFmpeg/ffmpeg tests/conformance/failed || true
+      run: python3 tests/tools/ffmpeg.py --threads ${{ matrix.os.runner_threads }} --ffmpeg-path=./FFmpeg/ffmpeg tests/conformance/failed || true
 
   checkasm:
     name: checkasm / windows/${{ matrix.compiler.name }}/${{ matrix.assembler.name }}

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,14 +16,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: 
+        os:
           - { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4 }
           - { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 2 }
-        compiler: 
+        compiler:
           - { name: gcc, flags: --cc=gcc }
           - { name: clang, flags: --cc=clang }
           - { name: msvc, flags: --toolchain=msvc }
-        assembler: 
+        assembler:
           - { name: no asm, flags: --disable-asm }
           - { name: yasm, flags: --as=yasm }
           - { name: nasm, flags: --as=nasm }
@@ -76,7 +76,7 @@ jobs:
       run: cd FFmpeg && make -j
 
     - name: Get tests
-      uses: actions/checkout@v3 
+      uses: actions/checkout@v3
       with:
         repository: ffvvc/tests
         path: tests
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: 
+        compiler:
           - { name: msvc, flags: --toolchain=msvc }
         assembler:
           - { name: yasm, flags: --as=yasm }


### PR DESCRIPTION
68c056f071a543c50395515275a6f26e3223df64 builds checkasm using a single thread to prevent an intermittent error `unable to find mspdbcore.dll`. This issue seems to also affect building FFmpeg in the ffvvc-test job, so this PR builds this with a single thread also.

This PR aims to close #68.