### PR TITLE
Implement alf filter vb.

### DIFF
--- a/libavcodec/vvc/vvc_data.c
+++ b/libavcodec/vvc/vvc_data.c
@@ -1641,7 +1641,7 @@ const uint8_t ff_vvc_lfnst_tr_set_index[95] =
 uint8_t ff_vvc_default_scale_m[64 * 64];
 
 //< AlfFixFiltCoeff
-const int8_t ff_vvc_alf_fix_filt_coeff[64][12] = {
+const int16_t ff_vvc_alf_fix_filt_coeff[64][12] = {
     {   0,   0,   2,  -3,   1,  -4,   1,   7,  -1,   1,  -1,   5 },
     {   0,   0,   0,   0,   0,  -1,   0,   1,   0,   0,  -1,   2 },
     {   0,   0,   0,   0,   0,   0,   0,   1,   0,   0,   0,   0 },

--- a/libavcodec/vvc/vvc_data.h
+++ b/libavcodec/vvc/vvc_data.h
@@ -60,7 +60,7 @@ extern const uint8_t ff_vvc_gpm_weights_offset_x[VVC_GPM_NUM_PARTITION][4][4];
 extern const uint8_t ff_vvc_gpm_weights_offset_y[VVC_GPM_NUM_PARTITION][4][4];
 extern const uint8_t ff_vvc_gpm_weights[6][VVC_GPM_WEIGHT_SIZE * VVC_GPM_WEIGHT_SIZE];
 
-extern const int8_t  ff_vvc_alf_fix_filt_coeff[64][12];
+extern const int16_t  ff_vvc_alf_fix_filt_coeff[64][12];
 extern const uint8_t ff_vvc_alf_class_to_filt_map[16][25];
 extern const uint8_t ff_vvc_alf_aps_class_to_filt_map[25];
 

--- a/libavcodec/vvc/vvc_filter.c
+++ b/libavcodec/vvc/vvc_filter.c
@@ -1146,13 +1146,13 @@ static void alf_prepare_buffer(VVCFrameContext *fc, uint8_t *_dst, const uint8_t
 #define ALF_MAX_BLOCKS_IN_CTU   (MAX_CTU_SIZE * MAX_CTU_SIZE / ALF_BLOCK_SIZE / ALF_BLOCK_SIZE)
 #define ALF_MAX_FILTER_SIZE     (ALF_MAX_BLOCKS_IN_CTU * ALF_NUM_COEFF_LUMA)
 
-static void alf_get_coeff_and_clip(VVCLocalContext *lc, int8_t *coeff, int16_t *clip,
+static void alf_get_coeff_and_clip(VVCLocalContext *lc, int16_t *coeff, int16_t *clip,
     const uint8_t *src, ptrdiff_t src_stride, int width, int height, int vb_pos, ALFParams *alf)
 {
     const VVCFrameContext *fc   = lc->fc;
     const VVCSH *sh             = &lc->sc->sh;
     uint8_t fixed_clip_set[ALF_NUM_FILTERS_LUMA * ALF_NUM_COEFF_LUMA] = { 0 };
-    const int8_t  *coeff_set;
+    const int16_t *coeff_set;
     const uint8_t *clip_idx_set;
     const uint8_t *class_to_filt;
     const int size = width * height / ALF_BLOCK_SIZE / ALF_BLOCK_SIZE;
@@ -1184,7 +1184,7 @@ static void alf_filter_luma(VVCLocalContext *lc, uint8_t *dst, const uint8_t *sr
     int vb_pos                  = _vb_pos - y0;
     const int no_vb_height      = height > vb_pos ? vb_pos - ALF_VB_POS_ABOVE_LUMA : height;
     const int h                 = height - no_vb_height;
-    int8_t *coeff               = (int8_t*)lc->tmp;
+    int16_t *coeff               = (int16_t*)lc->tmp;
     int16_t *clip               = (int16_t *)lc->tmp1;
 
     av_assert0(ALF_MAX_FILTER_SIZE <= sizeof(lc->tmp));
@@ -1218,7 +1218,7 @@ static void alf_filter_chroma(VVCLocalContext *lc, uint8_t *dst, const uint8_t *
     const VVCSH *sh         = &lc->sc->sh;
     const VVCALF *aps       = (VVCALF *)fc->ps.alf_list[sh->alf.aps_id_chroma]->data;
     const int off           = alf->alf_ctb_filter_alt_idx[c_idx - 1] * ALF_NUM_COEFF_CHROMA;
-    const int8_t *coeff     = aps->chroma_coeff + off;
+    const int16_t *coeff     = aps->chroma_coeff + off;
     const int no_vb_height  = height > vb_pos ? vb_pos - ALF_VB_POS_ABOVE_CHROMA : height;
     int16_t clip[ALF_NUM_COEFF_CHROMA];
 
@@ -1245,7 +1245,7 @@ static void alf_filter_cc(VVCLocalContext *lc, uint8_t *dst, const uint8_t *luma
     if (aps_buf) {
         const VVCALF *aps   = (VVCALF *)aps_buf->data;
         const int off       = (alf->ctb_cc_idc[idx] - 1)* ALF_NUM_COEFF_CC;
-        const int8_t *coeff = aps->cc_coeff[idx] + off;
+        const int16_t *coeff = aps->cc_coeff[idx] + off;
 
         fc->vvcdsp.alf.filter_cc(dst, dst_stride, luma, luma_stride, width, height, hs, vs, coeff, vb_pos);
     }

--- a/libavcodec/vvc/vvc_filter_template.c
+++ b/libavcodec/vvc/vvc_filter_template.c
@@ -230,7 +230,7 @@ static av_always_inline int16_t FUNC(alf_clip)(pixel curr, pixel v0, pixel v1, i
 }
 
 static void FUNC(alf_filter_luma)(uint8_t *_dst, ptrdiff_t dst_stride, const uint8_t *_src, ptrdiff_t src_stride,
-    const int width, const int height, const int8_t *filter, const int16_t *clip)
+    const int width, const int height, const int16_t *filter, const int16_t *clip)
 {
     const pixel *src    = (pixel *)_src;
     const int shift     = 7;
@@ -297,7 +297,7 @@ static void FUNC(alf_filter_luma)(uint8_t *_dst, ptrdiff_t dst_stride, const uin
 }
 
 static void FUNC(alf_filter_luma_vb)(uint8_t *_dst, ptrdiff_t dst_stride, const uint8_t *_src, ptrdiff_t src_stride,
-    const int width, const int height, const int8_t *filter, const int16_t *clip, const int vb_pos)
+    const int width, const int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
 {
     const pixel *src    = (pixel *)_src;
     const int shift     = 7;
@@ -391,7 +391,7 @@ static void FUNC(alf_filter_luma_vb)(uint8_t *_dst, ptrdiff_t dst_stride, const 
 }
 
 static void FUNC(alf_filter_chroma)(uint8_t* _dst, ptrdiff_t dst_stride, const uint8_t* _src, ptrdiff_t src_stride,
-    const int width, const int height, const int8_t* filter, const int16_t* clip)
+    const int width, const int height, const int16_t* filter, const int16_t* clip)
 {
     const pixel *src = (pixel *)_src;
     const int shift  = 7;
@@ -450,7 +450,7 @@ static void FUNC(alf_filter_chroma)(uint8_t* _dst, ptrdiff_t dst_stride, const u
 }
 
 static void FUNC(alf_filter_chroma_vb)(uint8_t* _dst, ptrdiff_t dst_stride, const uint8_t* _src, ptrdiff_t src_stride,
-    const int width, const int height, const int8_t* filter, const int16_t* clip, const int vb_pos)
+    const int width, const int height, const int16_t* filter, const int16_t* clip, const int vb_pos)
 {
     const pixel *src = (pixel *)_src;
     const int shift  = 7;
@@ -536,7 +536,7 @@ static void FUNC(alf_filter_chroma_vb)(uint8_t* _dst, ptrdiff_t dst_stride, cons
 }
 
 static void FUNC(alf_filter_cc)(uint8_t *_dst, ptrdiff_t dst_stride, const uint8_t *_luma, const ptrdiff_t luma_stride,
-    const int width, const int height, const int hs, const int vs, const int8_t *filter, const int vb_pos)
+    const int width, const int height, const int hs, const int vs, const int16_t *filter, const int vb_pos)
 {
     const ptrdiff_t stride = luma_stride / sizeof(pixel);
 
@@ -695,9 +695,9 @@ static void FUNC(alf_classify)(int *class_idx, int *transpose_idx,
 
 }
 
-static void FUNC(alf_recon_coeff_and_clip)(int8_t *coeff, int16_t *clip,
+static void FUNC(alf_recon_coeff_and_clip)(int16_t *coeff, int16_t *clip,
     const int *class_idx, const int *transpose_idx, const int size,
-    const int8_t *coeff_set, const uint8_t *clip_idx_set, const uint8_t *class_to_filt)
+    const int16_t *coeff_set, const uint8_t *clip_idx_set, const uint8_t *class_to_filt)
 {
     const static int index[][ALF_NUM_COEFF_LUMA] = {
         { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 },
@@ -711,7 +711,7 @@ static void FUNC(alf_recon_coeff_and_clip)(int8_t *coeff, int16_t *clip,
     };
 
     for (int i = 0; i < size; i++) {
-        const int8_t  *src_coeff = coeff_set + class_to_filt[class_idx[i]] * ALF_NUM_COEFF_LUMA;
+        const int16_t  *src_coeff = coeff_set + class_to_filt[class_idx[i]] * ALF_NUM_COEFF_LUMA;
         const uint8_t *clip_idx  = clip_idx_set + class_idx[i] * ALF_NUM_COEFF_LUMA;
 
         for (int j = 0; j < ALF_NUM_COEFF_LUMA; j++) {

--- a/libavcodec/vvc/vvc_filter_template.c
+++ b/libavcodec/vvc/vvc_filter_template.c
@@ -230,73 +230,6 @@ static av_always_inline int16_t FUNC(alf_clip)(pixel curr, pixel v0, pixel v1, i
 }
 
 static void FUNC(alf_filter_luma)(uint8_t *_dst, ptrdiff_t dst_stride, const uint8_t *_src, ptrdiff_t src_stride,
-    const int width, const int height, const int16_t *filter, const int16_t *clip)
-{
-    const pixel *src    = (pixel *)_src;
-    const int shift     = 7;
-    const int offset    = 1 << ( shift - 1 );
-
-    dst_stride /= sizeof(pixel);
-    src_stride /= sizeof(pixel);
-
-    for (int y = 0; y < height; y += ALF_BLOCK_SIZE) {
-        for (int x = 0; x < width; x += ALF_BLOCK_SIZE) {
-            const pixel *s0 = src + y * src_stride + x;
-            const pixel *s1 = s0 + src_stride;
-            const pixel *s2 = s0 - src_stride;
-            const pixel *s3 = s1 + src_stride;
-            const pixel *s4 = s2 - src_stride;
-            const pixel *s5 = s3 + src_stride;
-            const pixel *s6 = s4 - src_stride;
-
-            for (int i = 0; i < ALF_BLOCK_SIZE; i++) {
-                pixel *dst = (pixel *)_dst + (y + i) * dst_stride + x;
-
-                const pixel *p0 = s0 + i * src_stride;
-                const pixel *p1 = s1 + i * src_stride;
-                const pixel *p2 = s2 + i * src_stride;
-                const pixel *p3 = s3 + i * src_stride;
-                const pixel *p4 = s4 + i * src_stride;
-                const pixel *p5 = s5 + i * src_stride;
-                const pixel *p6 = s6 + i * src_stride;
-
-                for (int j = 0; j < ALF_BLOCK_SIZE; j++) {
-                    int sum = 0;
-                    const pixel curr = *p0;
-
-                    sum += filter[0]  * FUNC(alf_clip)(curr, p5[+0], p6[+0], clip[0]);
-                    sum += filter[1]  * FUNC(alf_clip)(curr, p3[+1], p4[-1], clip[1]);
-                    sum += filter[2]  * FUNC(alf_clip)(curr, p3[+0], p4[+0], clip[2]);
-                    sum += filter[3]  * FUNC(alf_clip)(curr, p3[-1], p4[+1], clip[3]);
-                    sum += filter[4]  * FUNC(alf_clip)(curr, p1[+2], p2[-2], clip[4]);
-                    sum += filter[5]  * FUNC(alf_clip)(curr, p1[+1], p2[-1], clip[5]);
-                    sum += filter[6]  * FUNC(alf_clip)(curr, p1[+0], p2[+0], clip[6]);
-                    sum += filter[7]  * FUNC(alf_clip)(curr, p1[-1], p2[+1], clip[7]);
-                    sum += filter[8]  * FUNC(alf_clip)(curr, p1[-2], p2[+2], clip[8]);
-                    sum += filter[9]  * FUNC(alf_clip)(curr, p0[+3], p0[-3], clip[9]);
-                    sum += filter[10] * FUNC(alf_clip)(curr, p0[+2], p0[-2], clip[10]);
-                    sum += filter[11] * FUNC(alf_clip)(curr, p0[+1], p0[-1], clip[11]);
-
-                    sum = (sum + offset) >> shift;
-                    sum += curr;
-                    dst[j] = CLIP(sum);
-
-                    p0++;
-                    p1++;
-                    p2++;
-                    p3++;
-                    p4++;
-                    p5++;
-                    p6++;
-                }
-            }
-            filter += ALF_NUM_COEFF_LUMA;
-            clip += ALF_NUM_COEFF_LUMA;
-        }
-    }
-}
-
-static void FUNC(alf_filter_luma_vb)(uint8_t *_dst, ptrdiff_t dst_stride, const uint8_t *_src, ptrdiff_t src_stride,
     const int width, const int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
 {
     const pixel *src    = (pixel *)_src;
@@ -391,65 +324,6 @@ static void FUNC(alf_filter_luma_vb)(uint8_t *_dst, ptrdiff_t dst_stride, const 
 }
 
 static void FUNC(alf_filter_chroma)(uint8_t* _dst, ptrdiff_t dst_stride, const uint8_t* _src, ptrdiff_t src_stride,
-    const int width, const int height, const int16_t* filter, const int16_t* clip)
-{
-    const pixel *src = (pixel *)_src;
-    const int shift  = 7;
-    const int offset = 1 << ( shift - 1 );
-
-    dst_stride /= sizeof(pixel);
-    src_stride /= sizeof(pixel);
-
-    for (int y = 0; y < height; y += ALF_BLOCK_SIZE) {
-        for (int x = 0; x < width; x += ALF_BLOCK_SIZE) {
-            const pixel *s0 = src + y * src_stride + x;
-            const pixel *s1 = s0 + src_stride;
-            const pixel *s2 = s0 - src_stride;
-            const pixel *s3 = s1 + src_stride;
-            const pixel *s4 = s2 - src_stride;
-            const pixel *s5 = s3 + src_stride;
-            const pixel *s6 = s4 - src_stride;
-
-            for (int i = 0; i < ALF_BLOCK_SIZE; i++) {
-                pixel *dst = (pixel *)_dst + (y + i) * dst_stride + x;
-
-                const pixel *p0 = s0 + i * src_stride;
-                const pixel *p1 = s1 + i * src_stride;
-                const pixel *p2 = s2 + i * src_stride;
-                const pixel *p3 = s3 + i * src_stride;
-                const pixel *p4 = s4 + i * src_stride;
-                const pixel *p5 = s5 + i * src_stride;
-                const pixel *p6 = s6 + i * src_stride;
-
-                for (int j = 0; j < ALF_BLOCK_SIZE; j++) {
-                    int sum = 0;
-                    const pixel curr = *p0;
-
-                    sum += filter[0]  * FUNC(alf_clip)(curr, p3[+0], p4[+0], clip[0]);
-                    sum += filter[1]  * FUNC(alf_clip)(curr, p1[+1], p2[-1], clip[1]);
-                    sum += filter[2]  * FUNC(alf_clip)(curr, p1[+0], p2[+0], clip[2]);
-                    sum += filter[3]  * FUNC(alf_clip)(curr, p1[-1], p2[+1], clip[3]);
-                    sum += filter[4]  * FUNC(alf_clip)(curr, p0[+2], p0[-2], clip[4]);
-                    sum += filter[5]  * FUNC(alf_clip)(curr, p0[+1], p0[-1], clip[5]);
-
-                    sum = (sum + offset) >> shift;
-                    sum += curr;
-                    dst[j] = CLIP(sum);
-
-                    p0++;
-                    p1++;
-                    p2++;
-                    p3++;
-                    p4++;
-                    p5++;
-                    p6++;
-                }
-            }
-        }
-    }
-}
-
-static void FUNC(alf_filter_chroma_vb)(uint8_t* _dst, ptrdiff_t dst_stride, const uint8_t* _src, ptrdiff_t src_stride,
     const int width, const int height, const int16_t* filter, const int16_t* clip, const int vb_pos)
 {
     const pixel *src = (pixel *)_src;
@@ -1206,11 +1080,9 @@ static void FUNC(ff_vvc_sao_dsp_init)(VVCSAODSPContext *const sao)
 
 static void FUNC(ff_vvc_alf_dsp_init)(VVCALFDSPContext *const alf)
 {
-    alf->filter[LUMA]       = FUNC(alf_filter_luma);
-    alf->filter[CHROMA]     = FUNC(alf_filter_chroma);
-    alf->filter_vb[LUMA]    = FUNC(alf_filter_luma_vb);
-    alf->filter_vb[CHROMA]  = FUNC(alf_filter_chroma_vb);
-    alf->filter_cc          = FUNC(alf_filter_cc);
-    alf->classify           = FUNC(alf_classify);
+    alf->filter[LUMA]    = FUNC(alf_filter_luma);
+    alf->filter[CHROMA]  = FUNC(alf_filter_chroma);
+    alf->filter_cc       = FUNC(alf_filter_cc);
+    alf->classify        = FUNC(alf_classify);
     alf->recon_coeff_and_clip = FUNC(alf_recon_coeff_and_clip);
 }

--- a/libavcodec/vvc/vvc_ps.c
+++ b/libavcodec/vvc/vvc_ps.c
@@ -2584,7 +2584,7 @@ int ff_vvc_decode_ph(VVCParamSets *ps, const int poc_tid0, const int is_clvss, G
 static int aps_alf_parse_luma(VVCALF *alf, GetBitContext *gb, void *log_ctx)
 {
     int     alf_luma_coeff_delta_idx[ALF_NUM_FILTERS_LUMA] = { 0 };
-    int8_t  luma_coeff   [ALF_NUM_FILTERS_LUMA * ALF_NUM_COEFF_LUMA];
+    int16_t luma_coeff   [ALF_NUM_FILTERS_LUMA * ALF_NUM_COEFF_LUMA];
     uint8_t luma_clip_idx[ALF_NUM_FILTERS_LUMA * ALF_NUM_COEFF_LUMA];
 
     const int alf_luma_clip_flag = get_bits1(gb);

--- a/libavcodec/vvc/vvc_ps.h
+++ b/libavcodec/vvc/vvc_ps.h
@@ -690,15 +690,15 @@ typedef struct VVCPH {
 } VVCPH;
 
 typedef struct VVCALF {
-    int8_t  luma_coeff     [ALF_NUM_FILTERS_LUMA * ALF_NUM_COEFF_LUMA];
+    int16_t luma_coeff     [ALF_NUM_FILTERS_LUMA * ALF_NUM_COEFF_LUMA];
     uint8_t luma_clip_idx  [ALF_NUM_FILTERS_LUMA * ALF_NUM_COEFF_LUMA];
 
     uint8_t num_chroma_filters;
-    int8_t  chroma_coeff   [ALF_NUM_FILTERS_CHROMA * ALF_NUM_COEFF_CHROMA];
+    int16_t chroma_coeff   [ALF_NUM_FILTERS_CHROMA * ALF_NUM_COEFF_CHROMA];
     uint8_t chroma_clip_idx[ALF_NUM_FILTERS_CHROMA * ALF_NUM_COEFF_CHROMA];
 
     uint8_t cc_filters_signalled[2];        //< alf_cc_cb_filters_signalled + 1, alf_cc_cr_filters_signalled + 1
-    int8_t  cc_coeff[2][ALF_NUM_FILTERS_CC * ALF_NUM_COEFF_CC];
+    int16_t cc_coeff[2][ALF_NUM_FILTERS_CC * ALF_NUM_COEFF_CC];
 } VVCALF;
 
 #define SL_MAX_ID          28

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -152,16 +152,16 @@ typedef struct VVCSAODSPContext {
 
 typedef struct VVCALFDSPContext {
     void (*filter[2 /* luma, chroma */])(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-        int width, int height, const int8_t *filter, const int16_t *clip);
+        int width, int height, const int16_t *filter, const int16_t *clip);
     void (*filter_vb[2 /* luma, chroma */])(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src,  ptrdiff_t src_stride,
-        int width, int height, const int8_t *filter, const int16_t *clip, int vb_pos);
+        int width, int height, const int16_t *filter, const int16_t *clip, int vb_pos);
     void (*filter_cc)(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *luma, ptrdiff_t luma_stride,
-        int width, int height, int hs, int vs, const int8_t *filter, int vb_pos);
+        int width, int height, int hs, int vs, const int16_t *filter, int vb_pos);
 
     void (*classify)(int *class_idx, int *transpose_idx, const uint8_t *src, ptrdiff_t src_stride, int width, int height,
         int vb_pos, int *gradient_tmp);
-    void (*recon_coeff_and_clip)(int8_t *coeff, int16_t *clip, const int *class_idx, const int *transpose_idx, int size,
-        const int8_t *coeff_set, const uint8_t *clip_idx_set, const uint8_t *class_to_filt);
+    void (*recon_coeff_and_clip)(int16_t *coeff, int16_t *clip, const int *class_idx, const int *transpose_idx, int size,
+        const int16_t *coeff_set, const uint8_t *clip_idx_set, const uint8_t *class_to_filt);
 } VVCALFDSPContext;
 
 typedef struct VVCDSPContext {

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -151,9 +151,7 @@ typedef struct VVCSAODSPContext {
 } VVCSAODSPContext;
 
 typedef struct VVCALFDSPContext {
-    void (*filter[2 /* luma, chroma */])(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-        int width, int height, const int16_t *filter, const int16_t *clip);
-    void (*filter_vb[2 /* luma, chroma */])(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src,  ptrdiff_t src_stride,
+    void (*filter[2 /* luma, chroma */])(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src,  ptrdiff_t src_stride,
         int width, int height, const int16_t *filter, const int16_t *clip, int vb_pos);
     void (*filter_cc)(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *luma, ptrdiff_t luma_stride,
         int width, int height, int hs, int vs, const int16_t *filter, int vb_pos);

--- a/libavcodec/x86/vvc_alf.asm
+++ b/libavcodec/x86/vvc_alf.asm
@@ -239,6 +239,9 @@ cglobal vvc_alf_filter_%2_w%3_%1bpc, 9, 14, 16, dst, dst_stride, src, src_stride
 
     shr             heightq, 2
 
+    movd          xm15, pixel_maxd
+    vpbroadcastw    m15, xm15
+
 .loop:
     LOAD_PARAMS
 
@@ -257,10 +260,9 @@ cglobal vvc_alf_filter_%2_w%3_%1bpc, 9, 14, 16, dst, dst_stride, src, src_stride
     paddw           m0, m2
 
     ;clip to pixel
-    movd          xm2, pixel_maxd
-    vpbroadcastw    m2, xm2
+
     pxor            m1, m1
-    CLIPW           m0, m1, m2
+    CLIPW           m0, m1, m15
 
     STORE_PIXELS    [dstq], 0
 

--- a/libavcodec/x86/vvc_alf.asm
+++ b/libavcodec/x86/vvc_alf.asm
@@ -132,7 +132,7 @@ SECTION .text
     %define filters m %+ j
     %define clips m %+ k
 
-    pshufb          m14, clips, [param_shuffe_ %+ i]          ;clip
+    pshufb          m14, clips, [param_shuffe_ %+ i]        ;clip
     pxor            m13, m13
     psubw           m13, m14                                ;-clip
 
@@ -175,13 +175,13 @@ SECTION .text
 ;filter pixels for luma and chroma
 %macro FILTER 0
     %if LUMA
-        FILTER          0, src_stride3q ,           src_strideq  * 2 + ps,  src_strideq  * 2
-        FILTER          3, src_strideq  * 2 - ps,   src_strideq  + 2 * ps,  src_strideq  + ps
-        FILTER          6, src_strideq,             src_strideq  - ps,      src_strideq  + -2 * ps
-        FILTER          9, src_stride0q + 3 * ps,   src_stride0q + 2 * ps,  src_stride0q + ps
+        FILTER          0, src_strideq  * 2 + src_strideq,  src_strideq  * 2 + ps,  src_strideq  * 2
+        FILTER          3, src_strideq  * 2 - ps,           src_strideq  + 2 * ps,  src_strideq  + ps
+        FILTER          6, src_strideq,                     src_strideq  - ps,      src_strideq  - 2 * ps
+        FILTER          9, src_stride0q + 3 * ps,           src_stride0q + 2 * ps,  src_stride0q + ps
     %else
-        FILTER          0, src_strideq * 2,         src_strideq  + ps,      src_strideq
-        FILTER          3, src_strideq - ps,        src_stride0q + 2 * ps,  src_stride0q + ps
+        FILTER          0, src_strideq * 2,                 src_strideq  + ps,      src_strideq
+        FILTER          3, src_strideq - ps,                src_stride0q + 2 * ps,  src_stride0q + ps
     %endif
 %endmacro
 
@@ -231,11 +231,9 @@ SECTION .text
 ; see c code for p0 to p6
 
 cglobal vvc_alf_filter_%2_w%3_%1bpc, 9, 14, 16, dst, dst_stride, src, src_stride, height, filter, clip, stride, pixel_max, \
-    tmp, offset, src_stride3, src_stride0, dst_stride3
+    tmp, offset, src_stride0
 ;pixel size
 %define ps (%1 / 8)
-    lea             src_stride3q, [src_strideq * 2 + src_strideq]
-    lea             dst_stride3q, [dst_strideq * 2 + dst_strideq]
 
     ;avoid "warning : absolute address can not be RIP-relative""
     mov             src_stride0q, 0

--- a/libavcodec/x86/vvc_alf.asm
+++ b/libavcodec/x86/vvc_alf.asm
@@ -160,12 +160,11 @@ SECTION .text
 %macro FILTER 4
     %assign %%i (%1)
     %rep 3
-        mov             tmpq, srcq
         lea             offsetq, [%2]
-        sub             tmpq, offsetq
-        LOAD_PIXELS     m9, [tmpq]
-        lea             tmpq, [srcq + offsetq]
-        LOAD_PIXELS     m10, [tmpq]
+        LOAD_PIXELS     m10, [srcq + offsetq]
+        neg             offsetq
+        LOAD_PIXELS     m9, [srcq + offsetq]
+
         FILTER  %%i
         %assign %%i %%i+1
         %rotate 1
@@ -231,7 +230,7 @@ SECTION .text
 ; see c code for p0 to p6
 
 cglobal vvc_alf_filter_%2_w%3_%1bpc, 9, 14, 16, dst, dst_stride, src, src_stride, height, filter, clip, stride, pixel_max, \
-    tmp, offset, src_stride0
+    offset, src_stride0
 ;pixel size
 %define ps (%1 / 8)
 

--- a/libavcodec/x86/vvc_alf.asm
+++ b/libavcodec/x86/vvc_alf.asm
@@ -124,7 +124,7 @@ SECTION .text
 ;FILTER(param_idx)
 ;input: m2, m9, m10
 ;output: m0, m1
-;m13 ~ m15: tmp
+;m11 ~ m13: tmp
 %macro FILTER 1
     %assign i (%1 % 4)
     %assign j (%1 / 4 + 3)
@@ -132,28 +132,28 @@ SECTION .text
     %define filters m %+ j
     %define clips m %+ k
 
-    pshufb          m14, clips, [param_shuffe_ %+ i]        ;clip
-    pxor            m13, m13
-    psubw           m13, m14                                ;-clip
+    pshufb          m12, clips, [param_shuffe_ %+ i]        ;clip
+    pxor            m11, m11
+    psubw           m11, m12                                ;-clip
 
     vpsubw          m9, m2
-    CLIPW           m9, m13, m14
+    CLIPW           m9, m11, m12
 
     vpsubw          m10, m2
-    CLIPW           m10, m13, m14
+    CLIPW           m10, m11, m12
 
-    vpunpckhwd      m15, m9, m10
+    vpunpckhwd      m13, m9, m10
     vpunpcklwd      m9, m9, m10
 
-    pshufb          m14, filters, [param_shuffe_ %+ i]       ;filter
-    vpunpcklwd      m10, m14, m14
-    vpunpckhwd      m14, m14, m14
+    pshufb          m12, filters, [param_shuffe_ %+ i]       ;filter
+    vpunpcklwd      m10, m12, m12
+    vpunpckhwd      m12, m12, m12
 
     vpmaddwd        m9, m10
-    vpmaddwd        m14, m15
+    vpmaddwd        m12, m13
 
     paddd           m0, m9
-    paddd           m1, m14
+    paddd           m1, m12
 %endmacro
 
 ;FILTER(param_start, off0~off2)

--- a/libavcodec/x86/vvcdsp.h
+++ b/libavcodec/x86/vvcdsp.h
@@ -26,35 +26,35 @@
 
 void ff_vvc_alf_filter_luma_w16_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_luma_w4_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_chroma_w16_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_chroma_w4_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_luma_w16_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_luma_w4_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_chroma_w16_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_chroma_w4_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int8_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
 /* each word in gradient_sum is sum gradient of 8x2 pixels, adjacent word share 4x2 pixels  */
 /* gradient_sum's stride aligned to 16 words                                                */

--- a/libavcodec/x86/vvcdsp.h
+++ b/libavcodec/x86/vvcdsp.h
@@ -24,46 +24,28 @@
 #ifndef AVCODEC_X86_VVCDSP_H
 #define AVCODEC_X86_VVCDSP_H
 
-void ff_vvc_alf_filter_luma_w16_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
-    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
+void ff_vvc_alf_filter_luma_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,
     const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
-void ff_vvc_alf_filter_luma_w4_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
-    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
+void ff_vvc_alf_filter_chroma_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,
     const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
-void ff_vvc_alf_filter_chroma_w16_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
-    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
+void ff_vvc_alf_filter_luma_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,
     const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
-void ff_vvc_alf_filter_chroma_w4_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
-    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
-
-void ff_vvc_alf_filter_luma_w16_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
-    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
-
-void ff_vvc_alf_filter_luma_w4_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
-    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
-
-void ff_vvc_alf_filter_chroma_w16_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
-    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
-    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
-
-void ff_vvc_alf_filter_chroma_w4_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
-    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t height,
+void ff_vvc_alf_filter_chroma_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,
     const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
 
 /* each word in gradient_sum is sum gradient of 8x2 pixels, adjacent word share 4x2 pixels  */
 /* gradient_sum's stride aligned to 16 words                                                */
 void ff_vvc_alf_classify_grad_8bpc_avx2(int *gradient_sum,
-    const uint8_t *src, ptrdiff_t src_stride, intptr_t width, intptr_t height,
-    intptr_t vb_pos);
+    const uint8_t *src, ptrdiff_t src_stride, intptr_t width, intptr_t height, intptr_t vb_pos);
 void ff_vvc_alf_classify_grad_16bpc_avx2(int *gradient_sum,
-    const uint8_t *src, ptrdiff_t src_stride, intptr_t width, intptr_t height,
-    intptr_t vb_pos);
+    const uint8_t *src, ptrdiff_t src_stride, intptr_t width, intptr_t height, intptr_t vb_pos);
 
 void ff_vvc_alf_classify_8bpc_avx2(int *class_idx, int *transpose_idx, const int *gradient_sum,
     intptr_t width, intptr_t height, intptr_t vb_pos, intptr_t bit_depth);

--- a/libavcodec/x86/vvcdsp.h
+++ b/libavcodec/x86/vvcdsp.h
@@ -26,19 +26,19 @@
 
 void ff_vvc_alf_filter_luma_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,
-    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t vb_pos, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_chroma_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,
-    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t vb_pos, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_luma_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,
-    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t vb_pos, ptrdiff_t pixel_max);
 
 void ff_vvc_alf_filter_chroma_8bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
     const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,
-    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t pixel_max);
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t vb_pos, ptrdiff_t pixel_max);
 
 /* each word in gradient_sum is sum gradient of 8x2 pixels, adjacent word share 4x2 pixels  */
 /* gradient_sum's stride aligned to 16 words                                                */

--- a/libavcodec/x86/vvcdsp_init.c
+++ b/libavcodec/x86/vvcdsp_init.c
@@ -36,41 +36,76 @@
 
 static void alf_filter_luma_16bpc_avx2(uint8_t *dst, const ptrdiff_t dst_stride,
     const uint8_t *src, const ptrdiff_t src_stride, const int width, const int height,
-    const int16_t *filter, const int16_t *clip, const int pixel_max)
+    const int16_t *filter, const int16_t *clip, const int vb_pos, const int pixel_max)
 {
     const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;
-    ff_vvc_alf_filter_luma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, param_stride, pixel_max);
+    ff_vvc_alf_filter_luma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, param_stride, vb_pos, pixel_max);
 }
 
 static void alf_filter_luma_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip)
 {
-    alf_filter_luma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, PIXEL_MAX_10);
+    alf_filter_luma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, MAX_CTU_SIZE, PIXEL_MAX_10);
 }
 
 static void alf_filter_luma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip)
 {
     const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;
-    ff_vvc_alf_filter_luma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, param_stride, PIXEL_MAX_8);
+    ff_vvc_alf_filter_luma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, param_stride, MAX_CTU_SIZE, PIXEL_MAX_8);
+}
+
+static void alf_filter_luma_vb_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
+    int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
+{
+    alf_filter_luma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, vb_pos, PIXEL_MAX_10);
+}
+
+static void alf_filter_luma_vb_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
+    int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
+{
+    const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;
+    ff_vvc_alf_filter_luma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, param_stride, vb_pos, PIXEL_MAX_8);
 }
 
 static void alf_filter_chroma_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int16_t *filter, const int16_t *clip, const int pixel_max)
+    int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos, const int pixel_max)
 {
-    ff_vvc_alf_filter_chroma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, 0, pixel_max);
+    ff_vvc_alf_filter_chroma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, 0, vb_pos, pixel_max);
 }
 
 static void alf_filter_chroma_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip)
 {
-    alf_filter_chroma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, PIXEL_MAX_10);
+    alf_filter_chroma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, MAX_CTU_SIZE, PIXEL_MAX_10);
 }
 
 static void alf_filter_chroma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip)
 {
-    ff_vvc_alf_filter_chroma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, 0, PIXEL_MAX_8);
+    ff_vvc_alf_filter_chroma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, 0, MAX_CTU_SIZE, PIXEL_MAX_8);
+}
+
+static void alf_filter_chroma_vb_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
+    int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
+{
+    alf_filter_chroma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, vb_pos, PIXEL_MAX_10);
+}
+
+static void alf_filter_chroma_vb_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
+    int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
+{
+    ff_vvc_alf_filter_chroma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height,
+        filter, clip, 0, vb_pos, PIXEL_MAX_8);
 }
 
 static void alf_classify_8_avx2(int *class_idx, int *transpose_idx,
@@ -90,8 +125,8 @@ static void alf_classify_10_avx2(int *class_idx, int *transpose_idx,
 }
 
 #define ALF_DSP(depth) do {                                                     \
-        c->alf.filter[LUMA] = alf_filter_luma_##depth##_avx2;                   \
-        c->alf.filter[CHROMA] = alf_filter_chroma_##depth##_avx2;               \
+        c->alf.filter_vb[LUMA] = alf_filter_luma_vb_##depth##_avx2;             \
+        c->alf.filter_vb[CHROMA] = alf_filter_chroma_vb_##depth##_avx2;         \
         c->alf.classify = alf_classify_##depth##_avx2;                          \
     } while (0)
 

