### PR TITLE
vvc_sao: proper fix for doubled PB size constant

### DIFF
--- a/libavcodec/x86/vvc_sao.asm
+++ b/libavcodec/x86/vvc_sao.asm
@@ -188,9 +188,9 @@ VVC_SAO_BAND_FILTER 128, 4
 ;SAO Edge Filter
 ;******************************************************************************
 
-%define MAX_PB_SIZE  64
+%define MAX_PB_SIZE  128
 %define PADDING_SIZE 64 ; AV_INPUT_BUFFER_PADDING_SIZE
-%define EDGE_SRCSTRIDE 4 * MAX_PB_SIZE + PADDING_SIZE
+%define EDGE_SRCSTRIDE 2 * MAX_PB_SIZE + PADDING_SIZE
 
 %macro VVC_SAO_EDGE_FILTER_INIT 0
 %if WIN64

--- a/libavcodec/x86/vvc_sao_10bit.asm
+++ b/libavcodec/x86/vvc_sao_10bit.asm
@@ -179,9 +179,9 @@ VVC_SAO_BAND_FILTER 12, 128, 8
 ;SAO Edge Filter
 ;******************************************************************************
 
-%define MAX_PB_SIZE  64
+%define MAX_PB_SIZE  128
 %define PADDING_SIZE 64 ; AV_INPUT_BUFFER_PADDING_SIZE
-%define EDGE_SRCSTRIDE 4 * MAX_PB_SIZE + PADDING_SIZE
+%define EDGE_SRCSTRIDE 2 * MAX_PB_SIZE + PADDING_SIZE
 
 %macro PMINUW 4
 %if cpuflag(sse4)


### PR DESCRIPTION
_Actually_ fixes the doubled PB size constant. Stupid error on my end, to be honest.

Fixes the first part of #119 