### PR TITLE
Fix 4:4:4 intra prediction 

### DIFF
--- a/libavcodec/vvc/vvc_ctu.c
+++ b/libavcodec/vvc/vvc_ctu.c
@@ -867,9 +867,8 @@ static enum IntraPredMode derive_center_luma_intra_pred_mode(const VVCFrameConte
 
     if (intra_mip_flag) {
         if (cu->tree_type == SINGLE_TREE && sps->chroma_format_idc == CHROMA_FORMAT_444)
-            return INTRA_DEFAULT;
-        else
-            return INTRA_PLANAR;
+            return INTRA_INVALID;
+        return INTRA_PLANAR;
     }
     if (cu_pred_mode == MODE_IBC || cu_pred_mode == MODE_PLT)
         return INTRA_DC;

--- a/libavcodec/vvc/vvc_ctu.c
+++ b/libavcodec/vvc/vvc_ctu.c
@@ -867,7 +867,7 @@ static enum IntraPredMode derive_center_luma_intra_pred_mode(const VVCFrameConte
 
     if (intra_mip_flag) {
         if (cu->tree_type == SINGLE_TREE && sps->chroma_format_idc == CHROMA_FORMAT_444)
-            return -1;
+            return INTRA_DEFAULT;
         else
             return INTRA_PLANAR;
     }

--- a/libavcodec/vvc/vvc_ctu.h
+++ b/libavcodec/vvc/vvc_ctu.h
@@ -162,6 +162,7 @@ typedef enum PredFlag {
 } PredFlag;
 
 typedef enum IntraPredMode {
+    INTRA_DEFAULT   = -1,
     INTRA_PLANAR    = 0,
     INTRA_DC,
     INTRA_HORZ      = 18,

--- a/libavcodec/vvc/vvc_ctu.h
+++ b/libavcodec/vvc/vvc_ctu.h
@@ -162,7 +162,7 @@ typedef enum PredFlag {
 } PredFlag;
 
 typedef enum IntraPredMode {
-    INTRA_DEFAULT   = -1,
+    INTRA_INVALID   = -1,
     INTRA_PLANAR    = 0,
     INTRA_DC,
     INTRA_HORZ      = 18,


### PR DESCRIPTION
It seems as though the `V_DIAG` mode should not be used when using Direct Mode MIP. To be honest, I don't see how this is implemented in the specification, so there's probably a better way to implement this. The only relevant clause I see in the specification is:
>If treeType is equal to SINGLE_TREE, sps_chroma_format_idc is equal to 3, intra_chroma_pred_mode is equal to 4, and IntraMipFlag[ xCb ][ yCb ] is equal to 1, the following applies:
>– The MIP chroma direct mode flag MipChromaDirectFlag[ xCb ][ yCb ] is set equal to 1.
>– The chroma intra prediction mode IntraPredModeC[ xCb ][ yCb ] is set equal to IntraPredModeY[ xCb ][ yCb ].

however this is already implemented and has the additional condition `intra_chroma_pred_mode == 4`.

As is, this fix appears to work however. I will make a PR in [ffvvc/tests](https://github.com/ffvvc/tests) to reflect the tests which now pass later.

This PR will fix #86.