--- a/libavcodec/x86/vvcdsp_init.c
+++ b/libavcodec/x86/vvcdsp_init.c
@@ -36,7 +36,7 @@
 
 static void alf_filter_luma_16bpc_avx2(uint8_t *dst, const ptrdiff_t dst_stride,
     const uint8_t *src, const ptrdiff_t src_stride, const int width, const int height,
-    const int8_t *filter, const int16_t *clip, const int pixel_max)
+    const int16_t *filter, const int16_t *clip, const int pixel_max)
 {
     const int ps            = 1;                                    //pixel shift
     const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;
@@ -55,13 +55,13 @@ static void alf_filter_luma_16bpc_avx2(uint8_t *dst, const ptrdiff_t dst_stride,
 }
 
 static void alf_filter_luma_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int8_t *filter, const int16_t *clip)
+    int width, int height, const int16_t *filter, const int16_t *clip)
 {
     alf_filter_luma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, PIXEL_MAX_10);
 }
 
 static void alf_filter_luma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int8_t *filter, const int16_t *clip)
+    int width, int height, const int16_t *filter, const int16_t *clip)
 {
     const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;
     int w;
@@ -79,7 +79,7 @@ static void alf_filter_luma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uin
 }
 
 static void alf_filter_chroma_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int8_t *filter, const int16_t *clip, const int pixel_max)
