### PR TITLE
12-Bit Support

### DIFF
--- a/libavcodec/cbs_h266_syntax_template.c
+++ b/libavcodec/cbs_h266_syntax_template.c
@@ -880,7 +880,7 @@ static int FUNC(vps)(CodedBitstreamContext *ctx, RWContext *rw,
             ues(vps_ols_dpb_pic_width[i], 0, UINT16_MAX, 1, i);
             ues(vps_ols_dpb_pic_height[i], 0, UINT16_MAX, 1, i);
             ubs(2, vps_ols_dpb_chroma_format[i], 1, i);
-            ues(vps_ols_dpb_bitdepth_minus8[i], 0, 2, 1, i);
+            ues(vps_ols_dpb_bitdepth_minus8[i], 0, 8, 1, i);
             if (vps_num_dpb_params > 1 && vps_num_dpb_params != num_multi_layer_olss)
                 ues(vps_ols_dpb_params_idx[i], 0, vps_num_dpb_params - 1, 1, i);
             else if (vps_num_dpb_params == 1)
@@ -1125,7 +1125,7 @@ static int FUNC(sps)(CodedBitstreamContext *ctx, RWContext *rw,
     }
 
 
-    ue(sps_bitdepth_minus8,   0, 2);
+    ue(sps_bitdepth_minus8, 0, 8);
     qp_bd_offset = 6 * current->sps_bitdepth_minus8;
 
     flag(sps_entropy_coding_sync_enabled_flag);

--- a/libavcodec/vvc/vvc_ps.c
+++ b/libavcodec/vvc/vvc_ps.c
@@ -259,9 +259,15 @@ static int map_pixel_format(VVCSPS *sps, void *log_ctx)
         if (sps->chroma_format_idc == 2) sps->pix_fmt = AV_PIX_FMT_YUV422P10;
         if (sps->chroma_format_idc == 3) sps->pix_fmt = AV_PIX_FMT_YUV444P10;
         break;
+    case 12:
+        if (sps->chroma_format_idc == 0) sps->pix_fmt = AV_PIX_FMT_GRAY12;
+        if (sps->chroma_format_idc == 1) sps->pix_fmt = AV_PIX_FMT_YUV420P12;
+        if (sps->chroma_format_idc == 2) sps->pix_fmt = AV_PIX_FMT_YUV422P12;
+        if (sps->chroma_format_idc == 3) sps->pix_fmt = AV_PIX_FMT_YUV444P12;
+        break;
     default:
         av_log(log_ctx, AV_LOG_ERROR,
-               "The following bit-depths are currently specified: 8, 10 bits, "
+               "The following bit-depths are currently specified: 8, 10, 12 bits, "
                "chroma_format_idc is %d, depth is %d\n",
                sps->chroma_format_idc, sps->bit_depth);
         return AVERROR_INVALIDDATA;
@@ -471,7 +477,7 @@ static int sps_parse_subpic(VVCSPS *sps, GetBitContext *gb, void *log_ctx)
 static int sps_parse_bit_depth(VVCSPS *sps, GetBitContext *gb, void *log_ctx)
 {
     sps->bit_depth = get_ue_golomb_long(gb) + 8;
-    if (sps->bit_depth > 10) {
+    if (sps->bit_depth > 12) {
         avpriv_report_missing_feature(log_ctx, "%d bits", sps->bit_depth);
         return AVERROR_PATCHWELCOME;
     }

--- a/libavcodec/vvc/vvcdsp.c
+++ b/libavcodec/vvc/vvcdsp.c
@@ -291,6 +291,10 @@ typedef struct IntraEdgeParams {
 #include "vvcdsp_template.c"
 #undef BIT_DEPTH
 
+#define BIT_DEPTH 12
+#include "vvcdsp_template.c"
+#undef BIT_DEPTH
+
 void ff_vvc_dsp_init(VVCDSPContext *vvcdsp, int bit_depth)
 {
 #undef FUNC
@@ -306,6 +310,9 @@ void ff_vvc_dsp_init(VVCDSPContext *vvcdsp, int bit_depth)
     FUNC(ff_vvc_alf_dsp_init, depth)(&vvcdsp->alf);                             \
 
     switch (bit_depth) {
+    case 12:
+        VVC_DSP(12);
+        break;
     case 10:
         VVC_DSP(10);
         break;

--- a/libavcodec/vvc_parser.c
+++ b/libavcodec/vvc_parser.c
@@ -77,6 +77,11 @@ static const enum AVPixelFormat pix_fmts_10bit[] = {
     AV_PIX_FMT_YUV422P10, AV_PIX_FMT_YUV444P10
 };
 
+static const enum AVPixelFormat pix_fmts_12bit[] = {
+    AV_PIX_FMT_GRAY12, AV_PIX_FMT_YUV420P12,
+    AV_PIX_FMT_YUV422P12, AV_PIX_FMT_YUV444P12
+};
+
 static int get_format(const H266RawSPS *sps)
 {
     switch (sps->sps_bitdepth_minus8) {
@@ -84,6 +89,8 @@ static int get_format(const H266RawSPS *sps)
             return pix_fmts_8bit[sps->sps_chroma_format_idc];
         case 2:
             return pix_fmts_10bit[sps->sps_chroma_format_idc];
+        case 4:
+            return pix_fmts_12bit[sps->sps_chroma_format_idc];
     }
     return AV_PIX_FMT_NONE;
 }


### PR DESCRIPTION
This PR adds support for 12-bit colour.

This is a draft as the tests are currently failing. Below shows a still from 12b444vvc1_B_Sony_2. There appears to be some coloured artefacts on the centre and left of the screen. Without wishing to jump to conclusions, I suspect this is an issue with the inter-prediction code.

<img width="1463" alt="Screenshot 2023-05-30 at 10 57 19" src="https://github.com/ffvvc/FFmpeg/assets/6375868/36667b51-30ad-471b-b525-1f4a2b21a3d2">

When using a bit depth higher than 10, the standard allows a bitstream to include the range extension in the SPS. In practice, most do this as this is required to enable the `sps_extended_precision_flag`, which increases dynamic range. There are, however, a handful of conformance bitstreams which use 12-bit colour without the range extension:
* 12b420Ivvc1_A_InterDigital_2
* 12b420SPvvc1_A_KDDI_2
* 12b420vvc1_A_Alibaba_2
* 12b444Ivvc1_A_Alibaba_2
* 12b444SPvvc1_A_Alibaba_2
* 12b444vvc1_A_Sony_2
* 12b444vvc1_B_Sony_2
* 12b444vvc1_C_Sony_2
* 12b444vvc1_D_Sony_2
* 12b444vvc1_E_Sony_2

In future, to make the most of the increased bit depths, we will likely want to implement the range extension, however this will require more substantial changes to the transform code and so is left to another PR. I have created #83 to track this.