### PR TITLE
vvc_thread: report mv progress in parser if we do not have dmvr

### DIFF
--- a/libavcodec/vvc/vvc_ctu.h
+++ b/libavcodec/vvc/vvc_ctu.h
@@ -328,6 +328,7 @@ typedef struct CTU {
     CodingUnit *cus;
     int max_y[2][VVC_MAX_REF_ENTRIES];
     int max_y_idx[2];
+    int has_dmvr;
 } CTU;
 
 typedef struct ReconstructedArea {

--- a/libavcodec/vvc/vvc_inter.c
+++ b/libavcodec/vvc/vvc_inter.c
@@ -761,20 +761,6 @@ static void set_dmvr_info(VVCFrameContext *fc, const int x0, const int y0,
     }
 }
 
-static void fill_dmvr_info(const VVCFrameContext *fc, const int x0, const int y0,
-    const int width, const int height)
-{
-    const VVCPPS *pps = fc->ps.pps;
-    const int w = width >> MIN_PU_LOG2;
-
-    for (int y = y0 >> MIN_PU_LOG2; y < (y0 + height) >> MIN_PU_LOG2; y++) {
-        const int idx = pps->min_pu_width * y + (x0 >> MIN_PU_LOG2);
-        const MvField *mvf = fc->tab.mvf + idx;
-        MvField *dmvr_mvf  = fc->ref->tab_dmvr_mvf + idx;
-        memcpy(dmvr_mvf, mvf, sizeof(MvField) * w);
-    }
-}
-
 static void derive_sb_mv(VVCLocalContext *lc, MvField *mv, MvField *orig_mv, int *sb_bdof_flag,
     const int x0, const int y0, const int sbw, const int sbh)
 {
@@ -899,8 +885,6 @@ static void predict_inter(VVCLocalContext *lc)
     else
         pred_regular_blk(lc, 1);    //intra block is not ready yet, skip ciip
 
-    if (!pu->dmvr_flag)
-        fill_dmvr_info(fc, cu->x0, cu->y0, cu->cb_width, cu->cb_height);
     if (lc->sc->sh.r->sh_lmcs_used_flag && !cu->ciip_flag) {
         uint8_t* dst0 = POS(0, cu->x0, cu->y0);
         fc->vvcdsp.lmcs.filter(dst0, fc->frame->linesize[LUMA], cu->cb_width, cu->cb_height, fc->ps.lmcs.fwd_lut);


### PR DESCRIPTION
CLIP|Before|After|Delta|
--|--|--|--|
BQTerrace_1920x1080_60_10_420_22_RA.vvc|141.3|141.3|0.00%|
Chimera_8bit_1080P_1000_frames.vvc	        |287.7	|290.3	|0.90%|
NovosobornayaSquare_1920x1080.bin	        |263.7	|267.3	|1.37%|
RitualDance_1920x1080_60_10_420_32_LD.266	|253.7	|268.3	|5.75%|
RitualDance_1920x1080_60_10_420_37_RA.266	|261.3	|263.3	|0.77%|
Tango2_3840x2160_60_10_420_27_LD.266    	|59	    |60.3	|2.20%|