### PR TITLE
vvc_sao: Add AArch64 NEON accelerated SAO band and edge filters

### DIFF
--- a/libavcodec/aarch64/Makefile
+++ b/libavcodec/aarch64/Makefile
@@ -71,3 +71,5 @@ NEON-OBJS-$(CONFIG_HEVC_DECODER)        += aarch64/hevcdsp_deblock_neon.o      \
                                            aarch64/hevcdsp_qpel_neon.o         \
                                            aarch64/hevcdsp_epel_neon.o         \
                                            aarch64/hevcdsp_sao_neon.o
+NEON-OBJS-$(CONFIG_VVC_DECODER)		+= aarch64/vvcdsp_init_aarch64.o	\
+					   aarch64/vvcdsp_sao_neon.o

--- a/libavcodec/aarch64/vvcdsp_init_aarch64.c
+++ b/libavcodec/aarch64/vvcdsp_init_aarch64.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Shaun Loo
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <stdint.h>
+
+#include "libavutil/attributes.h"
+#include "libavutil/cpu.h"
+#include "libavutil/aarch64/cpu.h"
+#include "libavcodec/vvc/vvcdsp.h"
+
+void ff_vvc_sao_band_filter_8x8_8_neon(uint8_t *_dst, uint8_t *_src,
+                                  ptrdiff_t stride_dst, ptrdiff_t stride_src,
+                                  int16_t *sao_offset_val, int sao_left_class,
+                                  int width, int height);
+void ff_vvc_sao_edge_filter_16x16_8_neon(uint8_t *dst, const uint8_t *src, ptrdiff_t stride_dst,
+                                          const int16_t *sao_offset_val, int eo, int width, int height);
+void ff_vvc_sao_edge_filter_8x8_8_neon(uint8_t *dst, const uint8_t *src, ptrdiff_t stride_dst,
+                                        const int16_t *sao_offset_val, int eo, int width, int height);
+
+av_cold void ff_vvc_dsp_init_aarch64(VVCDSPContext *c, const int bit_depth) {
+	if (!have_neon(av_get_cpu_flags())) return;
+	if (bit_depth == 8) {
+        	c->sao.band_filter[0]          =
+        	c->sao.band_filter[1]          =
+        	c->sao.band_filter[2]          =
+        	c->sao.band_filter[3]          =
+		c->sao.band_filter[4]	       =
+		c->sao.band_filter[5]	       =
+		c->sao.band_filter[6]	       =
+		c->sao.band_filter[7]	       =
+        	c->sao.band_filter[8]          = ff_vvc_sao_band_filter_8x8_8_neon;
+        	c->sao.edge_filter[0]          = ff_vvc_sao_edge_filter_8x8_8_neon;
+        	c->sao.edge_filter[1]          =
+        	c->sao.edge_filter[2]          =
+        	c->sao.edge_filter[3]          =
+		c->sao.edge_filter[4]	       =
+	        c->sao.edge_filter[5]	       =
+		c->sao.edge_filter[6]	       =
+		c->sao.edge_filter[7]	       =
+        	c->sao.edge_filter[8]          = ff_vvc_sao_edge_filter_16x16_8_neon;
+	}
+}