+    int width, int height, const int16_t *filter, const int16_t *clip, const int pixel_max)
 {
     const int ps = 1;                                    //pixel shift
     int w;
@@ -95,13 +95,13 @@ static void alf_filter_chroma_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride, con
 }
 
 static void alf_filter_chroma_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int8_t *filter, const int16_t *clip)
+    int width, int height, const int16_t *filter, const int16_t *clip)
 {
     alf_filter_chroma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, PIXEL_MAX_10);
 }
 
 static void alf_filter_chroma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int8_t *filter, const int16_t *clip)
+    int width, int height, const int16_t *filter, const int16_t *clip)
 {
     int w;
 

--- a/libavcodec/x86/vvcdsp_init.c
+++ b/libavcodec/x86/vvcdsp_init.c
@@ -44,28 +44,13 @@ static void alf_filter_luma_16bpc_avx2(uint8_t *dst, const ptrdiff_t dst_stride,
 }
 
 static void alf_filter_luma_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int16_t *filter, const int16_t *clip)
-{
-    alf_filter_luma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
-        filter, clip, MAX_CTU_SIZE, PIXEL_MAX_10);
-}
-
-static void alf_filter_luma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int16_t *filter, const int16_t *clip)
-{
-    const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;
-    ff_vvc_alf_filter_luma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height,
-        filter, clip, param_stride, MAX_CTU_SIZE, PIXEL_MAX_8);
-}
-
-static void alf_filter_luma_vb_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
 {
     alf_filter_luma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
         filter, clip, vb_pos, PIXEL_MAX_10);
 }
 
