### PR TITLE
make parser and inter blockless

### DIFF
--- a/libavcodec/vvc/vvc_ctu.h
+++ b/libavcodec/vvc/vvc_ctu.h
@@ -271,6 +271,8 @@ typedef struct CodingUnit {
 
 struct CTU {
     CodingUnit *cus;
+    int max_y[2][VVC_MAX_REF_ENTRIES];
+    int max_y_idx[2];
 };
 
 typedef struct ReconstructedArea {

--- a/libavcodec/vvc/vvc_filter.c
+++ b/libavcodec/vvc/vvc_filter.c
@@ -406,7 +406,7 @@ static void vvc_deblock_subblock_bs_vertical(const VVCLocalContext *lc,
     const int cb_x, const int cb_y, const int x0, const int y0, const int width, const int height)
 {
     const VVCFrameContext  *fc  = lc->fc;
-    MvField *tab_mvf            = fc->ref->tab_mvf;
+    MvField *tab_mvf            = fc->tab.mvf;
     RefPicList *rpl             = lc->sc->rpl;
     const int min_pu_width      = fc->ps.pps->min_pu_width;
     const int log2_min_pu_size  = MIN_PU_LOG2;
@@ -447,7 +447,7 @@ static void vvc_deblock_subblock_bs_horizontal(const VVCLocalContext *lc,
     const int cb_x, const int cb_y, const int x0, const int y0, const int width, const int height)
 {
     const VVCFrameContext  *fc  = lc->fc;
-    MvField* tab_mvf            = fc->ref->tab_mvf;
+    MvField* tab_mvf            = fc->tab.mvf;
     RefPicList* rpl             = lc->sc->rpl;
     const int min_pu_width      = fc->ps.pps->min_pu_width;
     const int log2_min_pu_size  = MIN_PU_LOG2;
@@ -490,7 +490,7 @@ static void vvc_deblock_bs_luma_vertical(const VVCLocalContext *lc,
     const int x0, const int y0, const int width, const int height)
 {
     const VVCFrameContext *fc  = lc->fc;
-    MvField *tab_mvf           = fc->ref->tab_mvf;
+    MvField *tab_mvf           = fc->tab.mvf;
     const int log2_min_pu_size = MIN_PU_LOG2;
     const int log2_min_tu_size = MIN_TU_LOG2;
     const int min_pu_width     = fc->ps.pps->min_pu_width;
@@ -572,7 +572,7 @@ static void vvc_deblock_bs_luma_horizontal(const VVCLocalContext *lc,
     const int x0, const int y0, const int width, const int height)
 {
     const VVCFrameContext *fc  = lc->fc;
-    MvField *tab_mvf           = fc->ref->tab_mvf;
+    MvField *tab_mvf           = fc->tab.mvf;
     const int log2_min_pu_size = MIN_PU_LOG2;
     const int log2_min_tu_size = MIN_TU_LOG2;
     const int min_pu_width     = fc->ps.pps->min_pu_width;
@@ -653,7 +653,7 @@ static void vvc_deblock_bs_chroma_vertical(const VVCLocalContext *lc,
     const int x0, const int y0, const int width, const int height)
 {
     const VVCFrameContext *fc  = lc->fc;
-    MvField *tab_mvf           = fc->ref->tab_mvf;
+    MvField *tab_mvf           = fc->tab.mvf;
     const int log2_min_pu_size = MIN_PU_LOG2;
     const int log2_min_tu_size = MIN_PU_LOG2;
     const int min_pu_width     = fc->ps.pps->min_pu_width;
@@ -709,7 +709,7 @@ static void vvc_deblock_bs_chroma_horizontal(const VVCLocalContext *lc,
     const int x0, const int y0, const int width, const int height)
 {
     const VVCFrameContext *fc = lc->fc;
-    MvField *tab_mvf = fc->ref->tab_mvf;
+    MvField *tab_mvf = fc->tab.mvf;
     const int log2_min_pu_size = MIN_PU_LOG2;
     const int log2_min_tu_size = MIN_PU_LOG2;
     const int min_pu_width = fc->ps.pps->min_pu_width;

--- a/libavcodec/vvc/vvc_inter.c
+++ b/libavcodec/vvc/vvc_inter.c
@@ -1028,7 +1028,7 @@ static void ctu_wait_refs(VVCLocalContext *lc, const CTU *ctu)
             const int y = max_y[lx][i];
             VVCFrame *ref = lc->sc->rpl[lx].ref[i];
             if (ref && y >= 0)
-                ff_vvc_await_progress(ref, y + LUMA_EXTRA_AFTER);
+                ff_vvc_await_progress(ref, VVC_PROGRESS_PIXEL, y + LUMA_EXTRA_AFTER);
         }
     }
 }

--- a/libavcodec/vvc/vvc_inter.h
+++ b/libavcodec/vvc/vvc_inter.h
@@ -39,12 +39,4 @@ int ff_vvc_predict_inter(VVCLocalContext *lc, int rs);
  */
 void ff_vvc_predict_ciip(VVCLocalContext *lc);
 
-/**
- * apply DMVR(Decoder-Side Motion Vector Refinement) for the ctu
- * @param lc local context for CTU
- * @param x0 x position for the CTU
- * @param y0 y position for the CTU
- */
-void ff_vvc_ctu_apply_dmvr_info(VVCFrameContext *fc, int x0, const int y0);
-
 #endif // AVCODEC_VVC_INTER_H

--- a/libavcodec/vvc/vvc_mvs.c
+++ b/libavcodec/vvc/vvc_mvs.c
@@ -231,7 +231,7 @@ static int temporal_luma_motion_vector(const VVCLocalContext *lc,
         x < fc->ps.sps->width) {
         x                 &= ~7;
         y                 &= ~7;
-        ff_vvc_await_progress(ref, VVC_PROGRESS_PIXEL, y);
+        ff_vvc_await_progress(ref, VVC_PROGRESS_MV, y);
         temp_col           = TAB_MVF(x, y);
         availableFlagLXCol = DERIVE_TEMPORAL_COLOCATED_MVS(sb_flag);
     }
@@ -242,7 +242,7 @@ static int temporal_luma_motion_vector(const VVCLocalContext *lc,
             y                  = cu->y0 + (cu->cb_height >> 1);
             x                 &= ~7;
             y                 &= ~7;
-            ff_vvc_await_progress(ref, VVC_PROGRESS_PIXEL, y);
+            ff_vvc_await_progress(ref, VVC_PROGRESS_MV, y);
             temp_col           = TAB_MVF(x, y);
             availableFlagLXCol = DERIVE_TEMPORAL_COLOCATED_MVS(sb_flag);
         }
@@ -1018,7 +1018,7 @@ static void sb_temproal_luma_motion(const VVCLocalContext *lc,
 
     sb_clip_location(fc, x_ctb, y_ctb, temp_mv, &x, &y);
 
-    ff_vvc_await_progress(ref, VVC_PROGRESS_PIXEL, y);
+    ff_vvc_await_progress(ref, VVC_PROGRESS_MV, y);
 
     temp_col    = TAB_MVF(x, y);
     mvLXCol     = mv + 0;

--- a/libavcodec/vvc/vvc_mvs.c
+++ b/libavcodec/vvc/vvc_mvs.c
@@ -231,7 +231,7 @@ static int temporal_luma_motion_vector(const VVCLocalContext *lc,
         x < fc->ps.sps->width) {
         x                 &= ~7;
         y                 &= ~7;
-        ff_vvc_await_progress(ref, y);
+        ff_vvc_await_progress(ref, VVC_PROGRESS_PIXEL, y);
         temp_col           = TAB_MVF(x, y);
         availableFlagLXCol = DERIVE_TEMPORAL_COLOCATED_MVS(sb_flag);
     }
@@ -242,7 +242,7 @@ static int temporal_luma_motion_vector(const VVCLocalContext *lc,
             y                  = cu->y0 + (cu->cb_height >> 1);
             x                 &= ~7;
             y                 &= ~7;
-            ff_vvc_await_progress(ref, y);
+            ff_vvc_await_progress(ref, VVC_PROGRESS_PIXEL, y);
             temp_col           = TAB_MVF(x, y);
             availableFlagLXCol = DERIVE_TEMPORAL_COLOCATED_MVS(sb_flag);
         }
@@ -1018,7 +1018,7 @@ static void sb_temproal_luma_motion(const VVCLocalContext *lc,
 
     sb_clip_location(fc, x_ctb, y_ctb, temp_mv, &x, &y);
 
-    ff_vvc_await_progress(ref, y);
+    ff_vvc_await_progress(ref, VVC_PROGRESS_PIXEL, y);
 
     temp_col    = TAB_MVF(x, y);
     mvLXCol     = mv + 0;

--- a/libavcodec/vvc/vvc_mvs.c
+++ b/libavcodec/vvc/vvc_mvs.c
@@ -231,7 +231,6 @@ static int temporal_luma_motion_vector(const VVCLocalContext *lc,
         x < fc->ps.sps->width) {
         x                 &= ~7;
         y                 &= ~7;
-        ff_vvc_await_progress(ref, VVC_PROGRESS_MV, y);
         temp_col           = TAB_MVF(x, y);
         availableFlagLXCol = DERIVE_TEMPORAL_COLOCATED_MVS(sb_flag);
     }
@@ -242,7 +241,6 @@ static int temporal_luma_motion_vector(const VVCLocalContext *lc,
             y                  = cu->y0 + (cu->cb_height >> 1);
             x                 &= ~7;
             y                 &= ~7;
-            ff_vvc_await_progress(ref, VVC_PROGRESS_MV, y);
             temp_col           = TAB_MVF(x, y);
             availableFlagLXCol = DERIVE_TEMPORAL_COLOCATED_MVS(sb_flag);
         }
@@ -1017,8 +1015,6 @@ static void sb_temproal_luma_motion(const VVCLocalContext *lc,
     int X                       = 0;
 
     sb_clip_location(fc, x_ctb, y_ctb, temp_mv, &x, &y);
-
-    ff_vvc_await_progress(ref, VVC_PROGRESS_MV, y);
 
     temp_col    = TAB_MVF(x, y);
     mvLXCol     = mv + 0;

--- a/libavcodec/vvc/vvc_refs.c
+++ b/libavcodec/vvc/vvc_refs.c
@@ -49,8 +49,8 @@ void ff_vvc_unref_frame(VVCFrameContext *fc, VVCFrame *frame, int flags)
 
         av_buffer_unref(&frame->progress_buf);
 
-        av_buffer_unref(&frame->tab_mvf_buf);
-        frame->tab_mvf = NULL;
+        av_buffer_unref(&frame->tab_dmvr_mvf_buf);
+        frame->tab_dmvr_mvf = NULL;
 
         av_buffer_unref(&frame->rpl_buf);
         av_buffer_unref(&frame->rpl_tab_buf);
@@ -130,12 +130,12 @@ static VVCFrame *alloc_frame(VVCContext *s, VVCFrameContext *fc)
         if (!frame->rpl_buf)
             goto fail;
 
-        frame->tab_mvf_buf = av_buffer_pool_get(fc->tab_mvf_pool);
-        if (!frame->tab_mvf_buf)
+        frame->tab_dmvr_mvf_buf = av_buffer_pool_get(fc->tab_dmvr_mvf_pool);
+        if (!frame->tab_dmvr_mvf_buf)
             goto fail;
-        frame->tab_mvf = (MvField *)frame->tab_mvf_buf->data;
+        frame->tab_dmvr_mvf = (MvField *)frame->tab_dmvr_mvf_buf->data;
         //fixme: remove this
-        memset(frame->tab_mvf, 0, frame->tab_mvf_buf->size);
+        memset(frame->tab_dmvr_mvf, 0, frame->tab_dmvr_mvf_buf->size);
 
         frame->rpl_tab_buf = av_buffer_pool_get(fc->rpl_tab_pool);
         if (!frame->rpl_tab_buf)

--- a/libavcodec/vvc/vvc_refs.c
+++ b/libavcodec/vvc/vvc_refs.c
@@ -354,7 +354,7 @@ static VVCFrame *generate_missing_ref(VVCContext *s, VVCFrameContext *fc, int po
     frame->sequence = s->seq_decode;
     frame->flags    = 0;
 
-    ff_vvc_report_progress(frame, INT_MAX);
+    ff_vvc_report_frame_finished(frame);
 
     return frame;
 }
@@ -469,6 +469,10 @@ fail:
     return ret;
 }
 
+void ff_vvc_report_frame_finished(VVCFrame *frame)
+{
+    ff_vvc_report_progress(frame, INT_MAX);
+}
 
 void ff_vvc_report_progress(VVCFrame *frame, int n)
 {

--- a/libavcodec/vvc/vvc_refs.c
+++ b/libavcodec/vvc/vvc_refs.c
@@ -471,6 +471,7 @@ fail:
 
 void ff_vvc_report_frame_finished(VVCFrame *frame)
 {
+    ff_vvc_report_progress(frame, VVC_PROGRESS_MV, INT_MAX);
     ff_vvc_report_progress(frame, VVC_PROGRESS_PIXEL, INT_MAX);
 }
 

--- a/libavcodec/vvc/vvc_refs.c
+++ b/libavcodec/vvc/vvc_refs.c
@@ -500,3 +500,16 @@ void ff_vvc_await_progress(VVCFrame *frame, const VVCProgress vp, const int y)
 
     pthread_mutex_unlock(&p->lock);
 }
+
+int ff_vvc_check_progress(VVCFrame *frame, const VVCProgress vp, const int y)
+{
+    int ready ;
+    FrameProgress *p = (FrameProgress*)frame->progress_buf->data;
+
+    pthread_mutex_lock(&p->lock);
+
+    ready = p->progress[vp] > y + 1;
+
+    pthread_mutex_unlock(&p->lock);
+    return ready;
+}

--- a/libavcodec/vvc/vvc_refs.c
+++ b/libavcodec/vvc/vvc_refs.c
@@ -488,19 +488,6 @@ void ff_vvc_report_progress(VVCFrame *frame, const VVCProgress vp, const int y)
     pthread_mutex_unlock(&p->lock);
 }
 
-void ff_vvc_await_progress(VVCFrame *frame, const VVCProgress vp, const int y)
-{
-    FrameProgress *p = (FrameProgress*)frame->progress_buf->data;
-
-    pthread_mutex_lock(&p->lock);
-
-    // +1 for progress default value 0
-    while (p->progress[vp] < y + 1)
-        pthread_cond_wait(&p->cond, &p->lock);
-
-    pthread_mutex_unlock(&p->lock);
-}
-
 int ff_vvc_check_progress(VVCFrame *frame, const VVCProgress vp, const int y)
 {
     int ready ;

--- a/libavcodec/vvc/vvc_refs.h
+++ b/libavcodec/vvc/vvc_refs.h
@@ -47,5 +47,6 @@ typedef enum VVCProgress{
 void ff_vvc_report_frame_finished(VVCFrame *frame);
 void ff_vvc_report_progress(VVCFrame *frame, VVCProgress vp, int y);
 void ff_vvc_await_progress(VVCFrame *frame, VVCProgress vp, int y);
+int ff_vvc_check_progress(VVCFrame *frame, VVCProgress vp, int y);
 
 #endif // AVCODEC_VVC_REFS_H

--- a/libavcodec/vvc/vvc_refs.h
+++ b/libavcodec/vvc/vvc_refs.h
@@ -38,6 +38,7 @@ int ff_vvc_slice_rpl(VVCContext *s, VVCFrameContext *fc, SliceContext *sc);
 void ff_vvc_unref_frame(VVCFrameContext *fc, VVCFrame *frame, int flags);
 void ff_vvc_clear_refs(VVCFrameContext *fc);
 
+void ff_vvc_report_frame_finished(VVCFrame *frame);
 void ff_vvc_report_progress(VVCFrame *frame, int n);
 void ff_vvc_await_progress(VVCFrame *frame, int n);
 

--- a/libavcodec/vvc/vvc_refs.h
+++ b/libavcodec/vvc/vvc_refs.h
@@ -38,8 +38,14 @@ int ff_vvc_slice_rpl(VVCContext *s, VVCFrameContext *fc, SliceContext *sc);
 void ff_vvc_unref_frame(VVCFrameContext *fc, VVCFrame *frame, int flags);
 void ff_vvc_clear_refs(VVCFrameContext *fc);
 
+typedef enum VVCProgress{
+    VVC_PROGRESS_MV,
+    VVC_PROGRESS_PIXEL,
+    VVC_PROGRESS_LAST,
+} VVCProgress;
+
 void ff_vvc_report_frame_finished(VVCFrame *frame);
-void ff_vvc_report_progress(VVCFrame *frame, int n);
-void ff_vvc_await_progress(VVCFrame *frame, int n);
+void ff_vvc_report_progress(VVCFrame *frame, VVCProgress vp, int y);
+void ff_vvc_await_progress(VVCFrame *frame, VVCProgress vp, int y);
 
 #endif // AVCODEC_VVC_REFS_H

--- a/libavcodec/vvc/vvc_refs.h
+++ b/libavcodec/vvc/vvc_refs.h
@@ -46,7 +46,6 @@ typedef enum VVCProgress{
 
 void ff_vvc_report_frame_finished(VVCFrame *frame);
 void ff_vvc_report_progress(VVCFrame *frame, VVCProgress vp, int y);
-void ff_vvc_await_progress(VVCFrame *frame, VVCProgress vp, int y);
 int ff_vvc_check_progress(VVCFrame *frame, VVCProgress vp, int y);
 
 #endif // AVCODEC_VVC_REFS_H

--- a/libavcodec/vvc/vvc_thread.c
+++ b/libavcodec/vvc/vvc_thread.c
@@ -757,7 +757,7 @@ int ff_vvc_frame_wait(VVCContext *s, VVCFrameContext *fc)
     }
 
     pthread_mutex_unlock(&ft->lock);
-    ff_vvc_report_progress(fc->ref, INT_MAX);
+    ff_vvc_report_frame_finished(fc->ref);
 
 #ifdef VVC_THREAD_DEBUG
     av_log(s->avctx, AV_LOG_DEBUG, "frame %5d done\r\n", (int)fc->decode_order);

--- a/libavcodec/vvc/vvc_thread.c
+++ b/libavcodec/vvc/vvc_thread.c
@@ -511,7 +511,6 @@ static int run_alf(VVCContext *s, VVCLocalContext *lc, VVCTask *t)
             ff_vvc_alf_filter(lc, x0, y0);
         }
     }
-    ff_vvc_ctu_apply_dmvr_info(fc, x0, y0);
     set_avail(ft, t->rx, t->ry, VVC_TASK_TYPE_ALF);
     report_frame_progress(fc, t);
 

--- a/libavcodec/vvc/vvc_thread.c
+++ b/libavcodec/vvc/vvc_thread.c
@@ -488,7 +488,7 @@ static void report_frame_progress(VVCFrameContext *fc, VVCTask *t)
             ft->alf_row_progress++;
         if (old != ft->alf_row_progress) {
             const int progress = ft->alf_row_progress == ft->ctu_height ? INT_MAX : ft->alf_row_progress * ctu_size;
-            ff_vvc_report_progress(fc->ref, progress);
+            ff_vvc_report_progress(fc->ref, VVC_PROGRESS_PIXEL, progress);
         }
         pthread_mutex_unlock(&ft->lock);
     }

--- a/libavcodec/vvc/vvc_thread.c
+++ b/libavcodec/vvc/vvc_thread.c
@@ -291,7 +291,7 @@ static void report_frame_progress(VVCFrameContext *fc, VVCTask *t)
 {
     VVCFrameThread *ft  = fc->frame_thread;
     const int ctu_size  = ft->ctu_size;
-    const int idx       = VVC_PROGRESS_PIXEL;
+    const int idx       = t->type == VVC_TASK_TYPE_INTER ? VVC_PROGRESS_MV : VVC_PROGRESS_PIXEL;
     int old;
 
     if (atomic_fetch_add(&ft->rows[t->ry].progress[idx], 1) == ft->ctu_width - 1) {
@@ -323,6 +323,7 @@ static int run_inter(VVCContext *s, VVCLocalContext *lc, VVCTask *t)
             ff_vvc_frame_add_task(s, &ft->rows[t->ry].reconstruct_task);
     }
     set_avail(ft, t->rx, t->ry, VVC_TASK_TYPE_INTER);
+    report_frame_progress(fc, t);
 
     return 0;
 }

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -938,7 +938,7 @@ static int decode_nal_units(VVCContext *s, VVCFrameContext *fc, const uint8_t *b
 
 fail:
     if (fc->ref)
-        ff_vvc_report_progress(fc->ref, INT_MAX);
+        ff_vvc_report_frame_finished(fc->ref);
     return ret;
 }
 

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -252,11 +252,11 @@ static int min_tu_arrays_init(VVCFrameContext *fc, const int pic_size_in_min_tu)
 
 static void min_pu_arrays_free(VVCFrameContext *fc)
 {
+    av_freep(&fc->tab.mvf);
     av_freep(&fc->tab.msf);
     av_freep(&fc->tab.iaf);
     av_freep(&fc->tab.mmi);
-    av_freep(&fc->tab.dmvr);
-    av_buffer_pool_uninit(&fc->tab_mvf_pool);
+    av_buffer_pool_uninit(&fc->tab_dmvr_mvf_pool);
 }
 
 static int min_pu_arrays_init(VVCFrameContext *fc, const int pic_size_in_min_pu)
@@ -266,17 +266,17 @@ static int min_pu_arrays_init(VVCFrameContext *fc, const int pic_size_in_min_pu)
         fc->tab.msf  = av_mallocz(pic_size_in_min_pu);
         fc->tab.iaf  = av_mallocz(pic_size_in_min_pu);
         fc->tab.mmi  = av_mallocz(pic_size_in_min_pu);
-        fc->tab.dmvr = av_calloc(pic_size_in_min_pu, sizeof(*fc->tab.dmvr));
-        if (!fc->tab.msf || !fc->tab.iaf || !fc->tab.mmi || !fc->tab.dmvr)
+        fc->tab.mvf  = av_mallocz(pic_size_in_min_pu * sizeof(*fc->tab.mvf));
+        if (!fc->tab.msf || !fc->tab.iaf || !fc->tab.mmi || !fc->tab.mvf)
             return AVERROR(ENOMEM);
-        fc->tab_mvf_pool  = av_buffer_pool_init(pic_size_in_min_pu * sizeof(MvField), av_buffer_allocz);
-        if (!fc->tab_mvf_pool)
+        fc->tab_dmvr_mvf_pool  = av_buffer_pool_init(pic_size_in_min_pu * sizeof(MvField), av_buffer_allocz);
+        if (!fc->tab_dmvr_mvf_pool)
             return AVERROR(ENOMEM);
     } else {
         memset(fc->tab.msf, 0, pic_size_in_min_pu);
         memset(fc->tab.iaf, 0, pic_size_in_min_pu);
         memset(fc->tab.mmi, 0, pic_size_in_min_pu);
-        memset(fc->tab.dmvr, 0, pic_size_in_min_pu * sizeof(*fc->tab.dmvr));
+        memset(fc->tab.mvf, 0, pic_size_in_min_pu * sizeof(*fc->tab.mvf));
     }
 
     return 0;
@@ -654,10 +654,10 @@ static int vvc_ref_frame(VVCFrameContext *fc, VVCFrame *dst, VVCFrame *src)
 
     dst->progress_buf = av_buffer_ref(src->progress_buf);
 
-    dst->tab_mvf_buf = av_buffer_ref(src->tab_mvf_buf);
-    if (!dst->tab_mvf_buf)
+    dst->tab_dmvr_mvf_buf = av_buffer_ref(src->tab_dmvr_mvf_buf);
+    if (!dst->tab_dmvr_mvf_buf)
         goto fail;
-    dst->tab_mvf = src->tab_mvf;
+    dst->tab_dmvr_mvf = src->tab_dmvr_mvf;
 
     dst->rpl_tab_buf = av_buffer_ref(src->rpl_tab_buf);
     if (!dst->rpl_tab_buf)

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -1160,7 +1160,7 @@ static av_cold int vvc_decode_init(AVCodecContext *avctx)
             goto fail;
     }
 
-    s->executor = ff_executor_alloc(&callbacks, s->nb_fcs * 3 / 2);
+    s->executor = ff_executor_alloc(&callbacks, s->nb_fcs);
     s->eos = 1;
     GDR_SET_RECOVERED(s);
     pthread_once(&once_control, vvc_one_time_init);

--- a/libavcodec/vvc/vvcdec.h
+++ b/libavcodec/vvc/vvcdec.h
@@ -140,7 +140,7 @@ typedef struct VVCFrame {
     AVFrame *frame;
     ThreadFrame tf;
 
-    MvField  *tab_mvf;
+    MvField  *tab_dmvr_mvf;
     RefPicListTab **rpl_tab;
 
     int ctb_count;
@@ -149,7 +149,7 @@ typedef struct VVCFrame {
 
     struct VVCFrame *collocated_ref;
 
-    AVBufferRef *tab_mvf_buf;
+    AVBufferRef *tab_dmvr_mvf_buf;
     AVBufferRef *rpl_tab_buf;
     AVBufferRef *rpl_buf;
     AVBufferRef *progress_buf;
@@ -199,7 +199,7 @@ struct VVCFrameContext {
     AVPacket *avpkt;
     H2645Packet pkt;
 
-    AVBufferPool *tab_mvf_pool;
+    AVBufferPool *tab_dmvr_mvf_pool;
     AVBufferPool *rpl_tab_pool;
 
     AVBufferPool *cu_pool;
@@ -211,7 +211,6 @@ struct VVCFrameContext {
         DBParams  *deblock;
         SAOParams *sao;
         ALFParams *alf;
-        DMVRInfo  *dmvr;
 
         int     *cb_pos_x[2];                           ///< CbPosX[][][]
         int     *cb_pos_y[2];                           ///< CbPosY[][][]
@@ -232,6 +231,7 @@ struct VVCFrameContext {
         uint8_t *iaf;                                   ///< InterAffineFlag[][]
         uint8_t *mmi;                                   ///< MotionModelIdc[][]
         Mv      *cp_mv[2];                              ///< CpMvLX[][][][MAX_CONTROL_POINTS];
+        MvField *mvf;                                   ///< MvDmvrL0, MvDmvrL1
 
         uint8_t *tu_coded_flag[VVC_MAX_SAMPLE_ARRAYS];  ///< tu_y_coded_flag[][],  tu_cb_coded_flag[][],  tu_cr_coded_flag[][]
         uint8_t *tu_joint_cbcr_residual_flag;           ///< tu_joint_cbcr_residual_flag[][]


### PR DESCRIPTION
this will greatly improve performance in some cases.

Clip|Before|After|Delta
-|-|-|-
RitualDance_1920x1080_60_10_420_32_LD.266 	|159.3	|166.7	|4.65%
Tango2_3840x2160_60_10_420_27_RA.266 	    |39	    |38	    |-2.56%
RitualDance_1920x1080_60_10_420_37_RA.266 	|167	|173.7	|4.01%
Tango2_3840x2160_60_10_420_27_LD.266 	    |41	    |42.7	|4.15%
BQTerrace_1920x1080_60_10_420_22_RA.vvc 	|83.7	|94.7	|13.14%
NovosobornayaSquare_1920x1080.bin 	        |155	|200.7	|29.48%
Chimera_8bit_1080P_1000_frames.vvc 	        |191.7	|199.3	|3.96%

fixes https://github.com/ffvvc/FFmpeg/issues/23