--- a/libavcodec/aarch64/vvcdsp_sao_neon.S
+++ b/libavcodec/aarch64/vvcdsp_sao_neon.S
@@ -1,0 +1,197 @@
+/* -*-arm64-*-
+ * vim: syntax=arm64asm
+ *
+ * AArch64 NEON optimised SAO functions for VVC decoding
+ *
+ * Copyright (c) 2022 J. Dekker <jdek@itanimul.li>
+ * Copyright (c) 2023 Shaun Loo <shaunloo10@gmail.com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "libavutil/aarch64/asm.S"
+
+#define MAX_PB_SIZE 128 
+#define AV_INPUT_BUFFER_PADDING_SIZE 64
+#define SAO_STRIDE (2*MAX_PB_SIZE + AV_INPUT_BUFFER_PADDING_SIZE)
+
+// void sao_band_filter(uint8_t *_dst, uint8_t *_src,
+//                      ptrdiff_t stride_dst, ptrdiff_t stride_src,
+//                      int16_t *sao_offset_val, int sao_left_class,
+//                      int width, int height)
+function ff_vvc_sao_band_filter_8x8_8_neon, export=1
+        stp             xzr, xzr, [sp, #-64]!
+        stp             xzr, xzr, [sp, #16]
+        stp             xzr, xzr, [sp, #32]
+        stp             xzr, xzr, [sp, #48]
+        mov             w8,  #4
+0:      ldrsh           x9, [x4,  x8, lsl #1]      // sao_offset_val[k+1]
+        subs            w8,  w8,  #1
+        add             w10, w8,  w5               // k + sao_left_class
+        and             w10, w10, #0x1F
+        strh            w9, [sp, x10, lsl #1]
+        bne             0b
+        add             w6,  w6,  #7
+        bic             w6,  w6,  #7
+        ld1             {v16.16b-v19.16b}, [sp], #64
+        sub             x2,  x2,  x6
+        sub             x3,  x3,  x6
+        movi            v20.8h,   #1
+1:      mov             w8,  w6                    // beginning of line
+2:      // Simple layout for accessing 16bit values
+        // with 8bit LUT.
+        //
+        //   00  01  02  03  04  05  06  07
+        // +----------------------------------->
+        // |xDE#xAD|xCA#xFE|xBE#xEF|xFE#xED|....
+        // +----------------------------------->
+        //    i-0     i-1     i-2     i-3
+        ld1             {v2.8b}, [x1], #8          // dst[x] = av_clip_pixel(src[x] + offset_table[src[x] >> shift]);
+        subs            w8, w8,  #8
+        uxtl            v0.8h,  v2.8b              // load src[x]
+        ushr            v2.8h,  v0.8h, #3          // >> BIT_DEPTH - 3
+        shl             v1.8h,  v2.8h, #1          // low (x2, accessing short)
+        add             v3.8h,  v1.8h, v20.8h      // +1 access upper short
+        sli             v1.8h,  v3.8h, #8          // shift insert index to upper byte
+        tbx             v2.16b, {v16.16b-v19.16b}, v1.16b // table
+        add             v1.8h,  v0.8h, v2.8h       // src[x] + table
+        sqxtun          v4.8b,  v1.8h              // clip + narrow
+        st1             {v4.8b}, [x0], #8          // store
+        // done 8 pixels
+        bne             2b
+        subs            w7, w7,  #1                // finished line, prep. new
+        add             x0, x0,  x2                // dst += stride_dst
+        add             x1, x1,  x3                // src += stride_src
+        bne             1b
+        ret
+endfunc
+
+.Lsao_edge_pos:
+.word 1 // horizontal
+.word SAO_STRIDE // vertical
+.word SAO_STRIDE + 1 // 45 degree
+.word SAO_STRIDE - 1 // 135 degree
+
+// ff_hevc_sao_edge_filter_16x16_8_neon(char *dst, char *src, ptrdiff stride_dst,
+//                                      int16 *sao_offset_val, int eo, int width, int height)
+function ff_vvc_sao_edge_filter_16x16_8_neon, export=1
+        adr             x7, .Lsao_edge_pos
+        ld1             {v3.8h}, [x3]              // load sao_offset_val
+        add             w5,  w5,  #0xF
+        bic             w5,  w5,  #0xF
+        ldr             w4, [x7, w4, uxtw #2]      // stride_src
+        mov             v3.h[7], v3.h[0]           // reorder to [1,2,0,3,4]
+        mov             v3.h[0], v3.h[1]
+        mov             v3.h[1], v3.h[2]
+        mov             v3.h[2], v3.h[7]
+        // split 16bit values into two tables
+        uzp2            v1.16b, v3.16b, v3.16b     // sao_offset_val -> upper
+        uzp1            v0.16b, v3.16b, v3.16b     // sao_offset_val -> lower
+        movi            v2.16b, #2
+        mov             x15, #SAO_STRIDE
+        // strides between end of line and next src/dst
+        sub             x15, x15, x5               // stride_src - width
+        sub             x16, x2, x5                // stride_dst - width
+        mov             x11, x1                    // copy base src
+1:      // new line
+        mov             x14, x5                    // copy width
+        sub             x12, x11, x4               // src_a (prev) = src - sao_edge_pos
+        add             x13, x11, x4               // src_b (next) = src + sao_edge_pos
+2:      // process 16 bytes
+        ld1             {v3.16b}, [x11], #16       // load src
+        ld1             {v4.16b}, [x12], #16       // load src_a (prev)
+        ld1             {v5.16b}, [x13], #16       // load src_b (next)
+        subs            x14, x14, #16
+        cmhi            v16.16b, v4.16b, v3.16b    // (prev > cur)
+        cmhi            v17.16b, v3.16b, v4.16b    // (cur > prev)
+        cmhi            v18.16b, v5.16b, v3.16b    // (next > cur)
+        cmhi            v19.16b, v3.16b, v5.16b    // (cur > next)
+        sub             v20.16b, v16.16b, v17.16b  // diff0 = CMP(cur, prev) = (cur > prev) - (cur < prev)
+        sub             v21.16b, v18.16b, v19.16b  // diff1 = CMP(cur, next) = (cur > next) - (cur < next)
+        add             v20.16b, v20.16b, v21.16b  // diff = diff0 + diff1
+        add             v20.16b, v20.16b, v2.16b   // offset_val = diff + 2
+        tbl             v16.16b, {v0.16b}, v20.16b
+        tbl             v17.16b, {v1.16b}, v20.16b
+        uxtl            v20.8h, v3.8b              // src[0:7]
+        uxtl2           v21.8h, v3.16b             // src[7:15]
+        zip1            v18.16b, v16.16b, v17.16b  // sao_offset_val lower ->
+        zip2            v19.16b, v16.16b, v17.16b  // sao_offset_val upper ->
+        sqadd           v20.8h, v18.8h, v20.8h     // + sao_offset_val
+        sqadd           v21.8h, v19.8h, v21.8h
+        sqxtun          v3.8b, v20.8h
+        sqxtun2         v3.16b, v21.8h
+        st1             {v3.16b}, [x0], #16
+        // filtered 16 bytes
+        b.ne            2b                         // do we have width to filter?
+        // no width to filter, setup next line
+        subs            w6, w6, #1                 // filtered line
+        add             x11, x11, x15              // stride src to next line
+        add             x0, x0, x16                // stride dst to next line
+        b.ne            1b                         // do we have lines to process?
+        // no lines to filter
+        ret
+endfunc
+
+// ff_hevc_sao_edge_filter_8x8_8_neon(char *dst, char *src, ptrdiff stride_dst,
+//                                    int16 *sao_offset_val, int eo, int width, int height)
+function ff_vvc_sao_edge_filter_8x8_8_neon, export=1
+        adr             x7, .Lsao_edge_pos
+        ldr             w4, [x7, w4, uxtw #2]
+        ld1             {v3.8h}, [x3]
+        mov             v3.h[7], v3.h[0]
+        mov             v3.h[0], v3.h[1]
+        mov             v3.h[1], v3.h[2]
+        mov             v3.h[2], v3.h[7]
+        uzp2            v1.16b, v3.16b, v3.16b
+        uzp1            v0.16b, v3.16b, v3.16b
+        movi            v2.16b, #2
+        add             x16, x0, x2
+        lsl             x2,  x2, #1
+        mov             x15, #SAO_STRIDE
+        mov             x8,  x1
+        sub             x9,  x1, x4
+        add             x10, x1, x4
+1:      ld1             {v3.d}[0], [ x8], x15
+        ld1             {v4.d}[0], [ x9], x15
+        ld1             {v5.d}[0], [x10], x15
+        ld1             {v3.d}[1], [ x8], x15
+        ld1             {v4.d}[1], [ x9], x15
+        ld1             {v5.d}[1], [x10], x15
+        subs            w6, w6, #2
+        cmhi            v16.16b, v4.16b, v3.16b
+        cmhi            v17.16b, v3.16b, v4.16b
+        cmhi            v18.16b, v5.16b, v3.16b
+        cmhi            v19.16b, v3.16b, v5.16b
+        sub             v20.16b, v16.16b, v17.16b
+        sub             v21.16b, v18.16b, v19.16b
+        add             v20.16b, v20.16b, v21.16b
+        add             v20.16b, v20.16b, v2.16b
+        tbl             v16.16b, {v0.16b}, v20.16b
+        tbl             v17.16b, {v1.16b}, v20.16b
+        uxtl            v20.8h, v3.8b
+        uxtl2           v21.8h, v3.16b
+        zip1            v18.16b, v16.16b, v17.16b
+        zip2            v19.16b, v16.16b, v17.16b
+        sqadd           v20.8h, v18.8h, v20.8h
+        sqadd           v21.8h, v19.8h, v21.8h
+        sqxtun          v6.8b, v20.8h
+        sqxtun          v7.8b, v21.8h
+        st1             {v6.8b}, [ x0], x2
+        st1             {v7.8b}, [x16], x2
+        b.ne            1b
+        ret
+endfunc

--- a/libavcodec/vvc/vvcdsp.c
+++ b/libavcodec/vvc/vvcdsp.c
@@ -322,5 +322,7 @@ void ff_vvc_dsp_init(VVCDSPContext *vvcdsp, int bit_depth)
     }
 #if ARCH_X86
     ff_vvc_dsp_init_x86(vvcdsp, bit_depth);
+#elif ARCH_AARCH64
+    ff_vvc_dsp_init_aarch64(vvcdsp, bit_depth);
 #endif
 }

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -179,5 +179,6 @@ extern const int8_t ff_vvc_luma_filters[3][16][8];
 extern const int8_t ff_vvc_dmvr_filters[16][2];
 
 void ff_vvc_dsp_init_x86(VVCDSPContext *c, const int bit_depth);
+void ff_vvc_dsp_init_aarch64(VVCDSPContext *c, const int bit_depth);
 
 #endif /* AVCODEC_VVCDSP_H */