-static void alf_filter_luma_vb_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
+static void alf_filter_luma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
 {
     const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;
@@ -81,27 +66,13 @@ static void alf_filter_chroma_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride, con
 }
 
 static void alf_filter_chroma_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int16_t *filter, const int16_t *clip)
-{
-    alf_filter_chroma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
-        filter, clip, MAX_CTU_SIZE, PIXEL_MAX_10);
-}
-
-static void alf_filter_chroma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-    int width, int height, const int16_t *filter, const int16_t *clip)
-{
-    ff_vvc_alf_filter_chroma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height,
-        filter, clip, 0, MAX_CTU_SIZE, PIXEL_MAX_8);
-}
-
-static void alf_filter_chroma_vb_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
 {
     alf_filter_chroma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height,
         filter, clip, vb_pos, PIXEL_MAX_10);
 }
 
-static void alf_filter_chroma_vb_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
+static void alf_filter_chroma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)
 {
     ff_vvc_alf_filter_chroma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height,
@@ -125,8 +96,8 @@ static void alf_classify_10_avx2(int *class_idx, int *transpose_idx,
 }
 
 #define ALF_DSP(depth) do {                                                     \
-        c->alf.filter_vb[LUMA] = alf_filter_luma_vb_##depth##_avx2;             \
-        c->alf.filter_vb[CHROMA] = alf_filter_chroma_vb_##depth##_avx2;         \
+        c->alf.filter[LUMA] = alf_filter_luma_##depth##_avx2;                   \
+        c->alf.filter[CHROMA] = alf_filter_chroma_##depth##_avx2;               \
         c->alf.classify = alf_classify_##depth##_avx2;                          \
     } while (0)
 

