### PR TITLE
Score based parse and inter

### DIFF
--- a/libavcodec/vvc/vvc_ctu.c
+++ b/libavcodec/vvc/vvc_ctu.c
@@ -2381,7 +2381,6 @@ int ff_vvc_coding_tree_unit(VVCLocalContext *lc,
     lc->cu     = NULL;
 
     ff_vvc_cabac_init(lc, ctu_idx, rx, ry);
-    fc->tab.slice_idx[rs] = lc->sc->slice_idx;
     ff_vvc_decode_neighbour(lc, x_ctb, y_ctb, rx, ry, rs);
     ret = hls_coding_tree_unit(lc, x_ctb, y_ctb, ctu_idx, rx, ry);
     if (ret < 0)

--- a/libavcodec/vvc/vvc_ctu.h
+++ b/libavcodec/vvc/vvc_ctu.h
@@ -352,7 +352,7 @@ typedef struct EntryPoint {
     VVCCabacState cabac_state[VVC_CONTEXTS];
     CABACContext cc;
 
-    VVCTask *parse_task;
+    int ctu_start;
     int ctu_end;
 
     uint8_t is_first_qg;                            // first quantization group

--- a/libavcodec/vvc/vvc_refs.h
+++ b/libavcodec/vvc/vvc_refs.h
@@ -52,7 +52,6 @@ struct VVCProgressListener {
 
 void ff_vvc_report_frame_finished(VVCFrame *frame);
 void ff_vvc_report_progress(VVCFrame *frame, VVCProgress vp, int y);
-int ff_vvc_check_progress(VVCFrame *frame, VVCProgress vp, int y);
 void ff_vvc_add_progress_listener(VVCFrame *frame, VVCProgressListener *l);
 
 #endif // AVCODEC_VVC_REFS_H

--- a/libavcodec/vvc/vvc_refs.h
+++ b/libavcodec/vvc/vvc_refs.h
@@ -40,8 +40,19 @@ typedef enum VVCProgress {
     VVC_PROGRESS_LAST,
 } VVCProgress;
 
+typedef struct VVCProgressListener VVCProgressListener;
+typedef void (*progress_done_fn)(VVCProgressListener *l);
+
+struct VVCProgressListener {
+    VVCProgress vp;
+    int y;
+    progress_done_fn progress_done;
+    VVCProgressListener *next;   //used by ff_vvc_add_progress_listener only
+};
+
 void ff_vvc_report_frame_finished(VVCFrame *frame);
 void ff_vvc_report_progress(VVCFrame *frame, VVCProgress vp, int y);
 int ff_vvc_check_progress(VVCFrame *frame, VVCProgress vp, int y);
+void ff_vvc_add_progress_listener(VVCFrame *frame, VVCProgressListener *l);
 
 #endif // AVCODEC_VVC_REFS_H

--- a/libavcodec/vvc/vvc_thread.h
+++ b/libavcodec/vvc/vvc_thread.h
@@ -25,16 +25,12 @@
 
 #include "vvcdec.h"
 
-struct VVCTask* ff_vvc_parse_task_alloc(VVCFrameContext *fc,
-    SliceContext *sc,  EntryPoint *ep, int ctu_addr);
-void ff_vvc_parse_task_free(VVCTask *t);
-
 struct AVExecutor* ff_vvc_executor_alloc(VVCContext *s, int thread_count);
 void ff_vvc_executor_free(struct AVExecutor **e);
 
 int ff_vvc_frame_thread_init(VVCFrameContext *fc);
 void ff_vvc_frame_thread_free(VVCFrameContext *fc);
-void ff_vvc_frame_add_task(VVCContext *s, struct VVCTask *t);
+void ff_vvc_frame_submit(VVCContext *s, VVCFrameContext *fc);
 int ff_vvc_frame_wait(VVCContext *s, VVCFrameContext *fc);
 
 #endif // AVCODEC_VVC_THREAD_H


### PR DESCRIPTION
Using this approach, we do not need to check neighbors' status. Every ready CTU will scheduled based on scores. 
"is_ready" or "is_priority_higher" callback is not needed anymore. 
We may use a lockless executor to reduce multi-thread overhead in the future