### PR DESCRIPTION
I recently got an M1 Pro MacBook Pro (6x Performance Cores, 2x Efficiency Cores). As a distraction and exercise, I ported the HEVC SAO NEON code to VVC.

```
+++++++++ report +++++++++
passed files:
    APSMULT_A_MediaTek_4.bit
    MTS_LFNST_A_LGE_4.bit
    IP_A_Huawei_2.bit
    TILE_F_Nokia_2.bit
    STILL444_B_ERICSSON_1.bit
    JCCR_E_Nokia_1.bit
    OPI_A_Nokia_1.bit
    10b422_D_Sony_5.bit
    LFNST_A_LGE_4.bit
    SbTMVP_A_Bytedance_3.bit
    APSLMCS_D_Dolby_1.bit
    CCALF_D_Sharp_3.bit
    ALF_B_Huawei_3.bit
    BDOF_A_MediaTek_4.bit
    SCALING_A_InterDigital_1.bit
    MERGE_A_Qualcomm_2.bit
    PDPC_B_Qualcomm_3.bit
    LMCS_C_Dolby_1.bit
    DCI_A_Tencent_3.bit
    DEBLOCKING_B_Sharp_2.bit
    ENTHIGHTIER_B_Sony_3.bit
    BCW_A_MediaTek_4.bit
    QUANT_E_Interdigital_1.bit
    MRLP_B_HHI_2.bit
    8b420_A_Bytedance_2.bit
    MERGE_F_Qualcomm_2.bit
    8b422_B_Sony_5.bit
    ACTPIC_A_Huawei_3.bit
    PDPC_C_Qualcomm_2.bit
    APSLMCS_A_Dolby_3.bit
    MERGE_I_Qualcomm_2.bit
    SCALING_B_InterDigital_1.bit
    IP_B_Nokia_1.bit
    AMVR_B_HHI_3.bit
    POC_A_Nokia_1.bit
    DCI_B_Tencent_3.bit
    SDH_A_Dolby_2.bit
    PSEXT_A_Nokia_2.bit
    DPB_A_Sharplabs_2.bit
    TEMPSCAL_B_Panasonic_7.bit
    DMVR_B_KDDI_4.bit
    TRANS_C_Chipsnmedia_4.bit
    JCCR_C_HHI_3.bit
    LFNST_C_HHI_3.bit
    TRANS_B_Chipsnmedia_2.bit
    ENT444MAINTIER_B_Sony_3.bit
    MERGE_H_Qualcomm_2.bit
    TILE_C_Nokia_2.bit
    10b422_A_Sony_5.bit
    STILL_B_ERICSSON_1.bit
    CCALF_A_Sharp_3.bit
    RAP_C_HHI_1.bit
    AFF_A_HUAWEI_2.bit
    10b400_A_Bytedance_2.bit
    QUANT_A_Huawei_2.bit
    SAO_A_SAMSUNG_3.bit
    TREE_C_HHI_3.bit
    ENTROPY_B_Sharp_2.bit
    APSMULT_B_MediaTek_4.bit
    MERGE_E_Qualcomm_2.bit
    10b422_F_Sony_5.bit
    SMVD_A_HUAWEI_2.bit
    CCALF_B_Sharp_3.bit
    MPM_A_LGE_3.bit
    TRANS_A_Chipsnmedia_2.bit
    RAP_D_HHI_1.bit
    PSEXT_B_Nokia_2.bit
    MIP_A_HHI_3.bit
    ENT444HIGHTIER_B_Sony_3.bit
    WP_A_InterDigital_3.bit
    PQ_A_Dolby_1.bit
    PROF_B_Interdigital_3.bit
    MERGE_G_Qualcomm_2.bit
    TEMPSCAL_C_Panasonic_4.bit
    8b400_B_Bytedance_2.bit
    DQ_A_HHI_3.bit
    PDPC_A_Qualcomm_3.bit
    8b422_E_Sony_5.bit
    FILLER_A_Bytedance_1.bit
    MERGE_B_Qualcomm_2.bit
    LOSSLESS_A_HHI_3.bit
    PROF_A_Interdigital_3.bit
    WP_B_InterDigital_3.bit
    CodingToolsSets_C_Tencent_2.bit
    MERGE_J_Qualcomm_2.bit
    MERGE_C_Qualcomm_2.bit
    ISP_B_HHI_3.bit
    BDPCM_A_Orange_2.bit
    MTS_A_LGE_4.bit
    CCLM_A_KDDI_2.bit
    JCCR_D_HHI_3.bit
    LFNST_D_HHI_3.bit
    MVCOMP_A_Sharp_2.bit
    HLG_A_NHK_4.bit
    STILL444_A_KDDI_1.bit
    ENTMAINTIER_B_Sony_3.bit
    MERGE_D_Qualcomm_2.bit
    JCCR_F_Nokia_1.bit
    SLICES_A_HUAWEI_3.bit
    RAP_B_HHI_1.bit
    SPS_A_Bytedance_1.bit
    PPS_A_Bytedance_1.bit
    BUMP_A_LGE_2.bit
    TILE_E_Nokia_2.bit
    DEBLOCKING_A_Sharp_3.bit
    SAO_B_SAMSUNG_3.bit
    TRANS_D_Chipsnmedia_4.bit
    10b422_C_Sony_5.bit
    QUANT_D_Huawei_4.bit
    DPB_B_Sharplabs_2.bit
    LTRP_A_ERICSSON_3.bit
    ENT444HIGHTIER_D_Sony_3.bit
    QUANT_B_Huawei_2.bit
    8b422_C_Sony_5.bit
    PMERGE_D_MediaTek_1.bit
    CodingToolsSets_B_Tencent_2.bit
    ENTROPY_C_Qualcomm_1.bit
    GPM_B_Alibaba_1.bit
    CST_A_MediaTek_4.bit
    TILE_B_Nokia_2.bit
    TREE_B_HHI_3.bit
    TMVP_B_Chipsnmedia_3.bit
    CUBEMAP_C_MediaTek_3.bit
    8b420_B_Bytedance_2.bit
    PHSH_B_Sharp_1.bit
    CTU_A_MediaTek_4.bit
    DEBLOCKING_C_Huawei_3.bit
    SAO_C_SAMSUNG_3.bit
    ENTMAINTIER_A_Sony_3.bit
    JCCR_A_Nokia_2.bit
    PMERGE_C_MediaTek_1.bit
    ENT444MAINTIER_C_Sony_3.bit
    TEMPSCAL_A_Panasonic_4.bit
    MIP_B_HHI_3.bit
    PMERGE_B_MediaTek_1.bit
    GPM_A_Alibaba_3.bit
    QTBTT_A_MediaTek_4.bit
    QUANT_C_Huawei_2.bit
    MTS_B_LGE_4.bit
    SPS_C_Bytedance_1.bit
    10b422_E_Sony_5.bit
    SbTMVP_B_Bytedance_3.bit
    WPP_B_Sharp_2.bit
    MMVD_A_SAMSUNG_3.bit
    HLG_B_NHK_4.bit
    DEBLOCKING_F_Ericsson_2.bit
    ENTMAINTIER_D_Sony_3.bit
    ISP_A_HHI_3.bit
    TMVP_C_Chipsnmedia_3.bit
    APSLMCS_E_Dolby_1.bit
    PMERGE_E_MediaTek_1.bit
    BUMP_B_LGE_2.bit
    8b422_F_Sony_5.bit
    RAP_A_HHI_1.bit
    PPS_C_Bytedance_1.bit
    ENT444HIGHTIER_A_Sony_3.bit
    SUFAPS_A_HHI_1.bit
    TILE_G_Nokia_2.bit
    ENTHIGHTIER_C_Sony_3.bit
    ALF_D_Qualcomm_2.bit
    CodingToolsSets_A_Tencent_2.bit
    DQ_B_HHI_3.bit
    SPS_B_Bytedance_1.bit
    ALF_C_KDDI_3.bit
    SCALING_C_InterDigital_1.bit
    ACTPIC_C_Huawei_3.bit
    TILE_D_Nokia_2.bit
    LFNST_B_LGE_4.bit
    LMCS_A_Dolby_3.bit
    ENTHIGHTIER_D_Sony_3.bit
    CUBEMAP_B_MediaTek_3.bit
    8b422_A_Sony_5.bit
    MTS_LFNST_B_LGE_4.bit
    HRD_B_Fujitsu_2.bit
    SBT_A_HUAWEI_2.bit
    WPP_A_Sharp_3.bit
    10b422_B_Sony_5.bit
    PPS_B_Bytedance_1.bit
    ALF_A_Huawei_3.bit
    ENTMAINTIER_C_Sony_3.bit
    ENT444MAINTIER_A_Sony_3.bit
    CTU_B_MediaTek_4.bit
    JCCR_B_Nokia_2.bit
    CTU_C_MediaTek_4.bit
    AMVR_A_HHI_3.bit
    APSALF_A_Qualcomm_2.bit
    DEBLOCKING_E_Ericsson_3.bit
    STILL_A_KDDI_1.bit
    ENT444MAINTIER_D_Sony_3.bit
    PMERGE_A_MediaTek_1.bit
    HRD_A_Fujitsu_3.bit
    TREE_A_HHI_3.bit
    MRLP_A_HHI_2.bit
    TMVP_A_Chipsnmedia_3.bit
    POUT_A_Sharplabs_2.bit
    ACTPIC_B_Huawei_3.bit
    APSLMCS_C_Dolby_2.bit
    RPL_A_ERICSSON_2.bit
    8b400_A_Bytedance_2.bit
    AUD_A_Broadcom_3.bit
    CIIP_A_MediaTek_4.bit
    TILE_A_Nokia_2.bit
    ENTHIGHTIER_A_Sony_3.bit
    AFF_B_HUAWEI_2.bit
    CCALF_C_Sharp_3.bit
    BUMP_C_LGE_2.bit
    10b400_B_Bytedance_2.bit
    8b422_D_Sony_5.bit
    ENTROPY_A_Chipsnmedia_2.bit
    TMVP_D_Chipsnmedia_3.bit
    CUBEMAP_A_MediaTek_3.bit
    ENT444HIGHTIER_C_Sony_3.bit

total = 212, passed = 212, failed = 0, skipped = 0
----------
```

