### PR TITLE
inter: move refPicList from FrameContext to SliceContext

### DIFF
--- a/libavcodec/vvc/vvc_mvs.h
+++ b/libavcodec/vvc/vvc_mvs.h
@@ -38,7 +38,7 @@ void ff_vvc_store_mv(const VVCLocalContext *lc, const MotionInfo *mi);
 void ff_vvc_store_mvf(const VVCLocalContext *lc, const MvField *mvf);
 void ff_vvc_store_gpm_mvf(const VVCLocalContext *lc, const PredictionUnit* pu);
 void ff_vvc_update_hmvp(VVCLocalContext *lc, const MotionInfo *mi);
-int ff_vvc_no_backward_pred_flag(const VVCFrameContext *fc);
+int ff_vvc_no_backward_pred_flag(const VVCLocalContext *lc);
 MvField* ff_vvc_get_mvf(const VVCFrameContext *fc, const int x0, const int y0);
 void ff_vvc_set_mvf(const VVCLocalContext *lc, const int x0, const int y0, const int w, const int h, const MvField *mvf);
 void ff_vvc_set_intra_mvf(const VVCLocalContext *lc);

--- a/libavcodec/vvc/vvc_refs.h
+++ b/libavcodec/vvc/vvc_refs.h
@@ -33,8 +33,8 @@ int ff_vvc_output_frame(VVCContext *s, VVCFrameContext *fc, AVFrame *out, int no
 void ff_vvc_bump_frame(VVCContext *s, VVCFrameContext *fc);
 int ff_vvc_set_new_ref(VVCContext *s, VVCFrameContext *fc, AVFrame **frame);
 const RefPicList *ff_vvc_get_ref_list(const VVCFrameContext *fc, const VVCFrame *ref, int x0, int y0);
-int ff_vvc_frame_rpl(VVCContext *s, VVCFrameContext *fc, const SliceContext *sc);
-int ff_vvc_slice_rpl(VVCContext *s, VVCFrameContext *fc, const SliceContext *sc);
+int ff_vvc_frame_rpl(VVCContext *s, VVCFrameContext *fc, SliceContext *sc);
+int ff_vvc_slice_rpl(VVCContext *s, VVCFrameContext *fc, SliceContext *sc);
 void ff_vvc_unref_frame(VVCFrameContext *fc, VVCFrame *frame, int flags);
 void ff_vvc_clear_refs(VVCFrameContext *fc);
 

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -489,9 +489,10 @@ static int max_negtive(const int idx, const int diff, const int max_diff)
 
 typedef int (*smvd_find_fxn)(const int idx, const int diff, const int old_diff);
 
-static int8_t smvd_find(const VVCFrameContext *fc, const VVCSH *sh, int lx, smvd_find_fxn find)
+static int8_t smvd_find(const VVCFrameContext *fc, const SliceContext *sc, int lx, smvd_find_fxn find)
 {
-    const RefPicList *rpl   = fc->ref->refPicList + lx;
+    const VVCSH *sh         = &sc->sh;
+    const RefPicList *rpl   = sc->rpl + lx;
     const int poc           = fc->ref->poc;
     int8_t idx              = -1;
     int old_diff            = -1;
@@ -507,14 +508,15 @@ static int8_t smvd_find(const VVCFrameContext *fc, const VVCSH *sh, int lx, smvd
     return idx;
 }
 
-static void vvc_smvd_ref_idx(const VVCFrameContext *fc, VVCSH *sh)
+static void vvc_smvd_ref_idx(const VVCFrameContext *fc, SliceContext *sc)
 {
+    VVCSH *sh = &sc->sh;
     if (IS_B(sh)) {
-        sh->ref_idx_sym[0] = smvd_find(fc, sh, 0, min_positive);
-        sh->ref_idx_sym[1] = smvd_find(fc, sh, 1, max_negtive);
+        sh->ref_idx_sym[0] = smvd_find(fc, sc, 0, min_positive);
+        sh->ref_idx_sym[1] = smvd_find(fc, sc, 1, max_negtive);
         if (sh->ref_idx_sym[0] == -1 || sh->ref_idx_sym[1] == -1) {
-            sh->ref_idx_sym[0] = smvd_find(fc, sh, 0, max_negtive);
-            sh->ref_idx_sym[1] = smvd_find(fc, sh, 1, min_positive);
+            sh->ref_idx_sym[0] = smvd_find(fc, sc, 0, max_negtive);
+            sh->ref_idx_sym[1] = smvd_find(fc, sc, 1, min_positive);
         }
     }
 }
@@ -784,7 +786,7 @@ static int decode_slice(VVCContext *s, VVCFrameContext *fc, const H2645NAL *nal,
 
 
     if (!IS_I(sh))
-        vvc_smvd_ref_idx(fc, sh);
+        vvc_smvd_ref_idx(fc, sc);
 
     ret = init_slice_context(sc, fc, nal, gb);
     if (ret < 0)

--- a/libavcodec/vvc/vvcdec.h
+++ b/libavcodec/vvc/vvcdec.h
@@ -141,7 +141,6 @@ typedef struct VVCFrame {
     ThreadFrame tf;
 
     MvField  *tab_mvf;
-    RefPicList *refPicList;
     RefPicListTab **rpl_tab;
 
     int ctb_count;
@@ -171,6 +170,7 @@ struct SliceContext {
     VVCSH sh;
     EntryPoint *eps;
     int nb_eps;
+    RefPicList *rpl;
 };
 
 struct VVCFrameContext {


### PR DESCRIPTION
this will fix the round 2 round issue for ci
We parser slice header and reference list in the main thread. And use it in other threads. Since the reference list pointer will change from slice to slice, we need to move it to slice context"

fixes https://github.com/ffvvc/FFmpeg/issues/55