### PR TITLE
build: fix standalone build fail for decoder

### DIFF
--- a/configure
+++ b/configure
@@ -2511,6 +2511,7 @@ CONFIG_EXTRA="
     vp3dsp
     vp56dsp
     vp8dsp
+    vvcparse
     wma_freqs
     wmv2dsp
 "
@@ -2968,7 +2969,7 @@ vp6f_decoder_select="vp6_decoder"
 vp7_decoder_select="h264pred videodsp vp8dsp"
 vp8_decoder_select="h264pred videodsp vp8dsp"
 vp9_decoder_select="videodsp vp9_parser vp9_superframe_split_bsf"
-vvc_decoder_select="cabac golomb videodsp"
+vvc_decoder_select="cabac golomb videodsp vvcparse"
 wcmv_decoder_select="inflate_wrapper"
 webp_decoder_select="vp8_decoder exif"
 wmalossless_decoder_select="llauddsp"

--- a/libavcodec/Makefile
+++ b/libavcodec/Makefile
@@ -169,6 +169,7 @@ OBJS-$(CONFIG_VIDEODSP)                += videodsp.o
 OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
 OBJS-$(CONFIG_VP56DSP)                 += vp56dsp.o
 OBJS-$(CONFIG_VP8DSP)                  += vp8dsp.o
+OBJS-$(CONFIG_VVCPARSE)                += vvc_ps.o vvc_data.o h2645data.o h2645_parse.o h2645_vui.o
 OBJS-$(CONFIG_V4L2_M2M)                += v4l2_m2m.o v4l2_context.o v4l2_buffers.o v4l2_fmt.o
 OBJS-$(CONFIG_WMA_FREQS)               += wma_freqs.o
 OBJS-$(CONFIG_WMV2DSP)                 += wmv2dsp.o


### PR DESCRIPTION
./configure --disable-everything --enable-decoder=vvc && make -j

error:
/usr/bin/ld: libavcodec/libavcodec.a(vvcdec.o): in function `decode_nal_units': /home/nuomi/codec/ffmpeg/libavcodec/vvcdec.c:942: undefined reference to `ff_h2645_packet_split' /usr/bin/ld: libavcodec/libavcodec.a(vvcdec.o): in function `frame_context_free': ...