--- a/libavcodec/x86/vvcdsp_init.c
+++ b/libavcodec/x86/vvcdsp_init.c
@@ -38,20 +38,8 @@ static void alf_filter_luma_16bpc_avx2(uint8_t *dst, const ptrdiff_t dst_stride,
     const uint8_t *src, const ptrdiff_t src_stride, const int width, const int height,
     const int16_t *filter, const int16_t *clip, const int pixel_max)
 {
-    const int ps            = 1;                                    //pixel shift
     const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;
-    int w;
-
-    for (w = 0; w + 16 <= width; w += 16) {
-        const int param_offset = w * ALF_NUM_COEFF_LUMA / ALF_BLOCK_SIZE;
-        ff_vvc_alf_filter_luma_w16_16bpc_avx2(dst + (w << ps), dst_stride, src + (w << ps), src_stride,
-            height, filter + param_offset, clip + param_offset, param_stride, pixel_max);
-    }
-    for ( /* nothing */; w < width; w += 4) {
-        const int param_offset = w * ALF_NUM_COEFF_LUMA / ALF_BLOCK_SIZE;
-        ff_vvc_alf_filter_luma_w4_16bpc_avx2(dst + (w << ps), dst_stride, src + (w << ps), src_stride,
-            height, filter + param_offset, clip + param_offset, param_stride, pixel_max);
-    }
+    ff_vvc_alf_filter_luma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, param_stride, pixel_max);
 }
 
 static void alf_filter_luma_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
