### PR TITLE
avcodec/cbs_h266_syntax_template: Check num_output_layers_in_ols

### DIFF
--- a/libavcodec/cbs_h266_syntax_template.c
+++ b/libavcodec/cbs_h266_syntax_template.c
@@ -891,6 +891,8 @@ static int FUNC(vps) (CodedBitstreamContext *ctx, RWContext *rw,
                     }
                 }
             }
+            if (!num_output_layers_in_ols[i])
+                return AVERROR_INVALIDDATA;
         }
         for (i = 1; i < total_num_olss; i++) {
             int num_layers_in_ols = 0;


### PR DESCRIPTION
from the specification:
For each OLS, there shall be at least one layer that is an output layer. In other words, for any value of i in the range of 0 to TotalNumOlss − 1, inclusive, the value of NumOutputLayersInOls[ i ] shall be greater than or equal to 1

Fixes: index 257 out of bounds for type 'uint8_t [257]'
Fixes: 61160/clusterfuzz-testcase-minimized-ffmpeg_BSF_VVC_METADATA_fuzzer-6709397181825024

Found-by: continuous fuzzing process https://github.com/google/oss-fuzz/tree/master/projects/ffmpeg