### PR TITLE
inter: refact, use avg to simplify bi predict functions

### DIFF
--- a/libavcodec/vvc/vvc_inter.c
+++ b/libavcodec/vvc/vvc_inter.c
@@ -301,12 +301,12 @@ static void luma_bdof(VVCLocalContext *lc, uint8_t *dst, const ptrdiff_t dst_str
         int denom, w0, w1, o0, o1;
         fc->vvcdsp.inter.put[LUMA][!!my0][!!mx0](lc->tmp, src0, src0_stride,
             block_h, mx0, my0, block_w, hf_idx, vf_idx);
+        fc->vvcdsp.inter.put[LUMA][!!my1][!!mx1](lc->tmp1, src1, src1_stride,
+            block_h, mx1, my1, block_w, hf_idx, vf_idx);
         if (derive_weight(&denom, &w0, &w1, &o0, &o1, lc, mvf, LUMA, pu->dmvr_flag)) {
-            fc->vvcdsp.inter.put_bi_w[LUMA][!!my1][!!mx1](dst, dst_stride, src1, src1_stride, lc->tmp,
-                block_h, denom, w0, w1, o0, o1, mx1, my1, block_w, hf_idx, vf_idx);
+            fc->vvcdsp.inter.w_avg(dst, dst_stride, lc->tmp, lc->tmp1, block_w, block_h,
+                denom, w0, w1, o0, o1);
         } else {
-            fc->vvcdsp.inter.put[LUMA][!!my1][!!mx1](lc->tmp1, src1, src1_stride,
-                block_h, mx1, my1, block_w, hf_idx, vf_idx);
             fc->vvcdsp.inter.avg(dst, dst_stride, lc->tmp, lc->tmp1, block_w, block_h);
         }
     }
@@ -387,14 +387,14 @@ static void chroma_mc_bi(VVCLocalContext *lc, uint8_t *dst, const ptrdiff_t dst_
         EMULATED_EDGE_CHROMA(lc->edge_emu_buffer2, &src1, &src1_stride, x_off1, y_off1);
     }
 
-    fc->vvcdsp.inter.put[CHROMA][!!my0][!!mx0](lc->tmp, src0, src0_stride,
-                                                block_h, _mx0, _my0, block_w, hf_idx, vf_idx);
+    fc->vvcdsp.inter.put[CHROMA][!!my0][!!mx0](lc->tmp,  src0, src0_stride,
+        block_h, _mx0, _my0, block_w, hf_idx, vf_idx);
+    fc->vvcdsp.inter.put[CHROMA][!!my1][!!mx1](lc->tmp1, src1, src1_stride,
+        block_h, _mx1, _my1, block_w, hf_idx, vf_idx);
     if (derive_weight(&denom, &w0, &w1, &o0, &o1, lc, mvf, c_idx, dmvr_flag)) {
-        fc->vvcdsp.inter.put_bi_w[CHROMA][!!my1][!!mx1](dst, dst_stride, src1, src1_stride, lc->tmp,
-            block_h, denom, w0, w1, o0, o1, _mx1, _my1, block_w, hf_idx, vf_idx);
+        fc->vvcdsp.inter.w_avg(dst, dst_stride, lc->tmp, lc->tmp1,
+            block_w, block_h, denom, w0, w1, o0, o1);
     } else {
-        fc->vvcdsp.inter.put[CHROMA][!!my1][!!mx1](lc->tmp1, src1, src1_stride,
-                                                block_h, _mx1, _my1, block_w, hf_idx, vf_idx);
         fc->vvcdsp.inter.avg(dst, dst_stride, lc->tmp, lc->tmp1, block_w, block_h);
     }
 }
@@ -472,12 +472,12 @@ static void luma_prof_bi(VVCLocalContext *lc, uint8_t *dst, const ptrdiff_t dst_
         fc->vvcdsp.inter.apply_prof(lc->tmp, prof_tmp, pu->diff_mv_x[L0], pu->diff_mv_y[L0]);
     }
     if (!pu->cb_prof_flag[L1]) {
+        fc->vvcdsp.inter.put[LUMA][!!my1][!!mx1](lc->tmp1, src1, src1_stride,
+            block_h, mx1, my1, block_w, 2, 2);
         if (weight_flag) {
-            fc->vvcdsp.inter.put_bi_w[LUMA][!!my1][!!mx1](dst, dst_stride, src1, src1_stride, lc->tmp,
-                block_h, denom, w0, w1, o0, o1, mx1, my1, block_w, 2, 2);
+            fc->vvcdsp.inter.w_avg(dst, dst_stride, lc->tmp, lc->tmp1, block_w, block_h,
+                denom, w0, w1, o0, o1);
         } else {
-            fc->vvcdsp.inter.put[LUMA][!!my1][!!mx1](lc->tmp1, src1, src1_stride,
-                block_h, mx1, my1, block_w, 2, 2);
             fc->vvcdsp.inter.avg(dst, dst_stride, lc->tmp, lc->tmp1, block_w, block_h);
         }
     } else {

--- a/libavcodec/vvc/vvc_inter.c
+++ b/libavcodec/vvc/vvc_inter.c
@@ -305,8 +305,9 @@ static void luma_bdof(VVCLocalContext *lc, uint8_t *dst, const ptrdiff_t dst_str
             fc->vvcdsp.inter.put_bi_w[LUMA][!!my1][!!mx1](dst, dst_stride, src1, src1_stride, lc->tmp,
                 block_h, denom, w0, w1, o0, o1, mx1, my1, block_w, hf_idx, vf_idx);
         } else {
-            fc->vvcdsp.inter.put_bi[LUMA][!!my1][!!mx1](dst, dst_stride, src1, src1_stride, lc->tmp,
+            fc->vvcdsp.inter.put[LUMA][!!my1][!!mx1](lc->tmp1, src1, src1_stride,
                 block_h, mx1, my1, block_w, hf_idx, vf_idx);
+            fc->vvcdsp.inter.avg(dst, dst_stride, lc->tmp, lc->tmp1, block_w, block_h);
         }
     }
 }