@@ -64,34 +52,13 @@ static void alf_filter_luma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uin
     int width, int height, const int16_t *filter, const int16_t *clip)
 {
     const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;
-    int w;
-
-    for (w = 0; w + 16 <= width; w += 16) {
-        const int param_offset = w * ALF_NUM_COEFF_LUMA / ALF_BLOCK_SIZE;
-        ff_vvc_alf_filter_luma_w16_8bpc_avx2(dst + w, dst_stride, src + w, src_stride,
-            height, filter + param_offset, clip + param_offset, param_stride, PIXEL_MAX_8);
-    }
-    for ( /* nothing */; w < width; w += 4) {
-        const int param_offset = w * ALF_NUM_COEFF_LUMA / ALF_BLOCK_SIZE;
-        ff_vvc_alf_filter_luma_w4_8bpc_avx2(dst + w, dst_stride, src + w, src_stride,
-            height, filter + param_offset, clip + param_offset, param_stride, PIXEL_MAX_8);
-    }
+    ff_vvc_alf_filter_luma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, param_stride, PIXEL_MAX_8);
 }
 
 static void alf_filter_chroma_16bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip, const int pixel_max)
 {
-    const int ps = 1;                                    //pixel shift
-    int w;
-
-    for (w = 0; w + 16 <= width; w += 16) {
-        ff_vvc_alf_filter_chroma_w16_16bpc_avx2(dst + (w << ps), dst_stride, src + (w << ps), src_stride,
-            height, filter, clip, 0, pixel_max);
-    }
-    for ( /* nothing */ ; w < width; w += 4) {
-        ff_vvc_alf_filter_chroma_w4_16bpc_avx2(dst + (w << ps), dst_stride, src + (w << ps), src_stride,
-            height, filter, clip, 0, pixel_max);
-    }
+    ff_vvc_alf_filter_chroma_16bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, 0, pixel_max);
 }
 
 static void alf_filter_chroma_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
