### PR TITLE
lavc/vvc: Fix MvField alignment

### DIFF
--- a/libavcodec/vvc/vvc_ctu.h
+++ b/libavcodec/vvc/vvc_ctu.h
@@ -193,7 +193,7 @@ typedef struct Mv {
 } Mv;
 
 typedef struct MvField {
-    DECLARE_ALIGNED(4, Mv, mv)[2];  ///< mvL0, vvL1
+    DECLARE_ALIGNED(8, Mv, mv)[2];  ///< mvL0, vvL1
     int8_t  ref_idx[2];             ///< refIdxL0, refIdxL1
     uint8_t hpel_if_idx;            ///< hpelIfIdx
     uint8_t bcw_idx;                ///< bcwIdx


### PR DESCRIPTION
`IS_SAME_MV` requires motion vectors to be aligned to a multiple of 8 bytes:
https://github.com/ffvvc/FFmpeg/blob/ae5efc8e4b4d3ea0ce673d0ee69e425487591d42/libavcodec/vvc/vvc_mvs.c#L28
This PR adds the same requirement to the definition of MvField.  It fixes errors with UB sanitizers.