@@ -392,8 +393,9 @@ static void chroma_mc_bi(VVCLocalContext *lc, uint8_t *dst, const ptrdiff_t dst_
         fc->vvcdsp.inter.put_bi_w[CHROMA][!!my1][!!mx1](dst, dst_stride, src1, src1_stride, lc->tmp,
             block_h, denom, w0, w1, o0, o1, _mx1, _my1, block_w, hf_idx, vf_idx);
     } else {
-        fc->vvcdsp.inter.put_bi[CHROMA][!!my1][!!mx1](dst, dst_stride, src1, src1_stride, lc->tmp,
-            block_h, _mx1, _my1, block_w, hf_idx, vf_idx);
+        fc->vvcdsp.inter.put[CHROMA][!!my1][!!mx1](lc->tmp1, src1, src1_stride,
+                                                block_h, _mx1, _my1, block_w, hf_idx, vf_idx);
+        fc->vvcdsp.inter.avg(dst, dst_stride, lc->tmp, lc->tmp1, block_w, block_h);
     }
 }
 
@@ -474,8 +476,9 @@ static void luma_prof_bi(VVCLocalContext *lc, uint8_t *dst, const ptrdiff_t dst_
             fc->vvcdsp.inter.put_bi_w[LUMA][!!my1][!!mx1](dst, dst_stride, src1, src1_stride, lc->tmp,
                 block_h, denom, w0, w1, o0, o1, mx1, my1, block_w, 2, 2);
         } else {
-            fc->vvcdsp.inter.put_bi[LUMA][!!my1][!!mx1](dst, dst_stride, src1, src1_stride, lc->tmp,
+            fc->vvcdsp.inter.put[LUMA][!!my1][!!mx1](lc->tmp1, src1, src1_stride,
                 block_h, mx1, my1, block_w, 2, 2);
+            fc->vvcdsp.inter.avg(dst, dst_stride, lc->tmp, lc->tmp1, block_w, block_h);
         }
     } else {
         fc->vvcdsp.inter.put[LUMA][!!my1][!!mx1](prof_tmp, src1, src1_stride, AFFINE_MIN_BLOCK_SIZE, mx1, my1, AFFINE_MIN_BLOCK_SIZE, 2, 2);

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -61,6 +61,10 @@ typedef struct VVCInterDSPContext {
     void (*avg)(uint8_t *dst, ptrdiff_t dst_stride,
         const int16_t *tmp0, const int16_t *tmp1, int width, int height);
 
+    void (*w_avg)(uint8_t *_dst, const ptrdiff_t _dst_stride,
+        const int16_t *tmp0, const int16_t *tmp1, int width, int height,
+        int denom, int w0, int w1, int o0, int o1);
+
     void (*put_bi[2 /* luma, chroma */][2 /* int, frac */][2 /* int, frac */])(
         uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride, const int16_t *src2,
         int height, intptr_t mx, intptr_t my, int width, int hf_idx, int vf_idx);

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -58,6 +58,9 @@ typedef struct VVCInterDSPContext {
         const uint8_t *src, ptrdiff_t src_stride, int height, int denom, int wx, int ox,
         intptr_t mx, intptr_t my, int width, int hf_idx, int vf_idx);
 
+    void (*avg)(uint8_t *dst, ptrdiff_t dst_stride,
+        const int16_t *tmp0, const int16_t *tmp1, int width, int height);
+
     void (*put_bi[2 /* luma, chroma */][2 /* int, frac */][2 /* int, frac */])(
         uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride, const int16_t *src2,
         int height, intptr_t mx, intptr_t my, int width, int hf_idx, int vf_idx);

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -65,14 +65,6 @@ typedef struct VVCInterDSPContext {
         const int16_t *tmp0, const int16_t *tmp1, int width, int height,
         int denom, int w0, int w1, int o0, int o1);
 
-    void (*put_bi[2 /* luma, chroma */][2 /* int, frac */][2 /* int, frac */])(
-        uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride, const int16_t *src2,
-        int height, intptr_t mx, intptr_t my, int width, int hf_idx, int vf_idx);
-    void (*put_bi_w[2 /* luma, chroma */][2 /* int, frac */][2 /* int, frac */])(
-        uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride, const int16_t *src2,
-        int height, int denom, int wx0, int wx1, int ox0, int ox1,
-        intptr_t mx, intptr_t my, int width, int hf_idx, int vf_idx);
-
     void (*put_ciip)(uint8_t *dst, ptrdiff_t dst_stride, int width, int height,
         const uint8_t *inter, ptrdiff_t inter_stride, int inter_weight);
 


### PR DESCRIPTION
3 benifites
1. we can use current put_luma asm code
2. it will reduce asm functions number.
3. we can totally reuse dav1d avg and w_avg code