```
+++++++++ report +++++++++
passed files:
    12b444wpp_A_OPPO_1.bit
    12b444epp_A_Sharp_2.bit
    12b444errc_C_Qualcomm_2.bit
    12b400P16_B_Sony_2.bit
    12b444vvc1_A_Sony_2.bit
    12b444SPetsrc_C_Kwai_2.bit
    12b444SPerrc_A_Qualcomm_2.bit
    12b400P12_D_Sony_2.bit
    12b444SPetsrc_F_Kwai_2.bit
    12b400P12_A_Sony_2.bit
    12b444P16_C_Sony_2.bit
    12b444SPprrc_A_Qualcomm_2.bit
    10b444P12_E_Sony_2.bit
    12b420SPvvc1_A_KDDI_2.bit
    12b444SPvvc1_A_Alibaba_2.bit
    10b444P16_C_Sony_2.bit
    12b444errc_B_Qualcomm_2.bit
    12b420P12_E_Sony_2.bit
    12b444vvc1_D_Sony_2.bit
    12b444P16_A_Sony_2.bit
    12b420P16_D_Sony_2.bit
    12b422P16_E_Sony_2.bit
    12b422P12_C_Sony_2.bit
    12b444rlscp_A_OPPO_2.bit
    12b422P12_D_Sony_2.bit
    12b420P16_C_Sony_2.bit
    10b444P16_A_Sony_2.bit
    12b444prrc_A_Qualcomm_2.bit
    12b444SPetsrc_A_Kwai_2.bit
    12b444SPepp_A_Sharp_2.bit
    12b420P12_B_Sony_2.bit
    12b422P16_B_Sony_2.bit
    12b444SPetsrc_D_Kwai_2.bit
    12b444Irlscp_A_OPPO_2.bit
    12b422P12_A_Sony_2.bit
    10b444P12_B_Sony_2.bit
    12b420P16_A_Sony_2.bit
    10b444P16_D_Sony_2.bit
    12b444errc_A_Qualcomm_2.bit
    12b400P12_C_Sony_2.bit
    12b444SPetsrc_G_Kwai_2.bit
    12b444P16_D_Sony_2.bit
    12b444vvc1_C_Sony_2.bit
    12b444etsrc_A_Kwai_2.bit
    12b444Iprrc_A_Qualcomm_2.bit
    12b444SPrlscp_A_OPPO_2.bit
    12b420P16_B_Sony_2.bit
    12b420P12_D_Sony_2.bit
    10b444P12_A_Sony_2.bit
    12b422P16_D_Sony_2.bit
    12b400P16_E_Sony_2.bit
    12b422P12_B_Sony_2.bit
    12b444Ietsrc_A_Kwai_2.bit
    12b444P16_B_Sony_2.bit
    12b444Ierrc_A_Qualcomm_2.bit
    10b444P12_D_Sony_2.bit
    12b400P16_C_Sony_2.bit
    12b444SPetsrc_B_Kwai_2.bit
    12b420P12_A_Sony_2.bit
    12b422P16_A_Sony_2.bit
    12b420Ivvc1_A_InterDigital_2.bit
    HRD_A_Fujitsu_4.bit
    10b444P16_B_Sony_2.bit
    12b444SPetsrc_E_Kwai_2.bit
    12b444vvc1_E_Sony_2.bit
    12b400P12_B_Sony_2.bit
    12b400P12_E_Sony_2.bit
    12b444Ivvc1_A_Alibaba_2.bit
    12b400P16_D_Sony_2.bit
    12b444SPetsrc_H_Kwai_2.bit
    12b444Iwpp_A_OPPO_1.bit
    10b444P16_E_Sony_2.bit
    10b444P12_C_Sony_2.bit
    12b444Ierrc_B_Qualcomm_2.bit
    12b444vvc1_B_Sony_2.bit
    12b420vvc1_A_Alibaba_2.bit
    12b400P16_A_Sony_2.bit
    12b444P16_E_Sony_2.bit
    12b422P12_E_Sony_2.bit
    12b444Iepp_A_Sharp_2.bit
    12b420P12_C_Sony_2.bit
    12b420P16_E_Sony_2.bit
    12b422P16_C_Sony_2.bit

total = 83, passed = 83, failed = 0, skipped = 0
----------
```
```
[FFmpeg] tests/checkasm/checkasm --test=vvc_sao --benchmark
benchmarking with native FFmpeg timers
nop: 0.0
checkasm: using random seed 4055973423
NEON:   
 - vvc_sao.sao_band [OK]
 - vvc_sao.sao_edge [OK]
checkasm: all 18 tests passed
vvc_sao_band_8_8_c: 1.7
vvc_sao_band_8_8_neon: 0.0
vvc_sao_band_16_8_c: 7.7
vvc_sao_band_16_8_neon: 0.7
vvc_sao_band_32_8_c: 26.7
vvc_sao_band_32_8_neon: 2.7
vvc_sao_band_48_8_c: 55.0
vvc_sao_band_48_8_neon: 6.2
vvc_sao_band_64_8_c: 78.0
vvc_sao_band_64_8_neon: 10.7
vvc_sao_band_80_8_c: 114.7
vvc_sao_band_80_8_neon: 17.2
vvc_sao_band_96_8_c: 142.2
vvc_sao_band_96_8_neon: 25.0
vvc_sao_band_112_8_c: 196.0
vvc_sao_band_112_8_neon: 33.7
vvc_sao_band_128_8_c: 249.2
vvc_sao_band_128_8_neon: 44.2
vvc_sao_edge_8_8_c: 1.7
vvc_sao_edge_8_8_neon: 0.2
vvc_sao_edge_16_8_c: 6.5
vvc_sao_edge_16_8_neon: 0.5
vvc_sao_edge_32_8_c: 25.5
vvc_sao_edge_32_8_neon: 2.2
vvc_sao_edge_48_8_c: 57.0
vvc_sao_edge_48_8_neon: 5.0
vvc_sao_edge_64_8_c: 101.0
vvc_sao_edge_64_8_neon: 8.7
vvc_sao_edge_80_8_c: 163.0
vvc_sao_edge_80_8_neon: 13.5
vvc_sao_edge_96_8_c: 232.2
vvc_sao_edge_96_8_neon: 19.7
vvc_sao_edge_112_8_c: 312.0
vvc_sao_edge_112_8_neon: 26.5
vvc_sao_edge_128_8_c: 419.0
vvc_sao_edge_128_8_neon: 505.2
``` 

This last function seems to take longer than the C version. I don't know why, but I'm not exactly wiling to work more on this for now, I'd rather spend time on the x86 deblocker.

Benchmark on M1 Pro (6x Performance Cores, 2x Efficiency Cores)

| File | C | NEON | Delta |
|-----|--|-------|-------|
| Chimera_8bit_1080P_1000_frames.vvc | 154.0 | 155.3 | 0.84% |
| RitualDance_1920x1080_60_10_420_32_LD.266 | 91.7 | 106.0 | 14.46% |
| BQTerrace_1920x1080_60_10_420_22_RA.vvc | 55.0 | 53.0 | 3.7% |
| Tango2_3840x2160_60_10_420_27_LD.266 | 17.7 | 17.7 | 0.0% |
| RitualDance_1920x1080_60_10_420_37_RA.266 | 108.7 | 129.7 | 17.6% |
| NovosobornayaSquare_1920x1080.bin | 120.7 | 143.7 | 17.39% |

These numbers seem a little too good to be true, but I ran the benchmark again and I got roughly the same results.