### PR TITLE
lavc/vvc: Support rectangular single-slice subpics

### DIFF
--- a/libavcodec/cbs_h266_syntax_template.c
+++ b/libavcodec/cbs_h266_syntax_template.c
@@ -2118,6 +2118,8 @@ static int FUNC(pps) (CodedBitstreamContext *ctx, RWContext *rw,
             if (current->pps_no_pic_partition_flag)
                 infer(pps_num_slices_in_pic_minus1, 0);
             else if (current->pps_single_slice_per_subpic_flag)
+                for (i = 0; i <= sps->sps_num_subpics_minus1; i++)
+                    current->num_slices_in_subpic[i] = 1;
                 infer(pps_num_slices_in_pic_minus1,
                       sps->sps_num_subpics_minus1);
             // else?

--- a/libavcodec/vvc/vvc_ps.h
+++ b/libavcodec/vvc/vvc_ps.h
@@ -121,6 +121,8 @@ typedef struct VVCPPS {
     uint16_t *row_bd;
     uint16_t *ctb_to_col_bd;
     uint16_t *ctb_to_row_bd;
+    uint16_t *ctb_to_col_idx;
+    uint16_t *ctb_to_row_idx;
 
     uint16_t width32;                       ///< width  in 32 pixels
     uint16_t height32;                      ///< height in 32 pixels
@@ -128,7 +130,6 @@ typedef struct VVCPPS {
     uint16_t height64;                      ///< height in 64 pixels
 
     uint16_t ref_wraparound_offset;         ///< PpsRefWraparoundOffset
-
 } VVCPPS;
 
 #define MAX_WEIGHTS 15


### PR DESCRIPTION
This PR adds support for rectangular single-slice subpictures, as used by SUBPIC_C_ERICSSON_1 and SUBPIC_D_ERICSSON_1.  Before these changes, these bitstreams would crash with an out-of-bounds array access.  At the time of writing, the files now decode, but do not produce the expected output.  Intra frames appear to decode correctly, however inter frames do not.  Visually, the nature of these distortions are similar to those in LMCS_B_Dolby_2 — @nuomi2021 do you think perhaps there is some bug with inter prediction that we have not uncovered yet?  It seems very unlikely that the bug would only affect these bitstreams which were failing for other reasons though.