@@ -103,16 +70,7 @@ static void alf_filter_chroma_10_avx2(uint8_t *dst, ptrdiff_t dst_stride, const 
 static void alf_filter_chroma_8_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
     int width, int height, const int16_t *filter, const int16_t *clip)
 {
-    int w;
-
-    for (w = 0; w + 16 <= width; w += 16) {
-        ff_vvc_alf_filter_chroma_w16_8bpc_avx2(dst + w, dst_stride, src + w, src_stride,
-            height, filter, clip, 0, PIXEL_MAX_8);
-    }
-    for ( /* nothing */ ; w < width; w += 4) {
-        ff_vvc_alf_filter_chroma_w4_8bpc_avx2(dst + w, dst_stride, src + w, src_stride,
-            height, filter, clip, 0, PIXEL_MAX_8);
-    }
+    ff_vvc_alf_filter_chroma_8bpc_avx2(dst, dst_stride, src, src_stride, width, height, filter, clip, 0, PIXEL_MAX_8);
 }
 
 static void alf_classify_8_avx2(int *class_idx, int *transpose_idx,

--- a/tests/checkasm/vvc_alf.c
+++ b/tests/checkasm/vvc_alf.c
@@ -93,7 +93,7 @@ static void check_alf_filter(VVCDSPContext *c, const int bit_depth)
     for (int h = 4; h <= MAX_CTU_SIZE; h += 4) {
         for (int w = 4; w <= MAX_CTU_SIZE; w += 4) {
             const int ctu_size = MAX_CTU_SIZE;
-            if (check_func(c->alf.filter_vb[LUMA], "vvc_alf_filter_luma_%dx%d_%d", w, h, bit_depth)) {
+            if (check_func(c->alf.filter[LUMA], "vvc_alf_filter_luma_%dx%d_%d", w, h, bit_depth)) {
                 const int vb_pos = ctu_size - ALF_VB_POS_ABOVE_LUMA;
                 memset(dst0, 0, DST_BUF_SIZE);
                 memset(dst1, 0, DST_BUF_SIZE);
@@ -105,7 +105,7 @@ static void check_alf_filter(VVCDSPContext *c, const int bit_depth)
                 }
                 bench_new(dst1, dst_stride, src1 + offset, src_stride, w, h, filter, clip, vb_pos);
             }
-            if (check_func(c->alf.filter_vb[CHROMA], "vvc_alf_filter_chroma_%dx%d_%d", w, h, bit_depth)) {
+            if (check_func(c->alf.filter[CHROMA], "vvc_alf_filter_chroma_%dx%d_%d", w, h, bit_depth)) {
                 const int vb_pos = ctu_size - ALF_VB_POS_ABOVE_CHROMA;
                 memset(dst0, 0, DST_BUF_SIZE);
                 memset(dst1, 0, DST_BUF_SIZE);

--- a/tests/checkasm/vvc_alf.c
+++ b/tests/checkasm/vvc_alf.c
@@ -33,11 +33,11 @@
 static const uint32_t pixel_mask[3] = { 0xffffffff, 0x03ff03ff, 0x0fff0fff };
 
 #define SIZEOF_PIXEL ((bit_depth + 7) / 8)
-#define SRC_PIXEL_STRIDE (MAX_CU_SIZE + 2 * ALF_PADDING_SIZE)
+#define SRC_PIXEL_STRIDE (MAX_CTU_SIZE + 2 * ALF_PADDING_SIZE)
 #define DST_PIXEL_STRIDE (SRC_PIXEL_STRIDE + 4)
 #define SRC_BUF_SIZE (SRC_PIXEL_STRIDE * (MAX_CTU_SIZE + 3 * 2) * 2) //+3 * 2 for top and bottom row, *2 for high bit depth
 #define DST_BUF_SIZE (DST_PIXEL_STRIDE * (MAX_CTU_SIZE + 3 * 2) * 2)
-#define LUMA_PARAMS_SIZE (MAX_CU_SIZE * MAX_CU_SIZE / ALF_BLOCK_SIZE / ALF_BLOCK_SIZE * ALF_NUM_COEFF_LUMA)
+#define LUMA_PARAMS_SIZE (MAX_CTU_SIZE * MAX_CTU_SIZE / ALF_BLOCK_SIZE / ALF_BLOCK_SIZE * ALF_NUM_COEFF_LUMA)
 
 #define randomize_buffers(buf0, buf1, size)                 \
     do {                                                    \
@@ -90,8 +90,8 @@ static void check_alf_filter(VVCDSPContext *c, const int bit_depth)
     randomize_buffers2(filter, LUMA_PARAMS_SIZE, 1);
     randomize_buffers2(clip, LUMA_PARAMS_SIZE, 0);
 
-    for (int h = 4; h <= MAX_CU_SIZE; h += 4) {
-        for (int w = 4; w <= MAX_CU_SIZE; w += 4) {
+    for (int h = 4; h <= MAX_CTU_SIZE; h += 4) {
+        for (int w = 4; w <= MAX_CTU_SIZE; w += 4) {
             if (check_func(c->alf.filter[LUMA], "vvc_alf_filter_luma_%dx%d_%d", w, h, bit_depth)) {
                 memset(dst0, 0, DST_BUF_SIZE);
                 memset(dst1, 0, DST_BUF_SIZE);
@@ -136,8 +136,8 @@ static void check_alf_classify(VVCDSPContext *c, const int bit_depth)
 
     randomize_buffers(src0, src1, SRC_BUF_SIZE);
 
-    for (int h = 4; h <= MAX_CU_SIZE; h += 4) {
-        for (int w = 4; w <= MAX_CU_SIZE; w += 4) {
+    for (int h = 4; h <= MAX_CTU_SIZE; h += 4) {
+        for (int w = 4; w <= MAX_CTU_SIZE; w += 4) {
             const int id_size = w * h / ALF_BLOCK_SIZE / ALF_BLOCK_SIZE * sizeof(int);
             const int vb_pos  = MAX_CTU_SIZE - ALF_BLOCK_SIZE;
             if (check_func(c->alf.classify, "vvc_alf_classify_%dx%d_%d", w, h, bit_depth)) {

--- a/tests/checkasm/vvc_alf.c
+++ b/tests/checkasm/vvc_alf.c
@@ -72,7 +72,7 @@ static void check_alf_filter(VVCDSPContext *c, const int bit_depth)
     LOCAL_ALIGNED_32(uint8_t, dst1, [DST_BUF_SIZE]);
     LOCAL_ALIGNED_32(uint8_t, src0, [SRC_BUF_SIZE]);
     LOCAL_ALIGNED_32(uint8_t, src1, [SRC_BUF_SIZE]);
-    int8_t filter[LUMA_PARAMS_SIZE];
+    int16_t filter[LUMA_PARAMS_SIZE];
     int16_t clip[LUMA_PARAMS_SIZE];
 
     const int16_t clip_set[] = {
@@ -84,7 +84,7 @@ static void check_alf_filter(VVCDSPContext *c, const int bit_depth)
     int offset = (3 * SRC_PIXEL_STRIDE + 3) * SIZEOF_PIXEL;
 
     declare_func_emms(AV_CPU_FLAG_AVX2, void, uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
-        int width, int height, const int8_t *filter, const int16_t *clip);
+        int width, int height, const int16_t *filter, const int16_t *clip);
 
     randomize_buffers(src0, src1, SRC_BUF_SIZE);
     randomize_buffers2(filter, LUMA_PARAMS_SIZE, 1);


### PR DESCRIPTION
on a i7-12700:
clips|before|after|delta|
-|-|-|-|
RitualDance_1920x1080_60_10_420_32_LD.266 | 128.0 | 135.7|6.02%|
Tango2_3840x2160_60_10_420_27_RA.266 | 33.7 |36.0|6.82%|
RitualDance_1920x1080_60_10_420_37_RA.266 | 146.0 |155.7|6.64%|
Tango2_3840x2160_60_10_420_27_LD.266 | 32.3 |35.0 |8.36%|
BQTerrace_1920x1080_60_10_420_22_RA.vvc | 80.7 |85.3|5.70%|
NovosobornayaSquare_1920x1080.bin | 149.7 |156.3|4.41%|
Chimera_8bit_1080P_1000_frames.vvc | 161.3 |170.0|5.39%|
