### PR TITLE
WIP: Range extension

### DIFF
--- a/libavcodec/cbs_h266.h
+++ b/libavcodec/cbs_h266.h
@@ -120,6 +120,13 @@ typedef struct H266GeneralConstraintsInfo {
     uint8_t gci_no_virtual_boundaries_constraint_flag;
     uint8_t gci_num_reserved_bits;
     uint8_t gci_reserved_zero_bit[255];
+
+    uint8_t gci_all_rap_pictures_constraint_flag;
+    uint8_t gci_no_extended_precision_processing_constraint_flag;
+    uint8_t gci_no_ts_residual_coding_rice_constraint_flag;
+    uint8_t gci_no_rrc_rice_extension_constraint_flag;
+    uint8_t gci_no_persistent_rice_adaptation_constraint_flag;
+    uint8_t gci_no_reverse_last_sig_coeff_constraint_flag;
 } H266GeneralConstraintsInfo;
 
 typedef struct H266RawProfileTierLevel {
@@ -451,6 +458,14 @@ typedef struct H266RawSPS {
 
     uint8_t  sps_extension_flag;
 
+    uint8_t  sps_range_extension_flag;
+    uint8_t  sps_extended_precision_flag;
+    uint8_t  sps_ts_residual_coding_rice_present_in_sh_flag;
+    uint8_t  sps_rrc_rice_extension_flag;
+    uint8_t  sps_persistent_rice_adaptation_enabled_flag;
+    uint8_t  sps_reverse_last_sig_coeff_enabled_flag;
+
+    uint8_t  sps_extension_7bits;
     H266RawExtensionData extension_data;
 
     //calcalated value
@@ -738,6 +753,8 @@ typedef struct  H266RawSliceHeader {
 
     uint8_t  sh_sign_data_hiding_used_flag;
     uint8_t  sh_ts_residual_coding_disabled_flag;
+    uint8_t  sh_ts_residual_coding_rice_idx_minus1;
+    uint8_t  sh_reverse_last_sig_coeff_flag;
     uint16_t sh_slice_header_extension_length;
     uint8_t  sh_slice_header_extension_data_byte[256];
 

--- a/libavcodec/cbs_h266_syntax_template.c
+++ b/libavcodec/cbs_h266_syntax_template.c
@@ -61,7 +61,7 @@ static int FUNC(general_constraints_info)(CodedBitstreamContext *ctx,
                                           RWContext *rw,
                                           H266GeneralConstraintsInfo *current)
 {
-    int err, i;
+    int err, i, num_additional_bits_used;
 
     flag(gci_present_flag);
     if (current->gci_present_flag) {
@@ -149,7 +149,19 @@ static int FUNC(general_constraints_info)(CodedBitstreamContext *ctx,
         flag(gci_no_ladf_constraint_flag);
         flag(gci_no_virtual_boundaries_constraint_flag);
         ub(8, gci_num_reserved_bits);
-        for (i = 0; i < current->gci_num_reserved_bits; i++) {
+        if (current->gci_num_reserved_bits > 5) {
+            flag(gci_all_rap_pictures_constraint_flag);
+            flag(gci_no_extended_precision_processing_constraint_flag);
+            flag(gci_no_ts_residual_coding_rice_constraint_flag);
+            flag(gci_no_rrc_rice_extension_constraint_flag);
+            flag(gci_no_persistent_rice_adaptation_constraint_flag);
+            flag(gci_no_reverse_last_sig_coeff_constraint_flag);
+            num_additional_bits_used = 6;
+        } else {
+            num_additional_bits_used = 0;
+        }
+
+        for (i = 0; i < current->gci_num_reserved_bits - num_additional_bits_used; i++) {
             flags(gci_reserved_zero_bit[i], 1, i);
         }
     }
@@ -935,6 +947,23 @@ static int FUNC(vps)(CodedBitstreamContext *ctx, RWContext *rw,
     return 0;
 }
 
+static int FUNC(sps_range_extension)(CodedBitstreamContext *ctx, RWContext *rw,
+                                     H266RawSPS *current)
+{
+    int err;
+
+    flag(sps_extended_precision_flag);
+    if (current->sps_transform_skip_enabled_flag) {
+        flag(sps_ts_residual_coding_rice_present_in_sh_flag);
+    } else {
+        infer(sps_ts_residual_coding_rice_present_in_sh_flag, 0);
+    }
+    flag(sps_rrc_rice_extension_flag);
+    flag(sps_persistent_rice_adaptation_enabled_flag);
+    flag(sps_reverse_last_sig_coeff_enabled_flag);
+
+    return 0;
+}
 
 static int FUNC(sps)(CodedBitstreamContext *ctx, RWContext *rw,
                      H266RawSPS *current)
@@ -1485,8 +1514,32 @@ static int FUNC(sps)(CodedBitstreamContext *ctx, RWContext *rw,
     } else {
         CHECK(FUNC(vui_parameters_default)(ctx, rw, &current->vui));
     }
+
     flag(sps_extension_flag);
-    if (current->sps_extension_flag)
+    if (current->sps_extension_flag) {
+        flag(sps_range_extension_flag);
+        u(7, sps_extension_7bits, 0, 127);
+
+        if (current->sps_range_extension_flag) {
+            CHECK(FUNC(sps_range_extension)(ctx, rw, current));
+        } else {
+            infer(sps_extended_precision_flag, 0);
+            infer(sps_ts_residual_coding_rice_present_in_sh_flag, 0);
+            infer(sps_rrc_rice_extension_flag, 0);
+            infer(sps_persistent_rice_adaptation_enabled_flag, 0);
+            infer(sps_reverse_last_sig_coeff_enabled_flag, 0);
+        }
+    } else {
+        infer(sps_range_extension_flag, 0);
+        infer(sps_extension_7bits, 0);
+        infer(sps_extended_precision_flag, 0);
+        infer(sps_ts_residual_coding_rice_present_in_sh_flag, 0);
+        infer(sps_rrc_rice_extension_flag, 0);
+        infer(sps_persistent_rice_adaptation_enabled_flag, 0);
+        infer(sps_reverse_last_sig_coeff_enabled_flag, 0);
+    }
+
+    if (current->sps_extension_7bits)
         CHECK(FUNC(extension_data)(ctx, rw, &current->extension_data));
 
     CHECK(FUNC(rbsp_trailing_bits)(ctx, rw));
@@ -2921,6 +2974,18 @@ static int FUNC(slice_header)(CodedBitstreamContext *ctx, RWContext *rw,
         flag(sh_ts_residual_coding_disabled_flag);
     else
         infer(sh_ts_residual_coding_disabled_flag, 0);
+
+    if (!current->sh_ts_residual_coding_disabled_flag
+      && sps->sps_ts_residual_coding_rice_present_in_sh_flag)
+        u(3, sh_ts_residual_coding_rice_idx_minus1, 0, 7);
+    else
+        infer(sh_ts_residual_coding_rice_idx_minus1, 0);
+
+    if (sps->sps_reverse_last_sig_coeff_enabled_flag)
+        flag(sh_reverse_last_sig_coeff_flag);
+    else
+        infer(sh_reverse_last_sig_coeff_flag, 0);
+
     if (pps->pps_slice_header_extension_present_flag) {
         ue(sh_slice_header_extension_length, 0, 256);
         for (i = 0; i < current->sh_slice_header_extension_length; i++)

--- a/libavcodec/cbs_h266_syntax_template.c
+++ b/libavcodec/cbs_h266_syntax_template.c
@@ -2975,8 +2975,8 @@ static int FUNC(slice_header)(CodedBitstreamContext *ctx, RWContext *rw,
     else
         infer(sh_ts_residual_coding_disabled_flag, 0);
 
-    if (!current->sh_ts_residual_coding_disabled_flag
-      && sps->sps_ts_residual_coding_rice_present_in_sh_flag)
+    if (!current->sh_ts_residual_coding_disabled_flag &&
+        sps->sps_ts_residual_coding_rice_present_in_sh_flag)
         u(3, sh_ts_residual_coding_rice_idx_minus1, 0, 7);
     else
         infer(sh_ts_residual_coding_rice_idx_minus1, 0);

--- a/libavcodec/vvc/vvc_cabac.c
+++ b/libavcodec/vvc/vvc_cabac.c
@@ -2309,6 +2309,7 @@ static void derive_last_scan_pos(ResidualCoding *rc,
 static void last_significant_coeff_x_y_decode(ResidualCoding *rc, VVCLocalContext *lc,
     const int log2_zo_tb_width, const int log2_zo_tb_height)
 {
+    const VVCSH *sh = &lc->sc->sh;
     const TransformBlock *tb = rc->tb;
     int last_significant_coeff_x, last_significant_coeff_y;
 
@@ -2327,6 +2328,10 @@ static void last_significant_coeff_x_y_decode(ResidualCoding *rc, VVCLocalContex
         int suffix = last_sig_coeff_suffix_decode(lc, last_significant_coeff_y);
         last_significant_coeff_y = (1 << ((last_significant_coeff_y >> 1) - 1)) *
             (2 + (last_significant_coeff_y & 1)) + suffix;
+    }
+    if (sh->reverse_last_sig_coeff_flag) {
+        last_significant_coeff_x = (1 << log2_zo_tb_width) - 1 - last_significant_coeff_x;
+        last_significant_coeff_y = (1 << log2_zo_tb_height) - 1 - last_significant_coeff_y;
     }
     rc->last_significant_coeff_x = last_significant_coeff_x;
     rc->last_significant_coeff_y = last_significant_coeff_y;

--- a/libavcodec/vvc/vvc_cabac.c
+++ b/libavcodec/vvc/vvc_cabac.c
@@ -1883,7 +1883,8 @@ static int abs_remainder_decode(VVCLocalContext *lc, const ResidualCoding* rc, c
 
 static int abs_remainder_ts_decode(VVCLocalContext *lc, const ResidualCoding* rc, const int xc, const int yc)
 {
-    const int c_rice_param = 1;
+    const VVCSH* sh = &lc->sc->sh;
+    const int c_rice_param = sh->ts_residual_coding_rice_idx_minus1 + 1;
     const int rem = abs_decode(lc, c_rice_param);
     return rem;
 }

--- a/libavcodec/vvc/vvc_cabac.c
+++ b/libavcodec/vvc/vvc_cabac.c
@@ -1853,6 +1853,7 @@ static int abs_get_rice_param(const ResidualCoding* rc, const int xc, const int 
 
 static int abs_decode(VVCLocalContext *lc, const int c_rice_param)
 {
+    const VVCSPS *sps = lc->fc->ps.sps;
     const int MAX_BIN = 6;
     int prefix = 0;
     int suffix = 0;
@@ -1865,7 +1866,10 @@ static int abs_decode(VVCLocalContext *lc, const int c_rice_param)
             suffix = (suffix << 1) | vvc_get_cabac_bypass(&lc->ep->cc);
         }
     } else {
-        suffix = limited_kth_order_egk_decode(&lc->ep->cc, c_rice_param + 1, 11, 15);
+        suffix = limited_kth_order_egk_decode(&lc->ep->cc,
+                                              c_rice_param + 1,
+                                              26 - sps->log2_transform_range,
+                                              sps->log2_transform_range);
     }
     return suffix + (prefix << c_rice_param);
 }

--- a/libavcodec/vvc/vvc_ctu.c
+++ b/libavcodec/vvc/vvc_ctu.c
@@ -2315,3 +2315,9 @@ int ff_vvc_get_qPy(const VVCFrameContext *fc, const int xc, const int yc)
     return fc->tab.qp[LUMA][x + y * fc->ps.pps->min_cb_width];
 }
 
+void ff_vvc_ep_init_stat_coeff(EntryPoint *ep, int bit_depth, int persistent_rice_adaptation_enabled_flag) {
+    for (size_t i = 0; i < FF_ARRAY_ELEMS(ep->stat_coeff); ++i) {
+        ep->stat_coeff[i] =
+            persistent_rice_adaptation_enabled_flag ? 2 * (av_log2(bit_depth - 10)) : 0;
+    }
+}

--- a/libavcodec/vvc/vvc_ctu.c
+++ b/libavcodec/vvc/vvc_ctu.c
@@ -892,10 +892,15 @@ static void derive_chroma_intra_pred_mode(VVCLocalContext *lc,
         const int modes[4] = {INTRA_PLANAR, INTRA_VERT, INTRA_HORZ, INTRA_DC};
         int idx;
 
-        for (idx = 0; idx < FF_ARRAY_ELEMS(modes); idx++) {
-            if (modes[idx] == luma_intra_pred_mode)
-                break;
+        if (cu->tree_type == SINGLE_TREE && sps->chroma_format_idc == CHROMA_FORMAT_444 && intra_mip_flag) {
+            idx = 4;
+        } else {
+            for (idx = 0; idx < FF_ARRAY_ELEMS(modes); idx++) {
+                if (modes[idx] == luma_intra_pred_mode)
+                    break;
+            }
         }
+
         cu->intra_pred_mode_c = pred_mode_c[intra_chroma_pred_mode][idx];
     }
     if (sps->chroma_format_idc == CHROMA_FORMAT_422 && cu->intra_pred_mode_c <= INTRA_VDIAG) {

--- a/libavcodec/vvc/vvc_ctu.h
+++ b/libavcodec/vvc/vvc_ctu.h
@@ -408,5 +408,6 @@ void ff_vvc_set_neighbour_available(VVCLocalContext *lc, int x0, int y0, int w, 
 void ff_vvc_decode_neighbour(VVCLocalContext *lc, int x_ctb, int y_ctb, int rx, int ry, int rs);
 void ff_vvc_ctu_free_cus(CTU *ctu);
 int ff_vvc_get_qPy(const VVCFrameContext *fc, int xc, int yc);
+void ff_vvc_ep_init_stat_coeff(EntryPoint *ep, int bit_depth, int persistent_rice_adaptation_enabled_flag);
 
 #endif // AVCODEC_VVC_CTU_H

--- a/libavcodec/vvc/vvc_ctu.h
+++ b/libavcodec/vvc/vvc_ctu.h
@@ -282,6 +282,8 @@ typedef struct VVCCabacState {
 typedef struct EntryPoint {
     int8_t qp_y;                                    //< QpY
 
+    int stat_coeff[VVC_MAX_SAMPLE_ARRAYS];          ///< StatCoeff
+
     VVCCabacState cabac_state[VVC_CONTEXTS];
     CABACContext cc;
 

--- a/libavcodec/vvc/vvc_itx_1d.c
+++ b/libavcodec/vvc/vvc_itx_1d.c
@@ -697,7 +697,9 @@ DEFINE_INV_DST7_1D( 8)
 DEFINE_INV_DST7_1D(16)
 DEFINE_INV_DST7_1D(32)
 
-void ff_vvc_inv_lfnst_1d(int *v, const int *u, int no_zero_size, int n_tr_s, int pred_mode_intra, int lfnst_idx)
+void ff_vvc_inv_lfnst_1d(int *v, const int *u, int no_zero_size, int n_tr_s,
+                         int pred_mode_intra, int lfnst_idx, int coeff_min,
+                         int coeff_max)
 {
      int lfnst_tr_set_idx    = pred_mode_intra < 0 ? 1 : ff_vvc_lfnst_tr_set_index[pred_mode_intra];
      const int8_t *tr_mat = n_tr_s > 16 ? ff_vvc_lfnst_8x8[lfnst_tr_set_idx][lfnst_idx-1][0] : ff_vvc_lfnst_4x4[lfnst_tr_set_idx][lfnst_idx - 1][0];
@@ -707,6 +709,6 @@ void ff_vvc_inv_lfnst_1d(int *v, const int *u, int no_zero_size, int n_tr_s, int
 
         for (int i = 0; i < no_zero_size; i++)
             t += u[i] * tr_mat[i * n_tr_s];
-        v[j] = av_clip((t + 64) >> 7 , -(1 << 15), (1 << 15) - 1);
+        v[j] = av_clip((t + 64) >> 7 , coeff_min, coeff_max);
      }
 }

--- a/libavcodec/vvc/vvc_itx_1d.c
+++ b/libavcodec/vvc/vvc_itx_1d.c
@@ -698,8 +698,7 @@ DEFINE_INV_DST7_1D(16)
 DEFINE_INV_DST7_1D(32)
 
 void ff_vvc_inv_lfnst_1d(int *v, const int *u, int no_zero_size, int n_tr_s,
-                         int pred_mode_intra, int lfnst_idx, int coeff_min,
-                         int coeff_max)
+    int pred_mode_intra, int lfnst_idx, int log2_transform_range)
 {
      int lfnst_tr_set_idx    = pred_mode_intra < 0 ? 1 : ff_vvc_lfnst_tr_set_index[pred_mode_intra];
      const int8_t *tr_mat = n_tr_s > 16 ? ff_vvc_lfnst_8x8[lfnst_tr_set_idx][lfnst_idx-1][0] : ff_vvc_lfnst_4x4[lfnst_tr_set_idx][lfnst_idx - 1][0];
@@ -709,6 +708,6 @@ void ff_vvc_inv_lfnst_1d(int *v, const int *u, int no_zero_size, int n_tr_s,
 
         for (int i = 0; i < no_zero_size; i++)
             t += u[i] * tr_mat[i * n_tr_s];
-        v[j] = av_clip((t + 64) >> 7 , coeff_min, coeff_max);
+        v[j] = av_clip_intp2((t + 64) >> 7 , log2_transform_range);
      }
 }

--- a/libavcodec/vvc/vvc_itx_1d.h
+++ b/libavcodec/vvc/vvc_itx_1d.h
@@ -46,6 +46,8 @@ vvc_itx_1d_fn(ff_vvc_inv_dct8_16);
 vvc_itx_1d_fn(ff_vvc_inv_dct8_32);
 
 
-void ff_vvc_inv_lfnst_1d(int *v, const int *u, int no_zero_size, int n_tr_s, int pred_mode_intra, int lfnst_idx);
+void ff_vvc_inv_lfnst_1d(int *v, const int *u, int no_zero_size, int n_tr_s,
+                         int pred_mode_intra, int lfnst_idx, int coeff_min,
+                         int coeff_max);
 
 #endif // AVCODEC_VVC_ITX_1D_H

--- a/libavcodec/vvc/vvc_itx_1d.h
+++ b/libavcodec/vvc/vvc_itx_1d.h
@@ -47,7 +47,6 @@ vvc_itx_1d_fn(ff_vvc_inv_dct8_32);
 
 
 void ff_vvc_inv_lfnst_1d(int *v, const int *u, int no_zero_size, int n_tr_s,
-                         int pred_mode_intra, int lfnst_idx, int coeff_min,
-                         int coeff_max);
+    int pred_mode_intra, int lfnst_idx, int log2_transform_range);
 
 #endif // AVCODEC_VVC_ITX_1D_H

--- a/libavcodec/vvc/vvc_ps.c
+++ b/libavcodec/vvc/vvc_ps.c
@@ -198,6 +198,8 @@ static int gci_parse(GeneralConstraintsInfo *gci, GetBitContext *gb, void *log_c
         gci->no_lmcs_constraint_flag = get_bits1(gb);
         gci->no_ladf_constraint_flag = get_bits1(gb);
         gci->no_virtual_boundaries_constraint_flag = get_bits1(gb);
+
+        num_additional_bits_used = 0;
         gci_num_additional_bits = get_bits(gb, 8);
         if (gci_num_additional_bits > 5) {
             gci->all_rap_pictures_constraint_flag = get_bits1(gb);

--- a/libavcodec/vvc/vvc_ps.c
+++ b/libavcodec/vvc/vvc_ps.c
@@ -108,7 +108,7 @@ static int gci_parse(GeneralConstraintsInfo *gci, GetBitContext *gb, void *log_c
 
     gci->present_flag = get_bits1(gb);
     if (gci->present_flag) {
-        unsigned int num_reserved_bits;
+        unsigned int num_reserved_bits, num_additional_bits_used;
         /* general */
         gci->intra_only_constraint_flag = get_bits1(gb);
         gci->all_layers_independent_constraint_flag = get_bits1(gb);
@@ -199,7 +199,24 @@ static int gci_parse(GeneralConstraintsInfo *gci, GetBitContext *gb, void *log_c
         gci->no_ladf_constraint_flag = get_bits1(gb);
         gci->no_virtual_boundaries_constraint_flag = get_bits1(gb);
         num_reserved_bits = get_bits(gb, 8);
-        for (i = 0; i < num_reserved_bits; i++) {
+        if (num_reserved_bits > 5) {
+            gci->all_rap_pictures_constraint_flag = get_bits1(gb);
+            gci->no_extended_precision_processing_constraint_flag = get_bits1(gb);
+            gci->no_ts_residual_coding_rice_constraint_flag = get_bits1(gb);
+            gci->no_rrc_rice_extension_constraint_flag = get_bits1(gb);
+            gci->no_persistent_rice_adaptation_constraint_flag = get_bits1(gb);
+            gci->no_reverse_last_sig_coeff_constraint_flag = get_bits1(gb);
+            num_additional_bits_used = 6;
+        } else {
+            gci->all_rap_pictures_constraint_flag = 0;
+            gci->no_extended_precision_processing_constraint_flag = 0;
+            gci->no_ts_residual_coding_rice_constraint_flag = 0;
+            gci->no_rrc_rice_extension_constraint_flag = 0;
+            gci->no_persistent_rice_adaptation_constraint_flag = 0;
+            gci->no_reverse_last_sig_coeff_constraint_flag = 0;
+            num_additional_bits_used = 0;
+        }
+        for (i = 0; i < num_reserved_bits - num_additional_bits_used; i++) {
             skip_bits1(gb);          //reserved_zero_bit[i]
         }
     }
@@ -1012,6 +1029,32 @@ static int sps_parse_vui(VVCSPS *sps, GetBitContext *gb, void *log_ctx)
     return 0;
 }
 
+static int sps_parse_extension(VVCSPS *sps, GetBitContext *gb, void *log_ctx)
+{
+    int range_extension_flag;
+    sps->extended_precision_flag = 0;
+    sps->ts_residual_coding_rice_present_in_sh_flag = 0;
+    sps->rrc_rice_extension_flag = 0;
+    sps->persistent_rice_adaptation_enabled_flag = 0;
+    sps->reverse_last_sig_coeff_enabled_flag = 0;
+
+    if (get_bits1(gb)) {  // sps_extension_present_flag
+        range_extension_flag = get_bits1(gb);
+        skip_bits(gb, 7);  // sps_extension_7bits
+        if (range_extension_flag) {
+            sps->extended_precision_flag = get_bits1(gb);
+            if (sps->transform_skip_enabled_flag) {
+                sps->ts_residual_coding_rice_present_in_sh_flag = get_bits1(gb);
+            }
+            sps->rrc_rice_extension_flag = get_bits1(gb);
+            sps->persistent_rice_adaptation_enabled_flag = get_bits1(gb);
+            sps->reverse_last_sig_coeff_enabled_flag = get_bits1(gb);
+        }
+    }
+    
+    return 0;
+}
+
 static int sps_parse(VVCSPS *sps, GetBitContext *gb, unsigned int *sps_id,
     int apply_defdispwin, AVBufferRef **vps_list, AVCodecContext *avctx, int nuh_layer_id)
 {
@@ -1150,7 +1193,9 @@ static int sps_parse(VVCSPS *sps, GetBitContext *gb, unsigned int *sps_id,
     if (ret < 0)
         return ret;
 
-    skip_bits1(gb);                 ///< sps_extension_flag
+    ret = sps_parse_extension(sps, gb, log_ctx);
+    if (ret < 0)
+        return ret;
 
     if (get_bits_left(gb) < 0) {
         av_log(log_ctx, AV_LOG_ERROR,
@@ -3214,6 +3259,16 @@ static void sh_parse_transform(VVCSH *sh, const VVCSPS *sps, GetBitContext *gb)
         sh->ts_residual_coding_disabled_flag = get_bits1(gb);
 }
 
+static void sh_parse_range_extension(VVCSH *sh, const VVCSPS *sps, GetBitContext *gb) {
+    sh->ts_residual_coding_rice_idx_minus1 = 0;
+    if (sps->ts_residual_coding_rice_present_in_sh_flag)
+        sh->ts_residual_coding_rice_idx_minus1 = get_bits(gb, 3);
+
+    sh->reverse_last_sig_coeff_flag = 0;
+    if (sps->reverse_last_sig_coeff_enabled_flag)
+        sh->reverse_last_sig_coeff_flag = get_bits1(gb);
+}
+
 static int sh_parse_entry_points(VVCSH *sh, const int curr_subpic_idx,
     const VVCParamSets *ps, GetBitContext *gb, void *log_ctx)
 {
@@ -3339,6 +3394,8 @@ int ff_vvc_decode_sh(VVCSH *sh, VVCContext *s, const int is_first_slice, GetBitC
         return ret;
 
     sh_parse_transform(sh, ps->sps, gb);
+
+    sh_parse_range_extension(sh, ps->sps, gb);
 
     if (ps->pps->slice_header_extension_present_flag) {
         int sh_slice_header_extension_length;

--- a/libavcodec/vvc/vvc_ps.c
+++ b/libavcodec/vvc/vvc_ps.c
@@ -108,7 +108,7 @@ static int gci_parse(GeneralConstraintsInfo *gci, GetBitContext *gb, void *log_c
 
     gci->present_flag = get_bits1(gb);
     if (gci->present_flag) {
-        unsigned int gci_num_addtional_bits, num_additional_bits_used;
+        unsigned int gci_num_additional_bits, num_additional_bits_used;
         /* general */
         gci->intra_only_constraint_flag = get_bits1(gb);
         gci->all_layers_independent_constraint_flag = get_bits1(gb);
@@ -198,8 +198,8 @@ static int gci_parse(GeneralConstraintsInfo *gci, GetBitContext *gb, void *log_c
         gci->no_lmcs_constraint_flag = get_bits1(gb);
         gci->no_ladf_constraint_flag = get_bits1(gb);
         gci->no_virtual_boundaries_constraint_flag = get_bits1(gb);
-        gci_num_addtional_bits = get_bits(gb, 8);
-        if (gci_num_addtional_bits > 5) {
+        gci_num_additional_bits = get_bits(gb, 8);
+        if (gci_num_additional_bits > 5) {
             gci->all_rap_pictures_constraint_flag = get_bits1(gb);
             gci->no_extended_precision_processing_constraint_flag = get_bits1(gb);
             gci->no_ts_residual_coding_rice_constraint_flag = get_bits1(gb);
@@ -208,7 +208,7 @@ static int gci_parse(GeneralConstraintsInfo *gci, GetBitContext *gb, void *log_c
             gci->no_reverse_last_sig_coeff_constraint_flag = get_bits1(gb);
             num_additional_bits_used = 6;
         }
-        for (i = 0; i < gci_num_addtional_bits - num_additional_bits_used; i++) {
+        for (i = 0; i < gci_num_additional_bits - num_additional_bits_used; i++) {
             skip_bits1(gb);          // gci_reserved_bit[i]
         }
     }

--- a/libavcodec/vvc/vvc_ps.c
+++ b/libavcodec/vvc/vvc_ps.c
@@ -1038,9 +1038,8 @@ static int sps_parse_extension(VVCSPS *sps, GetBitContext *gb, void *log_ctx)
     }
 
     // Derived values
-    sps->log2_transform_range = sps->extended_precision_flag
-                              ? FFMAX(15, FFMIN(20, sps->bit_depth + 6))
-                              : 15;
+    sps->log2_transform_range =
+        sps->extended_precision_flag ? FFMAX(15, FFMIN(20, sps->bit_depth + 6)) : 15;
 
     return 0;
 }

--- a/libavcodec/vvc/vvc_ps.c
+++ b/libavcodec/vvc/vvc_ps.c
@@ -1051,7 +1051,18 @@ static int sps_parse_extension(VVCSPS *sps, GetBitContext *gb, void *log_ctx)
             sps->reverse_last_sig_coeff_enabled_flag = get_bits1(gb);
         }
     }
-    
+
+    // Derived values
+    sps->log2_transform_range = sps->extended_precision_flag
+                              ? FFMAX(15, FFMIN(20, sps->bit_depth + 6))
+                              : 15;
+    sps->coeff_min = -(1 << (sps->extended_precision_flag
+                            ? FFMAX(15, FFMIN(20, sps->bit_depth + 6))
+                            : 15));
+    sps->coeff_max = (1 << (sps->extended_precision_flag
+                           ? FFMAX(15, FFMIN(20, sps->bit_depth + 6))
+                           : 15)) - 1;
+
     return 0;
 }
 

--- a/libavcodec/vvc/vvc_ps.h
+++ b/libavcodec/vvc/vvc_ps.h
@@ -470,6 +470,9 @@ typedef struct VVCSPS {
     uint8_t max_num_ibc_merge_cand;                                 ///< MaxNumIbcMergeCand
     uint8_t max_num_gpm_merge_cand;                                 ///< MaxNumGpmMergeCand
     unsigned int ladf_interval_lower_bound[LADF_MAX_INTERVAL];      ///< SpsLadfIntervalLowerBound[]
+    uint8_t log2_transform_range;                                   ///< Log2TransformRange
+    int32_t coeff_min;                                              ///< CoeffMin
+    int32_t coeff_max;                                              ///< CoeffMax
 
     uint8_t data[4096];
     int data_size;

--- a/libavcodec/vvc/vvc_ps.h
+++ b/libavcodec/vvc/vvc_ps.h
@@ -168,6 +168,13 @@ typedef struct GeneralConstraintsInfo {
     uint8_t no_lmcs_constraint_flag;
     uint8_t no_ladf_constraint_flag;
     uint8_t no_virtual_boundaries_constraint_flag;
+
+    uint8_t all_rap_pictures_constraint_flag;
+    uint8_t no_extended_precision_processing_constraint_flag;
+    uint8_t no_ts_residual_coding_rice_constraint_flag;
+    uint8_t no_rrc_rice_extension_constraint_flag;
+    uint8_t no_persistent_rice_adaptation_constraint_flag;
+    uint8_t no_reverse_last_sig_coeff_constraint_flag;
 } GeneralConstraintsInfo;
 
 typedef struct PTL {
@@ -442,6 +449,12 @@ typedef struct VVCSPS {
 
     int hshift[VVC_MAX_SAMPLE_ARRAYS];
     int vshift[VVC_MAX_SAMPLE_ARRAYS];
+
+    uint8_t extended_precision_flag;
+    uint8_t ts_residual_coding_rice_present_in_sh_flag;
+    uint8_t rrc_rice_extension_flag;
+    uint8_t persistent_rice_adaptation_enabled_flag;
+    uint8_t reverse_last_sig_coeff_enabled_flag;
 
     //derived values
     unsigned int max_pic_order_cnt_lsb;                             ///< MaxPicOrderCntLsb
@@ -777,6 +790,9 @@ typedef struct VVCSH {
 
     uint8_t  sign_data_hiding_used_flag;
     uint8_t  ts_residual_coding_disabled_flag;
+
+    uint8_t  ts_residual_coding_rice_idx_minus1;
+    uint8_t  reverse_last_sig_coeff_flag;
 
     //calculated value;
     uint8_t  collocated_list;                               ///< !sh_collocated_from_l0_flag

--- a/libavcodec/vvc/vvc_ps.h
+++ b/libavcodec/vvc/vvc_ps.h
@@ -471,8 +471,6 @@ typedef struct VVCSPS {
     uint8_t max_num_gpm_merge_cand;                                 ///< MaxNumGpmMergeCand
     unsigned int ladf_interval_lower_bound[LADF_MAX_INTERVAL];      ///< SpsLadfIntervalLowerBound[]
     uint8_t log2_transform_range;                                   ///< Log2TransformRange
-    int32_t coeff_min;                                              ///< CoeffMin
-    int32_t coeff_max;                                              ///< CoeffMax
 
     uint8_t data[4096];
     int data_size;

--- a/libavcodec/vvc/vvc_thread.c
+++ b/libavcodec/vvc/vvc_thread.c
@@ -238,6 +238,7 @@ static void add_task(VVCContext *s, VVCTask *t, const VVCTaskType type)
 static int run_parse(VVCContext *s, VVCLocalContext *lc, VVCTask *t)
 {
     VVCFrameContext *fc     = lc->fc;
+    const VVCSPS *sps       = fc->ps.sps;
     const VVCPPS *pps       = fc->ps.pps;
     SliceContext *sc        = t->sc;
     const VVCSH *sh         = &sc->sh;
@@ -266,6 +267,11 @@ static int run_parse(VVCContext *s, VVCLocalContext *lc, VVCTask *t)
             if (next < sc->eps + sc->nb_eps) {
                 memcpy(next->cabac_state, ep->cabac_state, sizeof(next->cabac_state));
                 av_assert0(!next->parse_task->type);
+                for (size_t i = 0; i < FF_ARRAY_ELEMS(lc->ep->stat_coeff); ++i) {
+                    lc->ep->stat_coeff[i] = sps->persistent_rice_adaptation_enabled_flag
+                        ? 2 * (int) (av_log2(sps->bit_depth - 10))
+                        : 0;
+                }
                 ff_vvc_frame_add_task(s, next->parse_task);
             }
         }

--- a/libavcodec/vvc/vvc_thread.c
+++ b/libavcodec/vvc/vvc_thread.c
@@ -267,11 +267,7 @@ static int run_parse(VVCContext *s, VVCLocalContext *lc, VVCTask *t)
             if (next < sc->eps + sc->nb_eps) {
                 memcpy(next->cabac_state, ep->cabac_state, sizeof(next->cabac_state));
                 av_assert0(!next->parse_task->type);
-                for (size_t i = 0; i < FF_ARRAY_ELEMS(lc->ep->stat_coeff); ++i) {
-                    lc->ep->stat_coeff[i] = sps->persistent_rice_adaptation_enabled_flag
-                        ? 2 * (int) (av_log2(sps->bit_depth - 10))
-                        : 0;
-                }
+                ff_vvc_ep_init_stat_coeff(lc->ep, sps->bit_depth, sps->persistent_rice_adaptation_enabled_flag);
                 ff_vvc_frame_add_task(s, next->parse_task);
             }
         }

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -122,7 +122,7 @@ typedef struct VVCItxDSPContext {
     void (*pred_residual_joint)(int *buf, int width, int height, int c_sign, int shift);
 
     void (*itx[N_TX_TYPE][N_TX_SIZE])(int *out, ptrdiff_t out_step, const int *in, ptrdiff_t in_step);
-    void (*transform_bdpcm)(int *coeffs, int width, int height, int vertical, int depth);
+    void (*transform_bdpcm)(int *coeffs, int width, int height, int vertical, int coeff_min, int coeff_max);
 } VVCItxDSPContext;
 
 typedef struct VVCLMCSDSPContext {

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -122,7 +122,7 @@ typedef struct VVCItxDSPContext {
     void (*pred_residual_joint)(int *buf, int width, int height, int c_sign, int shift);
 
     void (*itx[N_TX_TYPE][N_TX_SIZE])(int *out, ptrdiff_t out_step, const int *in, ptrdiff_t in_step);
-    void (*transform_bdpcm)(int *coeffs, int width, int height, int vertical, int coeff_min, int coeff_max);
+    void (*transform_bdpcm)(int *coeffs, int width, int height, int vertical, int log2_transform_range);
 } VVCItxDSPContext;
 
 typedef struct VVCLMCSDSPContext {

--- a/libavcodec/vvc/vvcdsp_template.c
+++ b/libavcodec/vvc/vvcdsp_template.c
@@ -73,7 +73,7 @@ static void FUNC(pred_residual_joint)(int *buf, const int w, const int h,
 }
 
 static void FUNC(transform_bdpcm)(int *coeffs, const int width, const int height,
-    const int vertical, const int depth)
+    const int vertical, const int coeff_min, const int coeff_max)
 {
     int x, y;
 
@@ -81,13 +81,13 @@ static void FUNC(transform_bdpcm)(int *coeffs, const int width, const int height
         coeffs += width;
         for (y = 0; y < height - 1; y++) {
             for (x = 0; x < width; x++)
-                coeffs[x] = av_clip_intp2(coeffs[x] + coeffs[x - width], depth);
+                coeffs[x] = av_clip(coeffs[x] + coeffs[x - width], coeff_min, coeff_max);
             coeffs += width;
         }
     } else {
         for (y = 0; y < height; y++) {
             for (x = 1; x < width; x++)
-                coeffs[x] = av_clip_intp2(coeffs[x] + coeffs[x - 1], depth);
+                coeffs[x] = av_clip(coeffs[x] + coeffs[x - 1], coeff_min, coeff_max);
             coeffs += width;
         }
     }

--- a/libavcodec/vvc/vvcdsp_template.c
+++ b/libavcodec/vvc/vvcdsp_template.c
@@ -73,7 +73,7 @@ static void FUNC(pred_residual_joint)(int *buf, const int w, const int h,
 }
 
 static void FUNC(transform_bdpcm)(int *coeffs, const int width, const int height,
-    const int vertical, const int coeff_min, const int coeff_max)
+    const int vertical, const int log2_transform_range)
 {
     int x, y;
 
@@ -81,13 +81,13 @@ static void FUNC(transform_bdpcm)(int *coeffs, const int width, const int height
         coeffs += width;
         for (y = 0; y < height - 1; y++) {
             for (x = 0; x < width; x++)
-                coeffs[x] = av_clip(coeffs[x] + coeffs[x - width], coeff_min, coeff_max);
+                coeffs[x] = av_clip_intp2(coeffs[x] + coeffs[x - width], log2_transform_range);
             coeffs += width;
         }
     } else {
         for (y = 0; y < height; y++) {
             for (x = 1; x < width; x++)
-                coeffs[x] = av_clip(coeffs[x] + coeffs[x - 1], coeff_min, coeff_max);
+                coeffs[x] = av_clip_intp2(coeffs[x] + coeffs[x - 1], log2_transform_range);
             coeffs += width;
         }
     }


### PR DESCRIPTION
This PR implements the VVCv2 range extension, which allows for increased dynamic ranges. This PR is branched off #90 for the time-being, but can be rebased if we find a better solution on resolution of [VVC #1602](https://jvet.hhi.fraunhofer.de/trac/vvc/ticket/1602).

The range extension is made up of five parts. The status of each of these in this branch is as below:
- [x] `extended_precision_flag`
- [x]  `ts_residual_coding_rice_present_in_sh_flag`
- [x] `rrc_rice_extension_flag`
- [x] `persistent_rice_adaptation_enabled_flag`
- [x] `reverse_last_sig_coeff_enabled_flag`

Additionally, the the range extension syntax elements have been added to the CBS and parsed. See the table in https://github.com/ffvvc/FFmpeg/issues/83#issuecomment-1575658232 for which bitstreams test which features.