### PR TITLE
AVX2 implementation of DMVR SAD for VVC

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,91 @@
+name: test
+run-name: ${{ github.workflow }} - ${{ github.sha }}
+on:
+  push:
+    branches: [ main, up ]
+  pull_request:
+    branches: [ main, up ]
+  workflow_dispatch:
+
+
+jobs:
+  ffvvc-test:
+    name: ffvvc-test / ${{ matrix.os.name }}/${{ matrix.compiler.name }}/${{ matrix.assembler.name }}
+    env:
+      configure_flags: --enable-ffmpeg --disable-everything --enable-decoder=vvc --enable-parser=vvc --enable-demuxer=vvc --enable-protocol=file,pipe --enable-encoder=rawvideo,wrapped_avframe --enable-muxer=rawvideo,md5,null
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4 }
+          - { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
+        compiler:
+          - { name: gcc, flags: --cc=gcc }
+          - { name: clang, flags: --cc=clang }
+          - { name: msvc, flags: --toolchain=msvc }
+        assembler:
+          - { name: no asm, flags: --disable-asm }
+          - { name: yasm, flags: --as=yasm }
+          - { name: nasm, flags: --as=nasm }
+        exclude:
+          - os: { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4}
+            compiler: { name: msvc, flags: --toolchain=msvc }
+          - os: { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4 }
+            assembler: { name: yasm, flags: --as=yasm }
+          - os: { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4 }
+            assembler: { name: nasm, flags: --as=nasm }
+          - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
+            compiler: { name: gcc, flags: --cc=gcc }
+          - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
+            compiler: { name: clang, flags: --cc=clang }
+
+    runs-on: ${{ matrix.os.runner }}
+    defaults:
+      run:
+        shell: ${{ matrix.os.shell }}
+
+    steps:
+    - name: Get MSVC
+      if: ${{ matrix.compiler.name == 'msvc' && matrix.os.name == 'windows' }}
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Set up MSYS2
+      if: ${{ matrix.os.shell == 'msys2 {0}' }}
+      uses: msys2/setup-msys2@v2
+      with:
+        release: false
+        msystem: UCRT64
+        path-type: inherit
+        install: >-
+          make
+          diffutils
+
+    - name: Get assembler
+      if: ${{ matrix.os.shell == 'msys2 {0}' && matrix.assembler.name != 'no asm' }}
+      run: pacman --noconfirm -S ${{ matrix.assembler.name }}
+
+    - name: Get source
+      uses: actions/checkout@v3
+      with:
+        path: FFmpeg
+
+    - name: Configure
+      run: cd FFmpeg && ./configure ${{ matrix.compiler.flags }} ${{ matrix.assembler.flags }} ${{ env.configure_flags }} || (tail ffbuild/config.log; false)
+
+    - name: Build
+      run: cd FFmpeg && make -j8
+
+    - name: Get tests
+      uses: actions/checkout@v3
+      with:
+        repository: ffvvc/tests
+        path: tests
+
+    - name: Unit test
+      run: python3 tests/tools/ffmpeg.py --threads ${{ matrix.os.runner_threads }} --ffmpeg-path=./FFmpeg/ffmpeg tests/conformance/passed
+
+    - name: Check ASM
+      run: cd FFmpeg && make checkasm -j && ./tests/checkasm/checkasm
+
+    - name: Negative test
+      run: python3 tests/tools/ffmpeg.py --threads ${{ matrix.os.runner_threads }} --ffmpeg-path=./FFmpeg/ffmpeg tests/conformance/failed || true

--- a/libavcodec/vvc/vvc_ctu.c
+++ b/libavcodec/vvc/vvc_ctu.c
@@ -1081,6 +1081,11 @@ static PredMode pred_mode_decode(VVCLocalContext *lc,
             mode_type != MODE_TYPE_INTER || IS_I(rsh);
         pred_mode = pred_mode_flag ? MODE_INTRA : MODE_INTER;
     }
+
+    set_cb_tab(lc, fc->tab.cpm[cu->ch_type], pred_mode);
+    if (tree_type == SINGLE_TREE)
+        set_cb_tab(lc, fc->tab.cpm[CHROMA], pred_mode);
+
     return pred_mode;
 }
 
@@ -1227,7 +1232,6 @@ static void set_cu_tabs(const VVCLocalContext *lc, const CodingUnit *cu)
     const VVCFrameContext *fc   = lc->fc;
     const TransformUnit *tu     = cu->tus.head;
 
-    set_cb_tab(lc, fc->tab.cpm[cu->ch_type], cu->pred_mode);
     if (cu->tree_type != DUAL_TREE_CHROMA)
         set_cb_tab(lc, fc->tab.skip, cu->skip_flag);
 

--- a/libavcodec/vvc/vvc_ctu.c
+++ b/libavcodec/vvc/vvc_ctu.c
@@ -2362,6 +2362,8 @@ static void ctu_get_pred(VVCLocalContext *lc, const int rs)
     CTU *ctu                        = fc->tab.ctus + rs;
     const CodingUnit *cu            = ctu->cus;
 
+    ctu->has_dmvr = 0;
+
     if (IS_I(rsh))
         return;
 

--- a/libavcodec/vvc/vvc_ctu.c
+++ b/libavcodec/vvc/vvc_ctu.c
@@ -1229,9 +1229,12 @@ static CodingUnit* add_cu(VVCLocalContext *lc, const int x0, const int y0,
 
 static void set_cu_tabs(const VVCLocalContext *lc, const CodingUnit *cu)
 {
-    const VVCFrameContext *fc   = lc->fc;
-    const TransformUnit *tu     = cu->tus.head;
+    const VVCFrameContext *fc = lc->fc;
+    const PredictionUnit *pu  = &cu->pu;
+    const TransformUnit *tu   = cu->tus.head;
 
+    set_cb_tab(lc, fc->tab.mmi, pu->mi.motion_model_idc);
+    set_cb_tab(lc, fc->tab.msf, pu->merge_subblock_flag);
     if (cu->tree_type != DUAL_TREE_CHROMA)
         set_cb_tab(lc, fc->tab.skip, cu->skip_flag);
 
@@ -1320,7 +1323,6 @@ static void merge_data_subblock(VVCLocalContext *lc)
     PredictionUnit *pu          = &cu->pu;
     int merge_subblock_idx      = 0;
 
-    set_cb_tab(lc, fc->tab.msf, pu->merge_subblock_flag);
     if (ph->max_num_subblock_merge_cand > 1) {
         merge_subblock_idx = ff_vvc_merge_subblock_idx(lc, ph->max_num_subblock_merge_cand);
     }

--- a/libavcodec/vvc/vvc_filter.c
+++ b/libavcodec/vvc/vvc_filter.c
@@ -297,8 +297,8 @@ void ff_vvc_sao_filter(VVCLocalContext *lc, int x, int y)
     }
 }
 
-#define TAB_BS(t, x, y)       (t)[((y) >> 2) * (fc->tab.sz.bs_width) + ((x) >> 2)]
-#define TAB_MAX_LEN(t, x, y)  (t)[((y) >> 2) * (fc->tab.sz.bs_width) + ((x) >> 2)]
+#define TAB_BS(t, x, y)       (t)[((y) >> MIN_TU_LOG2) * (fc->ps.pps->min_tu_width) + ((x) >> MIN_TU_LOG2)]
+#define TAB_MAX_LEN(t, x, y)  (t)[((y) >> MIN_TU_LOG2) * (fc->ps.pps->min_tu_width) + ((x) >> MIN_TU_LOG2)]
 
 //8 samples a time
 #define DEBLOCK_STEP            8

--- a/libavcodec/vvc/vvc_inter.c
+++ b/libavcodec/vvc/vvc_inter.c
@@ -709,7 +709,7 @@ static void dmvr_mv_refine(VVCLocalContext *lc, MvField *mvf, MvField *orig_mv, 
         fc->vvcdsp.inter.dmvr[!!my][!!mx](tmp[i], src, src_stride, pred_h, mx, my, pred_w);
     }
 
-    min_sad = fc->vvcdsp.inter.sad(tmp[L0], tmp[L1], dx, dy, block_w, block_h);
+    min_sad = fc->vvcdsp.inter.sad[av_log2(block_w) - 2](tmp[L0], tmp[L1], dx, dy, block_w, block_h);
     min_sad -= min_sad >> 2;
     sad[dy][dx] = min_sad;
 
@@ -719,7 +719,7 @@ static void dmvr_mv_refine(VVCLocalContext *lc, MvField *mvf, MvField *orig_mv, 
         for (dy = 0; dy < SAD_ARRAY_SIZE; dy++) {
             for (dx = 0; dx < SAD_ARRAY_SIZE; dx++) {
                 if (dx != sr_range || dy != sr_range) {
-                    sad[dy][dx] = fc->vvcdsp.inter.sad(lc->tmp, lc->tmp1, dx, dy, block_w, block_h);
+                    sad[dy][dx] = fc->vvcdsp.inter.sad[av_log2(block_w) - 2](lc->tmp, lc->tmp1, dx, dy, block_w, block_h);
                     if (sad[dy][dx] < min_sad) {
                         min_sad = sad[dy][dx];
                         min_dx = dx;

--- a/libavcodec/vvc/vvc_inter_template.c
+++ b/libavcodec/vvc/vvc_inter_template.c
@@ -458,7 +458,12 @@ static void FUNC(ff_vvc_inter_dsp_init)(VVCInterDSPContext *const inter)
     inter->apply_prof_uni_w     = FUNC(apply_prof_uni_w);
     inter->apply_bdof           = FUNC(apply_bdof);
     inter->prof_grad_filter     = FUNC(prof_grad_filter);
-    inter->sad                  = vvc_sad;
+    inter->sad[0]                  = vvc_sad;
+    inter->sad[1]                  = vvc_sad;
+    inter->sad[2]                  = vvc_sad;
+    inter->sad[3]                  = vvc_sad;
+    inter->sad[4]                  = vvc_sad;
+    inter->sad[5]                  = vvc_sad;
 }
 
 #undef FUNCS

--- a/libavcodec/vvc/vvc_itx_1d.c
+++ b/libavcodec/vvc/vvc_itx_1d.c
@@ -66,6 +66,19 @@
 #define G8(m)  ((nz >  8) ? (m) : 0)
 #define G16(m) ((nz > 16) ? (m) : 0)
 
+//xxx_1 functions to make itx_2d and itx_1d happy
+void ff_vvc_inv_dct2_1(int *coeffs, const ptrdiff_t stride, const size_t nz)
+{
+}
+
+void ff_vvc_inv_dct8_1(int *coeffs, const ptrdiff_t stride, const size_t nz)
+{
+}
+
+void ff_vvc_inv_dst7_1(int *coeffs, const ptrdiff_t stride, const size_t nz)
+{
+}
+
 /*
 transmatrix[2][2] = {
     { a,  a },

--- a/libavcodec/vvc/vvc_itx_1d.h
+++ b/libavcodec/vvc/vvc_itx_1d.h
@@ -30,16 +30,19 @@
     void (name)(int *coeffs, ptrdiff_t stride, size_t nz)
 typedef vvc_itx_1d_fn(*vvc_itx_1d_fn);
 
+vvc_itx_1d_fn(ff_vvc_inv_dct2_1);
 vvc_itx_1d_fn(ff_vvc_inv_dct2_2);
 vvc_itx_1d_fn(ff_vvc_inv_dct2_4);
 vvc_itx_1d_fn(ff_vvc_inv_dct2_8);
 vvc_itx_1d_fn(ff_vvc_inv_dct2_16);
 vvc_itx_1d_fn(ff_vvc_inv_dct2_32);
 vvc_itx_1d_fn(ff_vvc_inv_dct2_64);
+vvc_itx_1d_fn(ff_vvc_inv_dst7_1);
 vvc_itx_1d_fn(ff_vvc_inv_dst7_4);
 vvc_itx_1d_fn(ff_vvc_inv_dst7_8);
 vvc_itx_1d_fn(ff_vvc_inv_dst7_16);
 vvc_itx_1d_fn(ff_vvc_inv_dst7_32);
+vvc_itx_1d_fn(ff_vvc_inv_dct8_1);
 vvc_itx_1d_fn(ff_vvc_inv_dct8_4);
 vvc_itx_1d_fn(ff_vvc_inv_dct8_8);
 vvc_itx_1d_fn(ff_vvc_inv_dct8_16);

--- a/libavcodec/vvc/vvc_mvs.c
+++ b/libavcodec/vvc/vvc_mvs.c
@@ -394,7 +394,6 @@ static void store_cp_mv(const VVCLocalContext *lc, const MotionInfo *mi, const i
             const int offset = (y_cb * min_cb_width + x_cb) * MAX_CONTROL_POINTS;
 
             memcpy(&fc->tab.cp_mv[lx][offset], mi->mv[lx], sizeof(Mv) * num_cp_mv);
-            SAMPLE_CTB(fc->tab.mmi, x_cb, y_cb) = mi->motion_model_idc;
         }
     }
 }

--- a/libavcodec/vvc/vvc_mvs.c
+++ b/libavcodec/vvc/vvc_mvs.c
@@ -606,7 +606,7 @@ static int check_available(Neighbour *n, const VVCLocalContext *lc, const int is
     if (!n->checked) {
         n->checked = 1;
         n->available = !sps->r->sps_entropy_coding_sync_enabled_flag || ((n->x >> sps->ctb_log2_size_y) <= (cu->x0 >> sps->ctb_log2_size_y));
-        n->available &= TAB_MVF(n->x, n->y).pred_flag != PF_INTRA;
+        n->available &= is_available(fc, n->x, n->y) && TAB_MVF(n->x, n->y).pred_flag != PF_INTRA;
         if (!is_mvp)
             n->available &= !is_same_mer(fc, n->x, n->y, cu->x0, cu->y0);
     }

--- a/libavcodec/vvc/vvc_mvs.c
+++ b/libavcodec/vvc/vvc_mvs.c
@@ -542,6 +542,16 @@ typedef struct NeighbourContext {
     const VVCLocalContext *lc;
 } NeighbourContext;
 
+static int is_available(const VVCFrameContext *fc, const int x0, const int y0)
+{
+    const VVCSPS *sps      = fc->ps.sps;
+    const int x            = x0 >> sps->min_cb_log2_size_y;
+    const int y            = y0 >> sps->min_cb_log2_size_y;
+    const int min_cb_width = fc->ps.pps->min_cb_width;
+
+    return SAMPLE_CTB(fc->tab.cb_width[0], x, y) != 0;
+}
+
 static int is_a0_available(const VVCLocalContext *lc, const CodingUnit *cu)
 {
     const VVCFrameContext *fc   = lc->fc;
@@ -552,15 +562,11 @@ static int is_a0_available(const VVCLocalContext *lc, const CodingUnit *cu)
     if (!x0b && !lc->ctb_left_flag) {
         cand_bottom_left = 0;
     } else {
-        const int log2_min_cb_size  = sps->min_cb_log2_size_y;
-        const int min_cb_width      = fc->ps.pps->min_cb_width;
-        const int x                 = (cu->x0 - 1) >> log2_min_cb_size;
-        const int y                 = (cu->y0 + cu->cb_height) >> log2_min_cb_size;
-        const int max_y             = FFMIN(fc->ps.pps->height, ((cu->y0 >> sps->ctb_log2_size_y) + 1) << sps->ctb_log2_size_y);
+        const int max_y = FFMIN(fc->ps.pps->height, ((cu->y0 >> sps->ctb_log2_size_y) + 1) << sps->ctb_log2_size_y);
         if (cu->y0 + cu->cb_height >= max_y)
             cand_bottom_left = 0;
         else
-            cand_bottom_left = SAMPLE_CTB(fc->tab.cb_width[0], x, y) != 0;
+            cand_bottom_left = is_available(fc, cu->x0 - 1, cu->y0 + cu->cb_height);
     }
     return cand_bottom_left;
 }

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -153,9 +153,7 @@ static void min_pu_tl_init(TabList *l, VVCFrameContext *fc)
 
     tl_init(l, 1, changed);
 
-    TL_ADD(msf, pic_size_in_min_pu);
     TL_ADD(iaf, pic_size_in_min_pu);
-    TL_ADD(mmi, pic_size_in_min_pu);
 }
 
 static void min_pu_nz_tl_init(TabList *l, VVCFrameContext *fc)
@@ -166,6 +164,8 @@ static void min_pu_nz_tl_init(TabList *l, VVCFrameContext *fc)
 
     tl_init(l, 0, changed);
 
+    TL_ADD(msf, pic_size_in_min_pu);
+    TL_ADD(mmi, pic_size_in_min_pu);
     TL_ADD(mvf, pic_size_in_min_pu);
 }
 

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -108,21 +108,6 @@ static void ctu_nz_tl_init(TabList *l, VVCFrameContext *fc)
     TL_ADD(coeffs,    ctu_count * ctu_size * VVC_MAX_SAMPLE_ARRAYS);
 }
 
-static void min_cb_tl_init(TabList *l, VVCFrameContext *fc)
-{
-    const VVCPPS *pps            = fc->ps.pps;
-    const int pic_size_in_min_cb = pps ? pps->min_cb_width * pps->min_cb_height : 0;
-    const int changed            = fc->tab.sz.pic_size_in_min_cb != pic_size_in_min_cb;
-
-    tl_init(l, 1, changed);
-
-    TL_ADD(imf,  pic_size_in_min_cb);
-    TL_ADD(imm,  pic_size_in_min_cb);
-
-    for (int i = LUMA; i <= CHROMA; i++)
-        TL_ADD(cb_width[i],  pic_size_in_min_cb);   //is_a0_available requires this
-}
-
 static void min_cb_nz_tl_init(TabList *l, VVCFrameContext *fc)
 {
     const VVCPPS *pps            = fc->ps.pps;
@@ -131,30 +116,23 @@ static void min_cb_nz_tl_init(TabList *l, VVCFrameContext *fc)
 
     tl_init(l, 0, changed);
 
-    TL_ADD(skip, pic_size_in_min_cb);
+    TL_ADD(imf,  pic_size_in_min_cb);
     TL_ADD(imtf, pic_size_in_min_cb);
+    TL_ADD(imm,  pic_size_in_min_cb);
+    TL_ADD(skip, pic_size_in_min_cb);
     TL_ADD(ipm,  pic_size_in_min_cb);
+    TL_ADD(iaf,  pic_size_in_min_cb);
 
     for (int i = LUMA; i <= CHROMA; i++) {
         TL_ADD(cqt_depth[i], pic_size_in_min_cb);
         TL_ADD(cb_pos_x[i],  pic_size_in_min_cb);
         TL_ADD(cb_pos_y[i],  pic_size_in_min_cb);
+        TL_ADD(cb_width[i],  pic_size_in_min_cb);
         TL_ADD(cb_height[i], pic_size_in_min_cb);
-        TL_ADD(cp_mv[i],     pic_size_in_min_cb * MAX_CONTROL_POINTS);
         TL_ADD(cpm[i],       pic_size_in_min_cb);
+        TL_ADD(cp_mv[i],     pic_size_in_min_cb * MAX_CONTROL_POINTS);
     }
     TL_ADD(qp[LUMA], pic_size_in_min_cb);
-}
-
-static void min_pu_tl_init(TabList *l, VVCFrameContext *fc)
-{
-    const VVCPPS *pps            = fc->ps.pps;
-    const int pic_size_in_min_pu = pps ? pps->min_pu_width * pps->min_pu_height : 0;
-    const int changed            = fc->tab.sz.pic_size_in_min_pu != pic_size_in_min_pu;
-
-    tl_init(l, 1, changed);
-
-    TL_ADD(iaf, pic_size_in_min_pu);
 }
 
 static void min_pu_nz_tl_init(TabList *l, VVCFrameContext *fc)
@@ -170,26 +148,6 @@ static void min_pu_nz_tl_init(TabList *l, VVCFrameContext *fc)
     TL_ADD(mvf, pic_size_in_min_pu);
 }
 
-static void min_tu_tl_init(TabList *l, VVCFrameContext *fc)
-{
-    const VVCPPS *pps            = fc->ps.pps;
-    const int pic_size_in_min_tu = pps ? pps->min_tu_width * pps->min_tu_height : 0;
-    const int changed            = fc->tab.sz.pic_size_in_min_tu != pic_size_in_min_tu;
-
-    tl_init(l, 1, changed);
-
-    TL_ADD(tu_joint_cbcr_residual_flag, pic_size_in_min_tu);
-
-    for (int i = LUMA; i <= CHROMA; i++)
-        TL_ADD(pcmf[i], pic_size_in_min_tu);
-
-    for (int i = 0; i < VVC_MAX_SAMPLE_ARRAYS; i++) {
-        TL_ADD(tu_coded_flag[i], pic_size_in_min_tu);
-        TL_ADD(horizontal_bs[i], pic_size_in_min_tu);
-        TL_ADD(vertical_bs[i],   pic_size_in_min_tu);
-    }
-}
-
 static void min_tu_nz_tl_init(TabList *l, VVCFrameContext *fc)
 {
     const VVCPPS *pps            = fc->ps.pps;
@@ -198,20 +156,25 @@ static void min_tu_nz_tl_init(TabList *l, VVCFrameContext *fc)
 
     tl_init(l, 0, changed);
 
-    for (int i = LUMA; i <= CHROMA; i++) {
-        TL_ADD(tb_pos_x0[i], pic_size_in_min_tu);
-        TL_ADD(tb_pos_y0[i], pic_size_in_min_tu);
-        TL_ADD(tb_width[i],  pic_size_in_min_tu);
-        TL_ADD(tb_height[i], pic_size_in_min_tu);
+    TL_ADD(tu_joint_cbcr_residual_flag, pic_size_in_min_tu);
+    for (int i = LUMA; i < VVC_MAX_SAMPLE_ARRAYS; i++) {
+        TL_ADD(tu_coded_flag[i], pic_size_in_min_tu);
+        if (i <= CHROMA) {
+            TL_ADD(tb_pos_x0[i], pic_size_in_min_tu);
+            TL_ADD(tb_pos_y0[i], pic_size_in_min_tu);
+            TL_ADD(tb_width[i],  pic_size_in_min_tu);
+            TL_ADD(tb_height[i], pic_size_in_min_tu);
+            TL_ADD(pcmf[i], pic_size_in_min_tu);
+        }
+        if (i != LUMA)
+            TL_ADD(qp[i], pic_size_in_min_tu);
+        TL_ADD(horizontal_bs[i], pic_size_in_min_tu);
+        TL_ADD(vertical_bs[i],   pic_size_in_min_tu);
     }
-
     TL_ADD(horizontal_q, pic_size_in_min_tu);
     TL_ADD(horizontal_p, pic_size_in_min_tu);
     TL_ADD(vertical_p,   pic_size_in_min_tu);
     TL_ADD(vertical_q,   pic_size_in_min_tu);
-
-    for (int i = CB; i < VVC_MAX_SAMPLE_ARRAYS; i++)
-        TL_ADD(qp[i], pic_size_in_min_tu);
 }
 
 static void pixel_buffer_nz_tl_init(TabList *l, VVCFrameContext *fc)
@@ -282,11 +245,8 @@ static int frame_context_for_each_tl(VVCFrameContext *fc, int (*unary_fn)(TabLis
 {
     const tl_init_fn init[] = {
         ctu_nz_tl_init,
-        min_cb_tl_init,
         min_cb_nz_tl_init,
-        min_pu_tl_init,
         min_pu_nz_tl_init,
-        min_tu_tl_init,
         min_tu_nz_tl_init,
         pixel_buffer_nz_tl_init,
         msm_tl_init,

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -176,28 +176,13 @@ static void min_tu_tl_init(TabList *l, VVCFrameContext *fc)
     for (int i = 0; i < VVC_MAX_SAMPLE_ARRAYS; i++) {
         TL_ADD(tu_coded_flag[i], pic_size_in_min_tu);
         TL_ADD(qp[i],            pic_size_in_min_tu);
+        TL_ADD(horizontal_bs[i], pic_size_in_min_tu);
+        TL_ADD(vertical_bs[i],   pic_size_in_min_tu);
     }
-}
-
-static void bs_tl_init(TabList *l, VVCFrameContext *fc)
-{
-    const VVCPPS *pps   = fc->ps.pps;
-    const int bs_width  = pps ? (pps->width >>  2) + 1 : 0;
-    const int bs_height = pps ? (pps->height >> 2) + 1 : 0;
-    const int bs_count  = bs_width * bs_height;
-    const int changed   = fc->tab.sz.bs_width != bs_width ||
-        fc->tab.sz.bs_height != bs_height;
-
-    tl_init(l, 1, changed);
-
-    for (int i = 0; i < VVC_MAX_SAMPLE_ARRAYS; i++) {
-        TL_ADD(horizontal_bs[i], bs_count);
-        TL_ADD(vertical_bs[i],   bs_count);
-    }
-    TL_ADD(horizontal_q, bs_count);
-    TL_ADD(horizontal_p, bs_count);
-    TL_ADD(vertical_p,   bs_count);
-    TL_ADD(vertical_q,   bs_count);
+    TL_ADD(horizontal_q, pic_size_in_min_tu);
+    TL_ADD(horizontal_p, pic_size_in_min_tu);
+    TL_ADD(vertical_p,   pic_size_in_min_tu);
+    TL_ADD(vertical_q,   pic_size_in_min_tu);
 }
 
 static void pixel_buffer_nz_tl_init(TabList *l, VVCFrameContext *fc)
@@ -272,7 +257,6 @@ static int frame_context_for_each_tl(VVCFrameContext *fc, int (*unary_fn)(TabLis
         min_cb_tl_init,
         min_pu_tl_init,
         min_tu_tl_init,
-        bs_tl_init,
         pixel_buffer_nz_tl_init,
         msm_tl_init,
         ispmf_tl_init,
@@ -350,8 +334,6 @@ static int pic_arrays_init(VVCContext *s, VVCFrameContext *fc)
     fc->tab.sz.ctu_height         = pps->ctb_height;
     fc->tab.sz.chroma_format_idc  = sps->r->sps_chroma_format_idc;
     fc->tab.sz.pixel_shift        = sps->pixel_shift;
-    fc->tab.sz.bs_width           = (fc->ps.pps->width >> 2) + 1;
-    fc->tab.sz.bs_height          = (fc->ps.pps->height >> 2) + 1;
 
     return 0;
 }

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -119,10 +119,8 @@ static void min_cb_tl_init(TabList *l, VVCFrameContext *fc)
     TL_ADD(imf,  pic_size_in_min_cb);
     TL_ADD(imm,  pic_size_in_min_cb);
 
-    for (int i = LUMA; i <= CHROMA; i++) {
+    for (int i = LUMA; i <= CHROMA; i++)
         TL_ADD(cb_width[i],  pic_size_in_min_cb);   //is_a0_available requires this
-        TL_ADD(cpm[i],       pic_size_in_min_cb);
-    };
 }
 
 static void min_cb_nz_tl_init(TabList *l, VVCFrameContext *fc)
@@ -143,6 +141,7 @@ static void min_cb_nz_tl_init(TabList *l, VVCFrameContext *fc)
         TL_ADD(cb_pos_y[i],  pic_size_in_min_cb);
         TL_ADD(cb_height[i], pic_size_in_min_cb);
         TL_ADD(cp_mv[i],     pic_size_in_min_cb * MAX_CONTROL_POINTS);
+        TL_ADD(cpm[i],       pic_size_in_min_cb);
     }
 }
 

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -98,9 +98,6 @@ static void ctu_tl_init(TabList *l, VVCFrameContext *fc)
 
     tl_init(l, 1, changed);
 
-    TL_ADD(deblock, ctu_count);
-    TL_ADD(sao,     ctu_count);
-    TL_ADD(alf,     ctu_count);
     TL_ADD(ctus,    ctu_count);
 }
 
@@ -113,6 +110,10 @@ static void ctu_nz_tl_init(TabList *l, VVCFrameContext *fc)
     const int changed   = fc->tab.sz.ctu_count != ctu_count || fc->tab.sz.ctu_size != ctu_size;
 
     tl_init(l, 0, changed);
+
+    TL_ADD(deblock, ctu_count);
+    TL_ADD(sao,     ctu_count);
+    TL_ADD(alf,     ctu_count);
     TL_ADD(slice_idx, ctu_count);
     TL_ADD(coeffs,    ctu_count * ctu_size * VVC_MAX_SAMPLE_ARRAYS);
 }
@@ -125,21 +126,34 @@ static void min_cb_tl_init(TabList *l, VVCFrameContext *fc)
 
     tl_init(l, 1, changed);
 
-    TL_ADD(skip, pic_size_in_min_cb);
     TL_ADD(imf,  pic_size_in_min_cb);
-    TL_ADD(imtf, pic_size_in_min_cb);
     TL_ADD(imm,  pic_size_in_min_cb);
+
+    for (int i = LUMA; i <= CHROMA; i++) {
+        TL_ADD(cb_width[i],  pic_size_in_min_cb);   //is_a0_available requires this
+        TL_ADD(cpm[i],       pic_size_in_min_cb);
+    };
+}
+
+static void min_cb_nz_tl_init(TabList *l, VVCFrameContext *fc)
+{
+    const VVCPPS *pps            = fc->ps.pps;
+    const int pic_size_in_min_cb = pps ? pps->min_cb_width * pps->min_cb_height : 0;
+    const int changed            = fc->tab.sz.pic_size_in_min_cb != pic_size_in_min_cb;
+
+    tl_init(l, 0, changed);
+
+    TL_ADD(skip, pic_size_in_min_cb);
+    TL_ADD(imtf, pic_size_in_min_cb);
     TL_ADD(ipm,  pic_size_in_min_cb);
 
     for (int i = LUMA; i <= CHROMA; i++) {
+        TL_ADD(cqt_depth[i], pic_size_in_min_cb);
         TL_ADD(cb_pos_x[i],  pic_size_in_min_cb);
         TL_ADD(cb_pos_y[i],  pic_size_in_min_cb);
-        TL_ADD(cb_width[i],  pic_size_in_min_cb);
         TL_ADD(cb_height[i], pic_size_in_min_cb);
-        TL_ADD(cqt_depth[i], pic_size_in_min_cb);
-        TL_ADD(cpm[i],       pic_size_in_min_cb);
         TL_ADD(cp_mv[i],     pic_size_in_min_cb * MAX_CONTROL_POINTS);
-    };
+    }
 }
 
 static void min_pu_tl_init(TabList *l, VVCFrameContext *fc)
@@ -165,13 +179,9 @@ static void min_tu_tl_init(TabList *l, VVCFrameContext *fc)
     tl_init(l, 1, changed);
 
     TL_ADD(tu_joint_cbcr_residual_flag, pic_size_in_min_tu);
-    for (int i = LUMA; i <= CHROMA; i++) {
-        TL_ADD(tb_pos_x0[i], pic_size_in_min_tu);
-        TL_ADD(tb_pos_y0[i], pic_size_in_min_tu);
-        TL_ADD(tb_width[i],  pic_size_in_min_tu);
-        TL_ADD(tb_height[i], pic_size_in_min_tu);
-        TL_ADD(pcmf[i],      pic_size_in_min_tu);
-    }
+
+    for (int i = LUMA; i <= CHROMA; i++)
+        TL_ADD(pcmf[i], pic_size_in_min_tu);
 
     for (int i = 0; i < VVC_MAX_SAMPLE_ARRAYS; i++) {
         TL_ADD(tu_coded_flag[i], pic_size_in_min_tu);
@@ -179,6 +189,23 @@ static void min_tu_tl_init(TabList *l, VVCFrameContext *fc)
         TL_ADD(horizontal_bs[i], pic_size_in_min_tu);
         TL_ADD(vertical_bs[i],   pic_size_in_min_tu);
     }
+}
+
+static void min_tu_nz_tl_init(TabList *l, VVCFrameContext *fc)
+{
+    const VVCPPS *pps            = fc->ps.pps;
+    const int pic_size_in_min_tu = pps ? pps->min_tu_width * pps->min_tu_height : 0;
+    const int changed            = fc->tab.sz.pic_size_in_min_tu != pic_size_in_min_tu;
+
+    tl_init(l, 0, changed);
+
+    for (int i = LUMA; i <= CHROMA; i++) {
+        TL_ADD(tb_pos_x0[i], pic_size_in_min_tu);
+        TL_ADD(tb_pos_y0[i], pic_size_in_min_tu);
+        TL_ADD(tb_width[i],  pic_size_in_min_tu);
+        TL_ADD(tb_height[i], pic_size_in_min_tu);
+    }
+
     TL_ADD(horizontal_q, pic_size_in_min_tu);
     TL_ADD(horizontal_p, pic_size_in_min_tu);
     TL_ADD(vertical_p,   pic_size_in_min_tu);
@@ -255,8 +282,10 @@ static int frame_context_for_each_tl(VVCFrameContext *fc, int (*unary_fn)(TabLis
         ctu_tl_init,
         ctu_nz_tl_init,
         min_cb_tl_init,
+        min_cb_nz_tl_init,
         min_pu_tl_init,
         min_tu_tl_init,
+        min_tu_nz_tl_init,
         pixel_buffer_nz_tl_init,
         msm_tl_init,
         ispmf_tl_init,

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -143,6 +143,7 @@ static void min_cb_nz_tl_init(TabList *l, VVCFrameContext *fc)
         TL_ADD(cp_mv[i],     pic_size_in_min_cb * MAX_CONTROL_POINTS);
         TL_ADD(cpm[i],       pic_size_in_min_cb);
     }
+    TL_ADD(qp[LUMA], pic_size_in_min_cb);
 }
 
 static void min_pu_tl_init(TabList *l, VVCFrameContext *fc)
@@ -184,7 +185,6 @@ static void min_tu_tl_init(TabList *l, VVCFrameContext *fc)
 
     for (int i = 0; i < VVC_MAX_SAMPLE_ARRAYS; i++) {
         TL_ADD(tu_coded_flag[i], pic_size_in_min_tu);
-        TL_ADD(qp[i],            pic_size_in_min_tu);
         TL_ADD(horizontal_bs[i], pic_size_in_min_tu);
         TL_ADD(vertical_bs[i],   pic_size_in_min_tu);
     }
@@ -209,6 +209,9 @@ static void min_tu_nz_tl_init(TabList *l, VVCFrameContext *fc)
     TL_ADD(horizontal_p, pic_size_in_min_tu);
     TL_ADD(vertical_p,   pic_size_in_min_tu);
     TL_ADD(vertical_q,   pic_size_in_min_tu);
+
+    for (int i = CB; i < VVC_MAX_SAMPLE_ARRAYS; i++)
+        TL_ADD(qp[i], pic_size_in_min_tu);
 }
 
 static void pixel_buffer_nz_tl_init(TabList *l, VVCFrameContext *fc)

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -157,6 +157,16 @@ static void min_pu_tl_init(TabList *l, VVCFrameContext *fc)
     TL_ADD(msf, pic_size_in_min_pu);
     TL_ADD(iaf, pic_size_in_min_pu);
     TL_ADD(mmi, pic_size_in_min_pu);
+}
+
+static void min_pu_nz_tl_init(TabList *l, VVCFrameContext *fc)
+{
+    const VVCPPS *pps            = fc->ps.pps;
+    const int pic_size_in_min_pu = pps ? pps->min_pu_width * pps->min_pu_height : 0;
+    const int changed            = fc->tab.sz.pic_size_in_min_pu != pic_size_in_min_pu;
+
+    tl_init(l, 0, changed);
+
     TL_ADD(mvf, pic_size_in_min_pu);
 }
 
@@ -273,6 +283,7 @@ static int frame_context_for_each_tl(VVCFrameContext *fc, int (*unary_fn)(TabLis
         min_cb_tl_init,
         min_cb_nz_tl_init,
         min_pu_tl_init,
+        min_pu_nz_tl_init,
         min_tu_tl_init,
         min_tu_nz_tl_init,
         pixel_buffer_nz_tl_init,

--- a/libavcodec/vvc/vvcdec.c
+++ b/libavcodec/vvc/vvcdec.c
@@ -90,17 +90,6 @@ static int tl_create(TabList *l)
     return 0;
 }
 
-static void ctu_tl_init(TabList *l, VVCFrameContext *fc)
-{
-    const VVCPPS *pps   = fc->ps.pps;
-    const int ctu_count = pps ? pps->ctb_count : 0;
-    const int changed   = fc->tab.sz.ctu_count != ctu_count;
-
-    tl_init(l, 1, changed);
-
-    TL_ADD(ctus,    ctu_count);
-}
-
 static void ctu_nz_tl_init(TabList *l, VVCFrameContext *fc)
 {
     const VVCSPS *sps   = fc->ps.sps;
@@ -111,6 +100,7 @@ static void ctu_nz_tl_init(TabList *l, VVCFrameContext *fc)
 
     tl_init(l, 0, changed);
 
+    TL_ADD(ctus,    ctu_count);
     TL_ADD(deblock, ctu_count);
     TL_ADD(sao,     ctu_count);
     TL_ADD(alf,     ctu_count);
@@ -279,7 +269,6 @@ typedef void (*tl_init_fn)(TabList *l, VVCFrameContext *fc);
 static int frame_context_for_each_tl(VVCFrameContext *fc, int (*unary_fn)(TabList *l))
 {
     const tl_init_fn init[] = {
-        ctu_tl_init,
         ctu_nz_tl_init,
         min_cb_tl_init,
         min_cb_nz_tl_init,

--- a/libavcodec/vvc/vvcdec.h
+++ b/libavcodec/vvc/vvcdec.h
@@ -183,8 +183,6 @@ typedef struct VVCFrameContext {
             int height;
             int chroma_format_idc;
             int pixel_shift;
-            int bs_width;
-            int bs_height;
         } sz;
     } tab;
 } VVCFrameContext;

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -35,6 +35,7 @@ enum TxType {
 };
 
 enum TxSize {
+    TX_SIZE_1,
     TX_SIZE_2,
     TX_SIZE_4,
     TX_SIZE_8,
@@ -114,7 +115,8 @@ typedef struct VVCItxDSPContext {
     void (*add_residual_joint)(uint8_t *dst, const int *res, int width, int height, ptrdiff_t stride, int c_sign, int shift);
     void (*pred_residual_joint)(int *buf, int width, int height, int c_sign, int shift);
 
-    void (*itx[N_TX_TYPE][N_TX_SIZE])(int *coeffs, ptrdiff_t step, size_t nz);
+    void (*itx[N_TX_TYPE /* trh */][N_TX_TYPE /* trv */][N_TX_SIZE /* log2(w) */][N_TX_SIZE /* log2(h) */])(int *coeffs,
+        size_t nzw, size_t nzh, intptr_t log2_transform_range, intptr_t bit_depth);
     void (*transform_bdpcm)(int *coeffs, int width, int height, int vertical, int log2_transform_range);
 } VVCItxDSPContext;
 

--- a/libavcodec/vvc/vvcdsp.h
+++ b/libavcodec/vvc/vvcdsp.h
@@ -87,7 +87,8 @@ typedef struct VVCInterDSPContext {
 
     void (*apply_bdof)(uint8_t *dst, ptrdiff_t dst_stride, int16_t *src0, int16_t *src1, int block_w, int block_h);
 
-    int (*sad)(const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+    int (*sad[6])(const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+
     void (*dmvr[2][2])(int16_t *dst, const uint8_t *src, ptrdiff_t src_stride, int height,
         intptr_t mx, intptr_t my, int width);
 } VVCInterDSPContext;

--- a/libavcodec/x86/Makefile
+++ b/libavcodec/x86/Makefile
@@ -79,6 +79,7 @@ OBJS-$(CONFIG_VP9_DECODER)             += x86/vp9dsp_init.o            \
                                           x86/vp9dsp_init_12bpp.o      \
                                           x86/vp9dsp_init_16bpp.o
 OBJS-$(CONFIG_WEBP_DECODER)            += x86/vp8dsp_init.o
+include $(SRC_PATH)/libavcodec/x86/vvc/Makefile
 
 
 # GCC inline assembly optimizations

--- a/libavcodec/x86/vvc/Makefile
+++ b/libavcodec/x86/vvc/Makefile
@@ -4,4 +4,7 @@ clean::
 OBJS-$(CONFIG_VVC_DECODER)             += x86/vvc/vvcdsp_init.o \
                                           x86/h26x/h2656dsp.o
 X86ASM-OBJS-$(CONFIG_VVC_DECODER)      += x86/vvc/vvc_mc.o       \
-                                          x86/h26x/h2656_inter.o
+                                          x86/h26x/h2656_inter.o \
+                                          x86/vvc/vvc_alf.o      \
+                                          x86/vvc/vvc_sao.o      \
+                                          x86/vvc/vvc_sao_10bit.o\

--- a/libavcodec/x86/vvc/Makefile
+++ b/libavcodec/x86/vvc/Makefile
@@ -8,3 +8,4 @@ X86ASM-OBJS-$(CONFIG_VVC_DECODER)      += x86/vvc/vvc_mc.o       \
                                           x86/vvc/vvc_alf.o      \
                                           x86/vvc/vvc_sao.o      \
                                           x86/vvc/vvc_sao_10bit.o\
+                                          x86/vvc/vvc_sad.o      \

--- a/libavcodec/x86/vvc/vvc_alf.asm
+++ b/libavcodec/x86/vvc/vvc_alf.asm
@@ -1,0 +1,797 @@
+;******************************************************************************
+;* VVC Adaptive Loop Filter SIMD optimizations
+;*
+;* Copyright (c) 2023 Nuo Mi <nuomi2021@gmail.com>
+;*
+;* This file is part of FFmpeg.
+;*
+;* FFmpeg is free software; you can redistribute it and/or
+;* modify it under the terms of the GNU Lesser General Public
+;* License as published by the Free Software Foundation; either
+;* version 2.1 of the License, or (at your option) any later version.
+;*
+;* FFmpeg is distributed in the hope that it will be useful,
+;* but WITHOUT ANY WARRANTY; without even the implied warranty of
+;* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;* Lesser General Public License for more details.
+;*
+;* You should have received a copy of the GNU Lesser General Public
+;* License along with FFmpeg; if not, write to the Free Software
+;* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+;******************************************************************************
+
+%include "libavutil/x86/x86util.asm"
+
+SECTION_RODATA
+
+%macro PARAM_SHUFFE 1
+%assign i (%1  * 2)
+%assign j ((i + 1) << 8) + (i)
+param_shuffe_ %+ %1:
+%rep 2
+    times 4 dw j
+    times 4 dw (j + 0x0808)
+%endrep
+%endmacro
+
+PARAM_SHUFFE 0
+PARAM_SHUFFE 1
+PARAM_SHUFFE 2
+PARAM_SHUFFE 3
+
+CLASSIFY_SHUFFE: times 2    db 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13
+TRANSPOSE_PERMUTE:          dd 0, 1, 4, 5, 2, 3, 6, 7
+ARG_VAR_SHUFFE: times 2     db 0, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4
+
+dd448: times 8             dd 512 - 64
+dw64: times 8              dd 64
+dd2:  times 8              dd 2
+dw3:  times 8              dd 3
+dw5:  times 8              dd 5
+dd15: times 8              dd 15
+
+SECTION .text
+
+
+%define ALF_NUM_COEFF_LUMA      12
+%define ALF_NUM_COEFF_CHROMA     6
+%define ALF_NUM_COEFF_CC         7
+
+%if HAVE_AVX2_EXTERNAL
+
+;%1-%3 out
+;%4 clip or filter
+%macro LOAD_LUMA_PARAMS_W16 4
+    lea             offsetq, [3 * xq]                   ;xq * ALF_NUM_COEFF_LUMA / ALF_BLOCK_SIZE
+    movu            m%1, [%4q + 2 * offsetq + 0 * 32]   ; 2 * for sizeof(int16_t)
+    movu            m%2, [%4q + 2 * offsetq + 1 * 32]
+    movu            m%3, [%4q + 2 * offsetq + 2 * 32]
+%endmacro
+
+%macro LOAD_LUMA_PARAMS_W16 6
+    LOAD_LUMA_PARAMS_W16    %1, %2, %3, %4
+    ;m%1 = 03 02 01 00
+    ;m%2 = 07 06 05 04
+    ;m%3 = 11 10 09 08
+
+    vshufpd                 m%5, m%1, m%2, 0011b        ;06 02 05 01
+    vshufpd                 m%6, m%3, m%5, 1001b        ;06 10 01 09
+
+    vshufpd                 m%1, m%1, m%6, 1100b        ;06 03 09 00
+    vshufpd                 m%2, m%2, m%6, 0110b        ;10 07 01 04
+    vshufpd                 m%3, m%3, m%5, 0110b        ;02 11 05 08
+
+    vpermpd                 m%1, m%1, 01111000b         ;09 06 03 00
+    vshufpd                 m%2, m%2, m%2, 1001b        ;10 07 04 01
+    vpermpd                 m%3, m%3, 10000111b         ;11 08 05 02
+%endmacro
+
+;%1-%3 out
+;%4 clip or filter
+;%5, %6 tmp
+%macro LOAD_LUMA_PARAMS 6
+    LOAD_LUMA_PARAMS_W16 %1, %2, %3, %4, %5, %6
+%endmacro
+
+%macro LOAD_CHROMA_PARAMS 4
+    ;LOAD_CHROMA_PARAMS_W %+ WIDTH %1, %2, %3, %4
+    movq            xm%1, [%3q]
+    movd            xm%2, [%3q + 8]
+    vpbroadcastq    m%1, xm%1
+    vpbroadcastq    m%2, xm%2
+%endmacro
+
+%macro LOAD_PARAMS 0
+    %if LUMA
+        LOAD_LUMA_PARAMS     3, 4, 5, filter, 6, 7
+        LOAD_LUMA_PARAMS     6, 7, 8, clip,   9, 10
+    %else
+        LOAD_CHROMA_PARAMS   3, 4, filter, 5
+        LOAD_CHROMA_PARAMS   6, 7, clip, 8
+    %endif
+%endmacro
+
+;FILTER(param_idx)
+;input: m2, m9, m10
+;output: m0, m1
+;m11 ~ m13: tmp
+%macro FILTER 1
+    %assign i (%1 % 4)
+    %assign j (%1 / 4 + 3)
+    %assign k (%1 / 4 + 6)
+    %define filters m %+ j
+    %define clips m %+ k
+
+    pshufb          m12, clips, [param_shuffe_ %+ i]        ;clip
+    pxor            m11, m11
+    psubw           m11, m12                                ;-clip
+
+    vpsubw          m9, m2
+    CLIPW           m9, m11, m12
+
+    vpsubw          m10, m2
+    CLIPW           m10, m11, m12
+
+    vpunpckhwd      m13, m9, m10
+    vpunpcklwd      m9, m9, m10
+
+    pshufb          m12, filters, [param_shuffe_ %+ i]       ;filter
+    vpunpcklwd      m10, m12, m12
+    vpunpckhwd      m12, m12, m12
+
+    vpmaddwd        m9, m10
+    vpmaddwd        m12, m13
+
+    paddd           m0, m9
+    paddd           m1, m12
+%endmacro
+
+;FILTER(param_idx, bottom, top, byte_offset)
+;input:  param_idx, bottom, top, byte_offset
+;output: m0, m1
+;temp:   m9, m10, offsetq
+%macro FILTER 4
+    mov             offsetq, %4
+    LOAD_PIXELS     m10, [%2 + offsetq]
+    neg             offsetq
+    LOAD_PIXELS     m9,  [%3 + offsetq]
+
+    FILTER  %1
+%endmacro
+
+;get source lines
+;GET_SRCS(line)
+;input:  src, src_stride, vb_pos
+;output: s1...s6
+%macro GET_SRCS 1
+    lea s1q, [srcq + src_strideq]
+    lea s3q, [s1q  + src_strideq]
+%if LUMA
+    lea s5q, [s3q  + src_strideq]
+%endif
+    neg src_strideq
+    lea s2q, [srcq + src_strideq]
+    lea s4q, [s2q  + src_strideq]
+%if LUMA
+    lea s6q, [s4q  + src_strideq]
+%endif
+    neg src_strideq
+
+%if LUMA
+    cmp vb_posq, 0
+    je %%vb_bottom
+    cmp vb_posq, 4
+    jne %%vb_end
+%else
+    cmp vb_posq, 2
+    jne %%vb_end
+    %if %1 >= 2
+        jmp %%vb_bottom
+    %endif
+%endif
+
+%%vb_above:
+    ;above
+    ;p1 = (y + i == vb_pos - 1) ? p0 : p1;
+    ;p2 = (y + i == vb_pos - 1) ? p0 : p2;
+    ;p3 = (y + i >= vb_pos - 2) ? p1 : p3;
+    ;p4 = (y + i >= vb_pos - 2) ? p2 : p4;
+    ;p5 = (y + i >= vb_pos - 3) ? p3 : p5;
+    ;p6 = (y + i >= vb_pos - 3) ? p4 : p6;
+    dec vb_posq
+    cmp vb_posq, %1
+    cmove s1q, srcq
+    cmove s2q, srcq
+
+    dec vb_posq
+    cmp vb_posq, %1
+    cmovbe s3q, s1q
+    cmovbe s4q, s2q
+
+    dec vb_posq
+%if LUMA
+    cmp vb_posq, %1
+    cmovbe s5q, s3q
+    cmovbe s6q, s4q
+%endif
+    add vb_posq, 3
+    jmp %%vb_end
+
+%%vb_bottom:
+    ;bottom
+    ;p1 = (y + i == vb_pos    ) ? p0 : p1;
+    ;p2 = (y + i == vb_pos    ) ? p0 : p2;
+    ;p3 = (y + i <= vb_pos + 1) ? p1 : p3;
+    ;p4 = (y + i <= vb_pos + 1) ? p2 : p4;
+    ;p5 = (y + i <= vb_pos + 2) ? p3 : p5;
+    ;p6 = (y + i <= vb_pos + 2) ? p4 : p6;
+    cmp vb_posq, %1
+    cmove s1q, srcq
+    cmove s2q, srcq
+
+    inc vb_posq
+    cmp vb_posq, %1
+    cmovae s3q, s1q
+    cmovae s4q, s2q
+
+    inc vb_posq
+%if LUMA
+    cmp vb_posq, %1
+    cmovae s5q, s3q
+    cmovae s6q, s4q
+%endif
+    sub vb_posq, 2
+%%vb_end:
+%endmacro
+
+;shift filter result
+;SHIFT_VB(line)
+;input:  m0, m1, vb_pos
+;output: m0
+;temp:   m9
+%macro SHIFT_VB 1
+%define SHIFT 7
+    %if LUMA
+        %if %1 == 3
+            cmp     vb_posq, 4
+            je      %%near_vb
+        %elif %1 == 0
+            cmp     vb_posq, 0
+            je      %%near_vb
+        %endif
+    %else
+        %if %1 == 1 || %1 == 2
+            cmp     vb_posq, 2
+            je      %%near_vb
+        %endif
+    %endif
+    ;no vb
+    vpsrad          m0, SHIFT
+    vpsrad          m1, SHIFT
+    jmp             %%shift_end
+%%near_vb:
+    ;vb
+    vpbroadcastd    m9, [dd448]
+    paddd           m0, m9
+    paddd           m1, m9
+    vpsrad          m0, SHIFT + 3
+    vpsrad          m1, SHIFT + 3
+%%shift_end:
+    vpackssdw       m0, m0, m1
+%endmacro
+
+;filter pixels for luma and chroma
+;FILTER_VB(line)
+;input:  line
+;output: m0, m1
+;temp:   s0q...s1q
+%macro FILTER_VB 1
+    vpbroadcastd    m0, [dw64]
+    vpbroadcastd    m1, [dw64]
+
+    GET_SRCS %1
+    %if LUMA
+        FILTER           0,  s5q,  s6q,  0 * ps
+        FILTER           1,  s3q,  s4q,  1 * ps
+        FILTER           2,  s3q,  s4q,  0 * ps
+        FILTER           3,  s3q,  s4q, -1 * ps
+        FILTER           4,  s1q,  s2q,  2 * ps
+        FILTER           5,  s1q,  s2q,  1 * ps
+        FILTER           6,  s1q,  s2q,  0 * ps
+        FILTER           7,  s1q,  s2q, -1 * ps
+        FILTER           8,  s1q,  s2q, -2 * ps
+        FILTER           9, srcq, srcq,  3 * ps
+        FILTER          10, srcq, srcq,  2 * ps
+        FILTER          11, srcq, srcq,  1 * ps
+    %else
+        FILTER           0,  s3q,  s4q,  0 * ps
+        FILTER           1,  s1q,  s2q,  1 * ps
+        FILTER           2,  s1q,  s2q,  0 * ps
+        FILTER           3,  s1q,  s2q, -1 * ps
+        FILTER           4, srcq, srcq,  2 * ps
+        FILTER           5, srcq, srcq,  1 * ps
+    %endif
+    SHIFT_VB %1
+%endmacro
+
+%macro FILTER_16x4 0
+    push filterq
+    push clipq
+    push strideq
+    push xq
+    %define s1q filterq
+    %define s2q clipq
+    %define s3q strideq
+    %define s4q pixel_maxq
+    %define s5q xq
+
+    %define %%i 0
+    %rep 4
+        LOAD_PIXELS     m2, [srcq]   ;p0
+
+        FILTER_VB       %%i
+
+        paddw           m0, m2
+
+        ;clip to pixel
+        CLIPW           m0, m14, m15
+
+        STORE_PIXELS    [dstq] , 0
+
+        lea             srcq, [srcq + src_strideq]
+        lea             dstq, [dstq + dst_strideq]
+        %assign         %%i %%i + 1
+    %endrep
+
+    %rep 4
+        sub             srcq, src_strideq
+        sub             dstq, dst_strideq
+    %endrep
+
+    pop xq
+    pop strideq
+    pop clipq
+    pop filterq
+%endmacro
+
+;STORE_PIXELS(dest, src)
+%macro STORE_PIXELS 2
+    %if ps == 2
+        movu         %1, m%2
+    %else
+        vpackuswb   m%2, m%2
+        vpermq      m%2, m%2, 0x8
+        movu        %1, xm%2
+    %endif
+%endmacro
+
+;LOAD_PIXELS(dest, src)
+%macro LOAD_PIXELS 2
+%if ps == 2
+    movu %1, %2
+%else
+    vpmovzxbw %1, %2
+%endif
+%endmacro
+
+;FILTER(bpc, luma/chroma)
+%macro ALF_FILTER 2
+%xdefine BPC   %1
+%ifidn %2, luma
+    %xdefine LUMA 1
+%else
+    %xdefine LUMA 0
+%endif
+; void vvc_alf_filter_%2_%1bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
+;   const ptrdiff_t width, cosnt ptr_diff_t height, const int16_t *filter, const int16_t *clip, ptrdiff_t stride,
+;   ptrdiff_t vb_pos, ptrdiff_t pixel_max);
+
+; see c code for s1 to s6
+
+cglobal vvc_alf_filter_%2_%1bpc, 11, 14, 16, 6*8, dst, dst_stride, src, src_stride, width, height, filter, clip, stride, vb_pos, pixel_max, \
+    offset, x, s6
+;pixel size
+%define ps (%1 / 8)
+    movd          xm15, pixel_maxd
+    vpbroadcastw  m15, xm15
+    pxor           m14, m14
+
+.loop:
+    push            srcq
+    push            dstq
+    xor             xd, xd
+
+    .loop_w:
+        LOAD_PARAMS
+        FILTER_16x4
+
+        add srcq, 16 * ps
+        add dstq, 16 * ps
+        add xd, 16
+        cmp xd, widthd
+        jl .loop_w
+
+    pop             dstq
+    pop             srcq
+    lea             srcq, [srcq + 4 * src_strideq]
+    lea             dstq, [dstq + 4 * dst_strideq]
+
+    lea             filterq, [filterq + 2 * strideq]
+    lea             clipq, [clipq + 2 * strideq]
+
+    sub             vb_posq, 4
+    sub             heightq, 4
+    jg              .loop
+    RET
+%endmacro
+
+;FILTER(bpc)
+%macro ALF_FILTER 1
+    ALF_FILTER  %1, luma
+    ALF_FILTER  %1, chroma
+%endmacro
+
+%define ALF_GRADIENT_BORDER 2
+%define ALF_BORDER_LUMA 3
+
+%macro ALF_CLASSIFY_GRAD 1
+;void ff_vvc_alf_classify_grad(int *gradient_sum,
+;       const uint8_t *src, ptrdiff_t src_stride, intptr_t width, intptr_t height,
+;       intptr_t vb_pos);
+cglobal vvc_alf_classify_grad_%1bpc, 6, 14, 16, gradient_sum, src, src_stride, width, height, vb_pos, \
+    x, y, s0, s1, s2, s3, vb_pos_below, src_stride3
+
+    lea src_stride3q, [src_strideq * 2 + src_strideq]
+
+    lea vb_pos_belowd, [vb_posd + ALF_GRADIENT_BORDER]
+
+    ;src = src - ALF_BORDER_LUMA * src_stride - ALF_BORDER_LUMA
+    sub srcq, src_stride3q
+    sub srcq, ALF_BORDER_LUMA * ps
+
+    add widthd, ALF_GRADIENT_BORDER * 2
+    add heightd, ALF_GRADIENT_BORDER * 2
+
+    xor yd, yd
+
+.loop_h:
+    xor  xd,  xd
+    pxor m15, m15                               ;prev
+    .loop_w:
+        lea     s0q, [srcq + xq * ps]
+        lea     s1q, [s0q + src_strideq]
+        lea     s2q, [s0q + 2 * src_strideq]
+        lea     s3q, [s0q + src_stride3q]
+
+        cmp     yd, vb_pos_belowd
+        cmove  s0q, s1q
+
+        cmp     yd, vb_posd
+        cmove  s3q, s2q
+
+        LOAD_PIXELS m0, [s0q]
+        LOAD_PIXELS m1, [s1q]
+        LOAD_PIXELS m2, [s2q]
+        LOAD_PIXELS m3, [s3q]
+
+        LOAD_PIXELS m4, [s0q + 2 * ps]
+        LOAD_PIXELS m5, [s1q + 2 * ps]
+        LOAD_PIXELS m6, [s2q + 2 * ps]
+        LOAD_PIXELS m7, [s3q + 2 * ps]
+
+        vpblendw m8,  m0,  m1, 0xaa             ;nw
+        vpblendw m9,  m0,  m5, 0x55             ;n
+        vpblendw m10, m4,  m5, 0xaa             ;ne
+        vpblendw m11, m1,  m2, 0xaa             ;w
+        vpblendw m12, m5,  m6, 0xaa             ;e
+        vpblendw m13, m2,  m3, 0xaa             ;sw
+        vpblendw m14, m2,  m7, 0x55             ;s
+
+
+        vpblendw m0,  m1,  m6, 0x55
+        vpaddw   m0,  m0                        ;c
+
+        movu     m1,  [CLASSIFY_SHUFFE]
+        pshufb   m1,  m0,  m1                   ;d
+
+        vpaddw   m9,  m14                       ;n + s
+        vpsubw   m9,  m0                        ;(n + s) - c
+        vpabsw   m9,  m9                        ;ver
+
+        vpaddw   m11, m12                       ;w + e
+        vpsubw   m11, m1                        ;(w + e) - d
+        vpabsw   m11, m11                       ;hor
+
+        vpblendw m14, m6, m7, 0xaa              ;se
+        vpaddw   m8,  m14                       ;nw + se
+        vpsubw   m8,  m1                        ;(nw + se) - d
+        vpabsw   m8,  m8                        ;di0
+
+        vpaddw   m10, m13                       ;ne + sw
+        vpsubw   m10, m1                        ;(nw + se) - d
+        vpabsw   m10, m10                       ;di1
+
+        phaddw   m9,  m11                       ;vh,  each word represent 2x2 pixels
+        phaddw   m8,  m10                       ;di,  each word represent 2x2 pixels
+        phaddw   m0,  m9, m8                    ;all = each word represent 4x2 pixels, order is v_h_d0_d1 x 4
+
+        vinserti128  m15, m15, xm0, 1
+        vpblendw     m1,  m0, m15, 0xaa         ;t
+
+        phaddw       m1,  m0                    ;each word represent 8x2 pixels, adjacent word share 4x2 pixels
+
+        vextracti128 xm15, m0, 1                ;prev
+
+        movu         [gradient_sumq], m1
+
+        add gradient_sumq, 32
+        add xd, 16
+        cmp xd, widthd
+        jl .loop_w
+
+    lea srcq, [srcq + 2 * src_strideq]
+    add yd, 2
+    cmp yd, heightd
+    jl .loop_h
+    RET
+%endmacro
+
+;SAVE_CLASSIFY_PARAM_W16(dest, src)
+%macro SAVE_CLASSIFY_PARAM_W16 2
+    lea tempq, [%1q + xq]
+    movu [tempq], xm%2
+    vperm2i128 m%2, m%2, m%2, 1
+    movu [tempq + widthq], xm%2
+%endmacro
+
+;SAVE_CLASSIFY_PARAM_W8
+%macro SAVE_CLASSIFY_PARAM_W8 2
+    movq [%1], xm%2
+    vperm2i128 m%2, m%2, m%2, 1
+    movq [%1 + widthq], xm%2
+%endmacro
+
+;SAVE_CLASSIFY_PARAM_W4
+%macro SAVE_CLASSIFY_PARAM_W4 2
+    movd [%1], xm%2
+    vperm2i128 m%2, m%2, m%2, 1
+    movd [%1 + widthq], xm%2
+%endmacro
+
+;SAVE_CLASSIFY_PARAM_W(dest, src)
+%macro SAVE_CLASSIFY_PARAM_W 2
+    lea tempq, [%1q + xq]
+
+    cmp wd, 8
+    jl %%w4
+        SAVE_CLASSIFY_PARAM_W8 tempq, %2
+        vpermq m%2, m%2, 00010011b
+        add tempq, 8
+        cmp wd, 8
+        je %%end
+    %%w4:
+    SAVE_CLASSIFY_PARAM_W4 tempq, %2
+%%end:
+%endmacro
+
+%macro ALF_CLASSIFY_H8 0
+    ;first line, sum of 16x4 pixels (includes borders)
+    lea gradq, [gradient_sumq + 2 * xq]
+    movu m0, [gradq]
+    movu m1, [gradq + sum_strideq]
+    movu m2, [gradq + 2 * sum_strideq]
+
+    pcmpeqb      m11, m11
+    movd xm13, yd
+    vpbroadcastd m13, xm13
+    movd xm12, vb_posd
+    vpbroadcastd m12, xm12
+    vpcmpeqd     m13, m12       ; y == vb_pos
+    pandn        m13, m11       ; y != vb_pos
+
+    vpbroadcastd m14, [dw3]
+    pblendvb m14, m14, [dd2], m13    ;ac
+
+    pblendvb m3, m15, [gradq + sum_stride3q], m13
+
+    ;extent to dword to avoid overflow
+    vpunpcklwd m4,  m0, m15
+    vpunpckhwd m5,  m0, m15
+    vpunpcklwd m6,  m1, m15
+    vpunpckhwd m7,  m1, m15
+    vpunpcklwd m8,  m2, m15
+    vpunpckhwd m9,  m2, m15
+    vpunpcklwd m10, m3, m15
+    vpunpckhwd m11, m3, m15
+
+    vpaddd m0, m4, m6
+    vpaddd m1, m5, m7
+    vpaddd m2, m8, m10
+    vpaddd m3, m9, m11
+
+    ;sum of the first row
+    vpaddd m0, m2           ;low
+    vpaddd m1, m3           ;high
+
+    lea gradq, [gradq + 2 * sum_strideq]
+
+    pblendvb m10, m15, [gradq], m13
+
+    movu m11, [gradq + sum_strideq]
+    movu m12, [gradq + 2 * sum_strideq]
+    movu m13, [gradq + sum_stride3q]
+
+    vpunpcklwd m4,  m10, m15
+    vpunpckhwd m5,  m10, m15
+    vpunpcklwd m6,  m11, m15
+    vpunpckhwd m7,  m11, m15
+    vpunpcklwd m8,  m12, m15
+    vpunpckhwd m9,  m12, m15
+    vpunpcklwd m10,  m13, m15
+    vpunpckhwd m11,  m13, m15
+
+    vpaddd m2, m4, m6
+    vpaddd m3, m5, m7
+    vpaddd m4, m8, m10
+    vpaddd m5, m9, m11
+
+    ;sum of the second row
+    vpaddd m2, m4           ;low
+    vpaddd m3, m5           ;high
+
+    vpunpckldq m4, m0, m2
+    vpunpckhdq m5, m0, m2
+    vpunpckldq m6, m1, m3
+    vpunpckhdq m7, m1, m3
+
+    ;each dword represent 4x2 alf blocks
+    ;the order is 01452367
+    vpunpckldq m0, m4, m6           ;sum_v
+    vpunpckhdq m1, m4, m6           ;sum_h
+    vpunpckldq m2, m5, m7           ;sum_d0
+    vpunpckhdq m3, m5, m7           ;sum_d1
+
+    vpcmpgtd   m4, m0, m1           ;dir_hv - 1
+    vpmaxsd    m5, m0, m1           ;hv1
+    vpminsd    m6, m0, m1           ;hv0
+
+    vpaddd     m0, m1;              ;sum_hv
+
+    vpcmpgtd   m7, m2, m3           ;dir_d - 1
+    vpmaxsd    m8, m2, m3           ;d1
+    vpminsd    m9, m2, m3           ;d0
+
+    ;*transpose_idx = dir_d * 2 + dir_hv;
+    vpbroadcastd m10, [dw3]
+    vpaddd m11, m7, m7
+    vpaddd m11, m4
+    vpaddd m10, m11
+    vpermq m10, m10, 11011000b
+    SAVE_CLASSIFY_PARAM transpose_idx, 10
+
+    vpsrlq    m10, m8, 32
+    vpsrlq    m11, m6, 32
+    pmuldq    m12, m10, m11         ;d1 * hv0 high
+    vpsrlq    m1,  m9, 32
+    vpsrlq    m2,  m5, 32
+    pmuldq    m3,  m1, m2           ;d0 * hv1 high
+    vpcmpgtq  m10, m12, m3          ;dir1 - 1 high
+
+    pmuldq    m1, m8, m6            ;d1 * hv0 low
+    pmuldq    m2, m9, m5            ;d0 * hv1 low
+    vpcmpgtq  m1, m2                ;dir1 - 1 low
+
+    vpblendd  m1, m1, m10, 0xaa     ;dir1 - 1
+
+    pblendvb  m2, m5, m8, m1        ;hvd1
+    pblendvb  m3, m6, m9, m1        ;hvd0
+
+    movd            xm5, bit_depthd
+    vpbroadcastd    m5, xm5
+
+    ;*class_idx = arg_var[av_clip_uintp2(sum_hv * ac >> (BIT_DEPTH - 1), 4)];
+    vpmulld   m0, m14               ;sum_hv * ac
+    vpsrlvd   m0, m0, m5
+    vpminsd   m0, [dd15]
+    movu      m6, [ARG_VAR_SHUFFE]
+    pshufb    m6, m0                ;class_idx
+
+    vpbroadcastd m10, [dw5]
+
+    ;if (hvd1 * 2 > 9 * hvd0)
+    ;   *class_idx += ((dir1 << 1) + 2) * 5;
+    ;else if (hvd1 > 2 * hvd0)
+    ;   *class_idx += ((dir1 << 1) + 1) * 5;
+    paddd     m7,  m3, m3
+    pcmpgtd   m7,  m2, m7           ;hvd1 > 2 * hvd0
+    pand      m7, m10
+    paddd     m6,  m7               ;class_idx
+
+    paddd     m8, m2, m2
+    vpslld    m9, m3, 3
+    paddd     m9, m3
+    pcmpgtd   m8, m9                ;hvd1 * 2 > 9 * hvd0
+    pand      m8, m10
+    paddd     m6, m8                ;class_idx
+
+    pandn     m1, m7
+    paddd     m1, m1                ;dir1 << 1
+    paddd     m6, m1                ;class_idx
+    vpermq    m6, m6, 11011000b
+
+    SAVE_CLASSIFY_PARAM class_idx, 6
+%endmacro
+
+%macro ALF_CLASSIFY_16x8 0
+%define SAVE_CLASSIFY_PARAM SAVE_CLASSIFY_PARAM_W16
+    ALF_CLASSIFY_H8
+%undef SAVE_CLASSIFY_PARAM
+%endmacro
+
+%macro ALF_CLASSIFY_Wx8 0
+%define SAVE_CLASSIFY_PARAM SAVE_CLASSIFY_PARAM_W
+    ALF_CLASSIFY_H8
+%undef SAVE_CLASSIFY_PARAM
+%endmacro
+
+%macro ALF_CLASSIFY 1
+;void ff_vvc_alf_classify(int *class_idx, int *transpose_idx,
+;       const int *gradient_sum, intptr_t width, intptr_t height,
+;       intptr_t vb_pos, int *gradient_tmp, intptr_t bit_depth);
+
+;pixel size
+%define ps (%1 / 8)
+ALF_CLASSIFY_GRAD %1
+cglobal vvc_alf_classify_%1bpc, 7, 15, 16, class_idx, transpose_idx, gradient_sum, width, height, vb_pos, bit_depth, \
+    x, y, grad, sum_stride, sum_stride3, temp, w
+
+    sub bit_depthq, 1
+
+    ;now we can use gradient to get class idx and transpose idx
+    lea sum_strideq, [widthd + ALF_GRADIENT_BORDER * 2]
+    add sum_strideq, 15
+    and sum_strideq, ~15                        ;align to 16
+    add sum_strideq, sum_strideq                ;two rows a time
+
+    add     gradient_sumq, 8                    ;first 4 words are garbage
+
+    lea     sum_stride3q, [3 * sum_strideq]
+
+    xor yd, yd
+    and vb_posd, ~7    ;floor align to 8
+    pxor m15, m15
+
+.loop_sum_h:
+    xor  xd,  xd
+    .loop_sum_w16:
+        lea wd, [widthd]
+        sub wd, xd
+        cmp wd, 16
+        jl .loop_sum_w16_end
+            ALF_CLASSIFY_16x8
+            add xd, 16
+        jmp .loop_sum_w16
+    .loop_sum_w16_end:
+
+    cmp wd, 0
+    je .loop_sum_w_end
+        ALF_CLASSIFY_Wx8
+    .loop_sum_w_end:
+
+    lea gradient_sumq, [gradient_sumq + 4 * sum_strideq]
+    lea transpose_idxq, [transpose_idxq + 2 * widthq]
+    lea class_idxq, [class_idxq + 2 * widthq]
+
+    add yd, 8
+    cmp yd, heightd
+    jl .loop_sum_h
+
+    RET
+%endmacro
+
+INIT_YMM avx2
+ALF_FILTER  16
+ALF_FILTER  8
+ALF_CLASSIFY 16
+ALF_CLASSIFY 8
+%endif

--- a/libavcodec/x86/vvc/vvc_inter.asm
+++ b/libavcodec/x86/vvc/vvc_inter.asm
@@ -1,0 +1,393 @@
+; /*
+; * Provide SIMD MC functions for VVC decoding
+; *
+; * Copyright (c) 2023 Wu Jianhua <toqsxw@outlook.com>
+; *
+; * This file is part of FFmpeg.
+; *
+; * FFmpeg is free software; you can redistribute it and/or
+; * modify it under the terms of the GNU Lesser General Public
+; * License as published by the Free Software Foundation; either
+; * version 2.1 of the License, or (at your option) any later version.
+; *
+; * FFmpeg is distributed in the hope that it will be useful,
+; * but WITHOUT ANY WARRANTY; without even the implied warranty of
+; * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+; * Lesser General Public License for more details.
+; *
+; * You should have received a copy of the GNU Lesser General Public
+; * License along with FFmpeg; if not, write to the Free Software
+; * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+; */
+%define MAX_PB_SIZE 128
+%include "libavcodec/x86/xvc_mc.asm"
+
+SECTION_RODATA 32
+
+pw_0    times 2 dw   0
+pw_1    times 2 dw   1
+pw_4    times 2 dw   4
+pw_12   times 2 dw  12
+pw_256  times 2 dw 256
+
+%macro AVG_JMP_TABLE 3-*
+    %xdefine %1_%2_%3_table (%%table - 2*%4)
+    %xdefine %%base %1_%2_%3_table
+    %xdefine %%prefix mangle(private_prefix %+ _vvc_%1_%2bpc_%3)
+    %%table:
+    %rep %0 - 3
+        dd %%prefix %+ .w%4 - %%base
+        %rotate 1
+    %endrep
+%endmacro
+
+AVG_JMP_TABLE    avg,  8, avx2,                2, 4, 8, 16, 32, 64, 128
+AVG_JMP_TABLE    avg, 16, avx2,                2, 4, 8, 16, 32, 64, 128
+AVG_JMP_TABLE  w_avg,  8, avx2,                2, 4, 8, 16, 32, 64, 128
+AVG_JMP_TABLE  w_avg, 16, avx2,                2, 4, 8, 16, 32, 64, 128
+
+SECTION .text
+
+%macro AVG_W16_FN 3 ; bpc, op, count
+    %assign %%i 0
+    %rep %3
+        %define off %%i
+        AVG_LOAD_W16        0, off
+        %2
+        AVG_SAVE_W16       %1, 0, off
+
+
+        AVG_LOAD_W16        1, off
+        %2
+        AVG_SAVE_W16       %1, 1, off
+
+        %assign %%i %%i+1
+    %endrep
+%endmacro
+
+%macro AVG_FN 2 ; bpc, op
+   jmp                  wq
+
+.w2:
+    movd                xm0, [src0q]
+    pinsrd              xm0, [src0q + AVG_SRC_STRIDE], 1
+    movd                xm1, [src1q]
+    pinsrd              xm1, [src1q + AVG_SRC_STRIDE], 1
+    %2
+    AVG_SAVE_W2          %1
+    AVG_LOOP_END        .w2
+
+.w4:
+    movq                xm0, [src0q]
+    pinsrq              xm0, [src0q + AVG_SRC_STRIDE], 1
+    movq                xm1, [src1q]
+    pinsrq              xm1, [src1q + AVG_SRC_STRIDE], 1
+    %2
+    AVG_SAVE_W4          %1
+
+    AVG_LOOP_END        .w4
+
+.w8:
+    vinserti128         m0, m0, [src0q], 0
+    vinserti128         m0, m0, [src0q + AVG_SRC_STRIDE], 1
+    vinserti128         m1, m1, [src1q], 0
+    vinserti128         m1, m1, [src1q + AVG_SRC_STRIDE], 1
+    %2
+    AVG_SAVE_W8         %1
+
+    AVG_LOOP_END       .w8
+
+.w16:
+    AVG_W16_FN          %1, %2, 1
+
+    AVG_LOOP_END       .w16
+
+.w32:
+    AVG_W16_FN          %1, %2, 2
+
+    AVG_LOOP_END       .w32
+
+.w64:
+    AVG_W16_FN          %1, %2, 4
+
+    AVG_LOOP_END       .w64
+
+.w128:
+    AVG_W16_FN          %1, %2, 8
+
+    AVG_LOOP_END       .w128
+
+.ret:
+    RET
+%endmacro
+
+%macro AVG   0
+    paddsw               m0, m1
+    pmulhrsw             m0, m2
+    CLIPW                m0, m3, m4
+%endmacro
+
+%macro W_AVG 0
+    punpckhwd            m5, m0, m1
+    pmaddwd              m5, m3
+    paddd                m5, m4
+    psrad                m5, xm2
+
+    punpcklwd            m0, m0, m1
+    pmaddwd              m0, m3
+    paddd                m0, m4
+    psrad                m0, xm2
+
+    packssdw             m0, m5
+    CLIPW                m0, m6, m7
+%endmacro
+
+%macro AVG_LOAD_W16 2  ; line, offset
+    movu               m0, [src0q + %1 * AVG_SRC_STRIDE + %2 * 32]
+    movu               m1, [src1q + %1 * AVG_SRC_STRIDE + %2 * 32]
+%endmacro
+
+%macro AVG_SAVE_W2 1 ;bpc
+    %if %1 == 16
+        pextrd           [dstq], xm0, 0
+        pextrd [dstq + strideq], xm0, 1
+    %else
+        packuswb           m0, m0
+        pextrw           [dstq], xm0, 0
+        pextrw [dstq + strideq], xm0, 1
+    %endif
+%endmacro
+
+%macro AVG_SAVE_W4 1 ;bpc
+    %if %1 == 16
+        pextrq           [dstq], xm0, 0
+        pextrq [dstq + strideq], xm0, 1
+    %else
+        packuswb           m0, m0
+        pextrd           [dstq], xm0, 0
+        pextrd [dstq + strideq], xm0, 1
+    %endif
+%endmacro
+
+%macro AVG_SAVE_W8 1 ;bpc
+    %if %1 == 16
+        vextracti128            [dstq], m0, 0
+        vextracti128  [dstq + strideq], m0, 1
+    %else
+        packuswb                    m0, m0
+        vpermq                      m0, m0, 1000b
+        pextrq                  [dstq], xm0, 0
+        pextrq        [dstq + strideq], xm0, 1
+    %endif
+%endmacro
+
+%macro AVG_SAVE_W16 3 ; bpc, line, offset
+    %if %1 == 16
+        movu               [dstq + %2 * strideq + %3 * 32], m0
+    %else
+        packuswb                                        m0, m0
+        vpermq                                          m0, m0, 1000b
+        vextracti128       [dstq + %2 * strideq + %3 * 16], m0, 0
+    %endif
+%endmacro
+
+%macro AVG_LOOP_END 1
+    sub                  hd, 2
+    je                 .ret
+
+    lea               src0q, [src0q + 2 * AVG_SRC_STRIDE]
+    lea               src1q, [src1q + 2 * AVG_SRC_STRIDE]
+    lea                dstq, [dstq + 2 * strideq]
+    jmp                  %1
+%endmacro
+
+%define AVG_SRC_STRIDE MAX_PB_SIZE*2
+
+;void ff_vvc_avg_%1bpc_avx2(uint8_t *dst, ptrdiff_t dst_stride,
+;   const int16_t *src0, const int16_t *src1, intptr_t width, intptr_t height, intptr_t pixel_max);
+%macro VVC_AVG_AVX2 1
+cglobal vvc_avg_%1bpc, 4, 7, 5, dst, stride, src0, src1, w, h, bd
+    movifnidn            hd, hm
+
+    pxor                 m3, m3             ; pixel min
+    vpbroadcastw         m4, bdm            ; pixel max
+
+    movifnidn           bdd, bdm
+    inc                 bdd
+    tzcnt               bdd, bdd            ; bit depth
+
+    sub                 bdd, 8
+    movd                xm0, bdd
+    vpbroadcastd         m1, [pw_4]
+    pminuw               m0, m1
+    vpbroadcastd         m2, [pw_256]
+    psllw                m2, xm0                ; shift
+
+    lea                  r6, [avg_%1 %+ SUFFIX %+ _table]
+    tzcnt                wd, wm
+    movsxd               wq, dword [r6+wq*4]
+    add                  wq, r6
+    AVG_FN               %1, AVG
+%endmacro
+
+;void ff_vvc_w_avg_%1bpc_avx(uint8_t *dst, ptrdiff_t dst_stride,
+;    const int16_t *src0, const int16_t *src1, intptr_t width, intptr_t height,
+;    intptr_t denom, intptr_t w0, intptr_t w1,  intptr_t o0, intptr_t o1, intptr_t pixel_max);
+%macro VVC_W_AVG_AVX2 1
+cglobal vvc_w_avg_%1bpc, 4, 7, 8, dst, stride, src0, src1, w, h, t0, t1
+
+    movifnidn            hd, hm
+
+    movifnidn           t0d, r8m                ; w1
+    shl                 t0d, 16
+    mov                 t0w, r7m                ; w0
+    movd                xm3, t0d
+    vpbroadcastd         m3, xm3                ; w0, w1
+
+    pxor                m6, m6                  ;pixel min
+    vpbroadcastw        m7, r11m                ;pixel max
+
+    mov                 t1q, rcx                ; save ecx
+    mov                 ecx, r11m
+    inc                 ecx                     ; bd
+    tzcnt               ecx, ecx
+    sub                 ecx, 8
+    mov                 t0d, r9m                ; o0
+    add                 t0d, r10m               ; o1
+    shl                 t0d, cl
+    inc                 t0d                     ;((o0 + o1) << (BIT_DEPTH - 8)) + 1
+
+    neg                 ecx
+    add                 ecx, 4                  ; bd - 12
+    cmovl               ecx, [pw_0]
+    add                 ecx, 3
+    add                 ecx, r6m
+    movd                xm2, ecx                ; shift
+
+    dec                ecx
+    shl                t0d, cl
+    movd               xm4, t0d
+    vpbroadcastd        m4, xm4                 ; offset
+    mov                rcx, t1q                 ; restore ecx
+
+    lea                  r6, [w_avg_%1 %+ SUFFIX %+ _table]
+    tzcnt                wd, wm
+    movsxd               wq, dword [r6+wq*4]
+    add                  wq, r6
+    AVG_FN               %1, W_AVG
+%endmacro
+
+%macro VVC_PUT_PIXELS 2
+    PUT_PIXELS vvc, %1, %2
+%endmacro
+
+%macro VVC_PUT_4TAP 2
+    PUT_4TAP vvc, %1, %2
+%endmacro
+
+%macro VVC_PUT_4TAP_HV 2
+    PUT_4TAP_HV vvc, %1, %2
+%endmacro
+
+%macro VVC_PUT_8TAP 2
+    PUT_8TAP vvc, %1, %2
+%endmacro
+
+%macro VVC_PUT_8TAP_HV 2
+    PUT_8TAP_HV vvc, %1, %2
+%endmacro
+
+%if ARCH_X86_64
+
+INIT_XMM sse4
+VVC_PUT_PIXELS  2, 8
+VVC_PUT_PIXELS  4, 8
+VVC_PUT_PIXELS  8, 8
+VVC_PUT_PIXELS 16, 8
+
+VVC_PUT_PIXELS 2, 10
+VVC_PUT_PIXELS 4, 10
+VVC_PUT_PIXELS 8, 10
+
+VVC_PUT_PIXELS 2, 12
+VVC_PUT_PIXELS 4, 12
+VVC_PUT_PIXELS 8, 12
+
+VVC_PUT_4TAP 2,  8
+VVC_PUT_4TAP 4,  8
+VVC_PUT_4TAP 8,  8
+VVC_PUT_4TAP 16, 8
+
+VVC_PUT_4TAP 2, 10
+VVC_PUT_4TAP 4, 10
+VVC_PUT_4TAP 8, 10
+
+VVC_PUT_4TAP 2, 12
+VVC_PUT_4TAP 4, 12
+VVC_PUT_4TAP 8, 12
+
+VVC_PUT_4TAP_HV 2,  8
+VVC_PUT_4TAP_HV 4,  8
+VVC_PUT_4TAP_HV 8,  8
+VVC_PUT_4TAP_HV 16, 8
+
+VVC_PUT_4TAP_HV 2, 10
+VVC_PUT_4TAP_HV 4, 10
+VVC_PUT_4TAP_HV 8, 10
+
+VVC_PUT_4TAP_HV 2, 12
+VVC_PUT_4TAP_HV 4, 12
+VVC_PUT_4TAP_HV 8, 12
+
+VVC_PUT_8TAP 4,  8
+VVC_PUT_8TAP 8,  8
+VVC_PUT_8TAP 16, 8
+
+VVC_PUT_8TAP 4, 10
+VVC_PUT_8TAP 8, 10
+
+VVC_PUT_8TAP 4, 12
+VVC_PUT_8TAP 8, 12
+
+VVC_PUT_8TAP_HV 4, 8
+VVC_PUT_8TAP_HV 8, 8
+
+VVC_PUT_8TAP_HV 4, 10
+VVC_PUT_8TAP_HV 8, 10
+
+VVC_PUT_8TAP_HV 4, 12
+VVC_PUT_8TAP_HV 8, 12
+
+%if HAVE_AVX2_EXTERNAL
+INIT_YMM avx2
+
+VVC_PUT_PIXELS  32, 8
+VVC_PUT_PIXELS  16, 10
+VVC_PUT_PIXELS  16, 12
+
+VVC_PUT_8TAP 32,  8
+VVC_PUT_8TAP 16, 10
+VVC_PUT_8TAP 16, 12
+
+VVC_PUT_8TAP_HV 32, 8
+VVC_PUT_8TAP_HV 16, 10
+VVC_PUT_8TAP_HV 16, 12
+
+VVC_PUT_4TAP 32,  8
+VVC_PUT_4TAP 16, 10
+VVC_PUT_4TAP 16, 12
+
+VVC_PUT_4TAP_HV 32, 8
+VVC_PUT_4TAP_HV 16, 10
+VVC_PUT_4TAP_HV 16, 12
+
+VVC_AVG_AVX2 16
+
+VVC_AVG_AVX2 8
+
+VVC_W_AVG_AVX2 16
+
+VVC_W_AVG_AVX2 8
+%endif
+
+%endif

--- a/libavcodec/x86/vvc/vvc_sad.asm
+++ b/libavcodec/x86/vvc/vvc_sad.asm
@@ -1,0 +1,265 @@
+; sad but specifically for dmvr which restricts applicable PU sizes and only does even rows to reduce complexity
+; w >= 8, h >= 8 and w*h >= 128
+
+%include "libavutil/x86/x86util.asm"
+
+
+SECTION .text
+
+%macro MIN_MAX_SAD 3 ; 
+    vpminuw           %1, %2, %3
+    vpmaxuw           %3, %2, %3
+    vpsubusw          %3, %3, %1
+%endmacro
+
+%macro HORIZONTAL_ADD 3  ; xm0, xm1, m1
+    vextracti128      %1, %3 , q0001 ;        3        2      1          0
+    vpaddd            %1, %2         ; xm0 (7 + 3) (6 + 2) (5 + 1)   (4 + 0)
+    vpshufd           %2, %1, q0032  ; xm1    -      -     (7 + 3)   (6 + 2)
+    vpaddd            %1, %1, %2     ; xm0    _      _     (5 1 7 3) (4 0 6 2)
+    vpshufd           %2, %1, q0001  ; xm1    _      _     (5 1 7 3) (5 1 7 3)
+    vpaddd            %1, %1, %2     ;                               (01234567)
+%endmacro
+
+%macro INIT_OFFSET 6 ; src1, src2, dxq, dyq, off1, off2
+
+    sub             %3, 2
+    sub             %4, 2
+
+    mov             %5, 2
+    mov             %6, 2
+
+    add             %5, %4   
+    sub             %6, %4
+
+    imul            %5, 128
+    imul            %6, 128
+
+    add             %5, 2
+    add             %6, 2
+    
+    add             %5, %3
+    sub             %6, %3
+
+    lea             %1, [%1 + %5 * 2]
+    lea             %2, [%2 + %6 * 2]
+
+%endmacro
+
+
+INIT_YMM avx2
+; technically not valid since 8x8 = 64 < 128 8x16 is valid though
+cglobal vvc_sad_8_16bpc, 6, 8, 13, src1, src2, dx, dy, block_w, block_h, off1, off2
+
+    INIT_OFFSET src1q, src2q, dxq, dyq, off1q, off2q
+    pxor               m3, m3
+
+    .loop_height:
+        movu              xm0, [src1q]
+        movu              xm1, [src2q]
+        MIN_MAX_SAD xm2, xm0, xm1
+        vpmovzxwd          m1, xm1
+        vpaddd             m3, m1
+
+        movu              xm5, [src1q + 128 * 2 * 2]
+        movu              xm6, [src2q + 128 * 2 * 2]
+        MIN_MAX_SAD xm7, xm5, xm6
+        vpmovzxwd          m6, xm6
+        vpaddd             m3, m6
+
+        movu              xm8, [src1q + 128 * 4 * 2]
+        movu              xm9, [src2q + 128 * 4 * 2]
+        MIN_MAX_SAD xm10, xm8, xm9
+        vpmovzxwd          m9, xm9
+        vpaddd             m3, m9
+
+        movu              xm11, [src1q + 128 * 6 * 2]
+        movu              xm12, [src2q + 128 * 6 * 2]
+        MIN_MAX_SAD       xm13, xm11, xm12
+        vpmovzxwd          m12, xm12
+
+        vpaddd              m3, m12
+
+        add             src1q, 8 * 128 * 2 
+        add             src2q, 8 * 128 * 2
+
+        sub          block_hd, 8
+        jg  .loop_height
+
+        HORIZONTAL_ADD xm0, xm3, m3
+        movd              eax, xm0
+    RET
+
+
+cglobal vvc_sad_16_16bpc, 6, 9, 13, src1, src2, dx, dy, block_w, block_h, off1, off2, sad
+    INIT_OFFSET src1q, src2q, dxq, dyq, off1q, off2q
+    pxor               m8, m8
+.load_pixels:
+        movu              xm0, [src1q]
+        movu              xm1, [src2q]
+        MIN_MAX_SAD       xm2, xm0, xm1
+        vpmovzxwd          m1, xm1
+        vpaddd             m8, m1
+
+        movu              xm5, [src1q + 16]
+        movu              xm6, [src2q + 16]
+        MIN_MAX_SAD       xm7, xm5, xm6
+        vpmovzxwd          m6, xm6
+        vpaddd             m8, m6
+
+        add             src1q, (2 * 128) * 2 
+        add             src2q, (2 * 128) * 2
+
+        sub  block_hd, 2
+        jg  .load_pixels
+
+        HORIZONTAL_ADD xm0, xm8, m8
+        movd              eax, xm0
+
+    RET
+
+cglobal vvc_sad_32_16bpc, 6, 9, 13, src1, src2, dx, dy, block_w, block_h, off1, off2, row_idx
+    INIT_OFFSET src1q, src2q, dxq, dyq, off1q, off2q
+    pxor                 m3, m3
+
+.loop_height:
+
+    mov               off1q, src1q
+    mov               off2q, src2q
+
+    .loop_row:
+        movu              xm0, [src1q]
+        movu              xm1, [src2q]
+        MIN_MAX_SAD       xm2, xm0, xm1
+        vpmovzxwd          m1, xm1
+        vpaddd             m3, m1
+
+        movu              xm5, [src1q + 16]
+        movu              xm6, [src2q + 16]
+        MIN_MAX_SAD       xm7, xm5, xm6
+        vpmovzxwd          m6, xm6
+        vpaddd             m3, m6
+
+        movu              xm8, [src1q + 32]
+        movu              xm9, [src2q + 32]
+        MIN_MAX_SAD       xm10, xm8, xm9
+        vpmovzxwd          m9, xm9
+        vpaddd             m3, m9
+
+        movu              xm11, [src1q + 48]
+        movu              xm12, [src2q + 48]
+        MIN_MAX_SAD       xm13, xm11, xm12
+        vpmovzxwd          m12, xm12
+        vpaddd             m3, m12
+
+    lea             src1q, [off1q + 2 * 128 * 2] 
+    lea             src2q, [off2q + 2 * 128 * 2]
+
+    sub block_hq, 2
+    jg .loop_height
+
+    HORIZONTAL_ADD xm0, xm3, m3
+    movd              eax, xm0
+
+    RET
+
+cglobal vvc_sad_64_16bpc, 6, 9, 13, src1, src2, dx, dy, block_w, block_h, off1, off2, row_idx
+    INIT_OFFSET src1q, src2q, dxq, dyq, off1q, off2q
+    pxor                 m3, m3
+
+.loop_height:
+
+    mov               off1q, src1q
+    mov               off2q, src2q
+    mov            row_idxd, 2
+
+    .loop_row:
+        movu              xm0, [src1q]
+        movu              xm1, [src2q]
+        MIN_MAX_SAD       xm2, xm0, xm1
+        vpmovzxwd          m1, xm1
+        vpaddd             m3, m1
+
+        movu              xm5, [src1q + 16]
+        movu              xm6, [src2q + 16]
+        MIN_MAX_SAD       xm7, xm5, xm6
+        vpmovzxwd          m6, xm6
+        vpaddd             m3, m6
+
+        movu              xm8, [src1q + 32]
+        movu              xm9, [src2q + 32]
+        MIN_MAX_SAD      xm10, xm8, xm9
+        vpmovzxwd          m9, xm9
+        vpaddd             m3, m9
+
+        movu              xm11, [src1q + 48]
+        movu              xm12, [src2q + 48]
+        MIN_MAX_SAD       xm13, xm11, xm12
+        vpmovzxwd          m12, xm12
+        vpaddd              m3, m12
+
+        add              src1q, 64
+        add              src2q, 64
+        dec           row_idxd
+        jg  .loop_row
+
+    lea             src1q, [off1q + 2 * 128 * 2] 
+    lea             src2q, [off2q + 2 * 128 * 2]
+
+    sub block_hq, 2
+    jg .loop_height
+
+    HORIZONTAL_ADD xm0, xm3, m3
+    movd              eax, xm0
+
+    RET
+
+cglobal vvc_sad_128_16bpc, 6, 9, 13, src1, src2, dx, dy, block_w, block_h, off1, off2, row_idx
+    INIT_OFFSET src1q, src2q, dxq, dyq, off1q, off2q
+    pxor                 m3, m3
+.loop_height:
+
+    mov               off1q, src1q
+    mov               off2q, src2q
+    mov            row_idxd, 4
+
+    .loop_row:
+        movu              xm0, [src1q]
+        movu              xm1, [src2q]
+        MIN_MAX_SAD       xm2, xm0, xm1
+        vpmovzxwd          m1, xm1
+        vpaddd             m3, m1
+
+        movu              xm5, [src1q + 16]
+        movu              xm6, [src2q + 16]
+        MIN_MAX_SAD       xm7, xm5, xm6
+        vpmovzxwd          m6, xm6
+        vpaddd             m3, m6
+
+        movu              xm8, [src1q + 32]
+        movu              xm9, [src2q + 32]
+        MIN_MAX_SAD       xm10, xm8, xm9
+        vpmovzxwd          m9, xm9
+        vpaddd             m3, m9
+
+        movu              xm11, [src1q + 48]
+        movu              xm12, [src2q + 48]
+        MIN_MAX_SAD       xm13, xm11, xm12
+        vpmovzxwd          m12, xm12
+        vpaddd             m3, m12
+
+        add             src1q, 64
+        add             src2q, 64
+        dec          row_idxd
+        jg  .loop_row
+
+    lea             src1q, [off1q + 2 * 128 * 2] 
+    lea             src2q, [off2q + 2 * 128 * 2]
+
+    sub block_hq, 2
+    jg .loop_height
+
+    HORIZONTAL_ADD    xm0, xm3, m3
+    movd              eax, xm0
+
+    RET

--- a/libavcodec/x86/vvc/vvc_sao.asm
+++ b/libavcodec/x86/vvc/vvc_sao.asm
@@ -1,0 +1,331 @@
+;******************************************************************************
+;* SIMD optimized SAO functions for VVC 8bit decoding
+;*
+;* Copyright (c) 2013 Pierre-Edouard LEPERE
+;* Copyright (c) 2014 James Almer
+;* Copyright (c) 2023 Shaun Loo
+;*
+;* This file is part of FFmpeg.
+;*
+;* FFmpeg is free software; you can redistribute it and/or
+;* modify it under the terms of the GNU Lesser General Public
+;* License as published by the Free Software Foundation; either
+;* version 2.1 of the License, or (at your option) any later version.
+;*
+;* FFmpeg is distributed in the hope that it will be useful,
+;* but WITHOUT ANY WARRANTY; without even the implied warranty of
+;* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;* Lesser General Public License for more details.
+;*
+;* You should have received a copy of the GNU Lesser General Public
+;* License along with FFmpeg; if not, write to the Free Software
+;* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+;******************************************************************************
+
+%include "libavutil/x86/x86util.asm"
+
+SECTION_RODATA 32
+
+pb_edge_shuffle: times 2 db 1, 2, 0, 3, 4, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+pb_eo:                   db -1, 0, 1, 0, 0, -1, 0, 1, -1, -1, 1, 1, 1, -1, -1, 1
+cextern pb_1
+cextern pb_2
+
+SECTION .text
+
+;******************************************************************************
+;SAO Band Filter
+;******************************************************************************
+
+%macro VVC_SAO_BAND_FILTER_INIT 0
+    and            leftq, 31
+    movd             xm0, leftd
+    add            leftq, 1
+    and            leftq, 31
+    movd             xm1, leftd
+    add            leftq, 1
+    and            leftq, 31
+    movd             xm2, leftd
+    add            leftq, 1
+    and            leftq, 31
+    movd             xm3, leftd
+
+    SPLATW            m0, xm0
+    SPLATW            m1, xm1
+    SPLATW            m2, xm2
+    SPLATW            m3, xm3
+%if mmsize > 16
+    SPLATW            m4, [offsetq + 2]
+    SPLATW            m5, [offsetq + 4]
+    SPLATW            m6, [offsetq + 6]
+    SPLATW            m7, [offsetq + 8]
+%else
+    movq              m7, [offsetq + 2]
+    SPLATW            m4, m7, 0
+    SPLATW            m5, m7, 1
+    SPLATW            m6, m7, 2
+    SPLATW            m7, m7, 3
+%endif
+
+%if ARCH_X86_64
+    pxor             m14, m14
+
+%else ; ARCH_X86_32
+    mova  [rsp+mmsize*0], m0
+    mova  [rsp+mmsize*1], m1
+    mova  [rsp+mmsize*2], m2
+    mova  [rsp+mmsize*3], m3
+    mova  [rsp+mmsize*4], m4
+    mova  [rsp+mmsize*5], m5
+    mova  [rsp+mmsize*6], m6
+    pxor              m0, m0
+    %assign MMSIZE mmsize
+    %define m14 m0
+    %define m13 m1
+    %define  m9 m2
+    %define  m8 m3
+%endif ; ARCH
+DEFINE_ARGS dst, src, dststride, srcstride, offset, height
+    mov          heightd, r7m
+%endmacro
+
+%macro VVC_SAO_BAND_FILTER_COMPUTE 2
+    psraw             %1, %2, 3
+%if ARCH_X86_64
+    pcmpeqw          m10, %1, m0
+    pcmpeqw          m11, %1, m1
+    pcmpeqw          m12, %1, m2
+    pcmpeqw           %1, m3
+    pand             m10, m4
+    pand             m11, m5
+    pand             m12, m6
+    pand              %1, m7
+    por              m10, m11
+    por              m12, %1
+    por              m10, m12
+    paddw             %2, m10
+%else ; ARCH_X86_32
+    pcmpeqw           m4, %1, [rsp+MMSIZE*0]
+    pcmpeqw           m5, %1, [rsp+MMSIZE*1]
+    pcmpeqw           m6, %1, [rsp+MMSIZE*2]
+    pcmpeqw           %1, [rsp+MMSIZE*3]
+    pand              m4, [rsp+MMSIZE*4]
+    pand              m5, [rsp+MMSIZE*5]
+    pand              m6, [rsp+MMSIZE*6]
+    pand              %1, m7
+    por               m4, m5
+    por               m6, %1
+    por               m4, m6
+    paddw             %2, m4
+%endif ; ARCH
+%endmacro
+
+;void ff_vvc_sao_band_filter_<width>_8_<opt>(uint8_t *_dst, const uint8_t *_src, ptrdiff_t _stride_dst, ptrdiff_t _stride_src,
+;                                             int16_t *sao_offset_val, int sao_left_class, int width, int height);
+%macro VVC_SAO_BAND_FILTER 2
+cglobal vvc_sao_band_filter_%1_8, 6, 6, 15, 7*mmsize*ARCH_X86_32, dst, src, dststride, srcstride, offset, left
+    VVC_SAO_BAND_FILTER_INIT
+
+align 16
+.loop:
+%if %1 == 8
+    movq              m8, [srcq]
+    punpcklbw         m8, m14
+    VVC_SAO_BAND_FILTER_COMPUTE m9, m8
+    packuswb          m8, m14
+    movq          [dstq], m8
+%endif ; %1 == 8
+
+%assign i 0
+%rep %2
+    mova             m13, [srcq + i]
+    punpcklbw         m8, m13, m14
+    VVC_SAO_BAND_FILTER_COMPUTE m9,  m8
+    punpckhbw        m13, m14
+    VVC_SAO_BAND_FILTER_COMPUTE m9, m13
+    packuswb          m8, m13
+    mova      [dstq + i], m8
+%assign i i+mmsize
+%endrep
+
+%if %1 == 48
+INIT_XMM cpuname
+
+    mova             m13, [srcq + i]
+    punpcklbw         m8, m13, m14
+    VVC_SAO_BAND_FILTER_COMPUTE m9,  m8
+    punpckhbw        m13, m14
+    VVC_SAO_BAND_FILTER_COMPUTE m9, m13
+    packuswb          m8, m13
+    mova      [dstq + i], m8
+%if cpuflag(avx2)
+INIT_YMM cpuname
+%endif
+%endif ; %1 == 48
+
+    add             dstq, dststrideq             ; dst += dststride
+    add             srcq, srcstrideq             ; src += srcstride
+    dec          heightd                         ; cmp height
+    jnz               .loop                      ; height loop
+    REP_RET
+%endmacro
+
+%if HAVE_AVX2_EXTERNAL
+INIT_XMM avx2
+VVC_SAO_BAND_FILTER  8, 0
+VVC_SAO_BAND_FILTER 16, 1
+INIT_YMM avx2
+VVC_SAO_BAND_FILTER 32,  1
+VVC_SAO_BAND_FILTER 48,  1
+VVC_SAO_BAND_FILTER 64,  2
+VVC_SAO_BAND_FILTER 80,  3
+VVC_SAO_BAND_FILTER 96,  3
+VVC_SAO_BAND_FILTER 112, 4
+VVC_SAO_BAND_FILTER 128, 4
+%endif
+
+;******************************************************************************
+;SAO Edge Filter
+;******************************************************************************
+
+%define MAX_PB_SIZE  128
+%define PADDING_SIZE 64 ; AV_INPUT_BUFFER_PADDING_SIZE
+%define EDGE_SRCSTRIDE 2 * MAX_PB_SIZE + PADDING_SIZE
+
+%macro VVC_SAO_EDGE_FILTER_INIT 0
+%if WIN64
+    movsxd           eoq, dword eom
+%elif ARCH_X86_64
+    movsxd           eoq, eod
+%else
+    mov              eoq, r4m
+%endif
+    lea            tmp2q, [pb_eo]
+    movsx      a_strideq, byte [tmp2q+eoq*4+1]
+    movsx      b_strideq, byte [tmp2q+eoq*4+3]
+    imul       a_strideq, EDGE_SRCSTRIDE
+    imul       b_strideq, EDGE_SRCSTRIDE
+    movsx           tmpq, byte [tmp2q+eoq*4]
+    add        a_strideq, tmpq
+    movsx           tmpq, byte [tmp2q+eoq*4+2]
+    add        b_strideq, tmpq
+%endmacro
+
+%macro VVC_SAO_EDGE_FILTER_COMPUTE 1
+    pminub            m4, m1, m2
+    pminub            m5, m1, m3
+    pcmpeqb           m2, m4
+    pcmpeqb           m3, m5
+    pcmpeqb           m4, m1
+    pcmpeqb           m5, m1
+    psubb             m4, m2
+    psubb             m5, m3
+    paddb             m4, m6
+    paddb             m4, m5
+
+    pshufb            m2, m0, m4
+%if %1 > 8
+    punpckhbw         m5, m7, m1
+    punpckhbw         m4, m2, m7
+    punpcklbw         m3, m7, m1
+    punpcklbw         m2, m7
+    pmaddubsw         m5, m4
+    pmaddubsw         m3, m2
+    packuswb          m3, m5
+%else
+    punpcklbw         m3, m7, m1
+    punpcklbw         m2, m7
+    pmaddubsw         m3, m2
+    packuswb          m3, m3
+%endif
+%endmacro
+
+;void ff_vvc_sao_edge_filter_<width>_8_<opt>(uint8_t *_dst, uint8_t *_src, ptrdiff_t stride_dst, int16_t *sao_offset_val,
+;                                             int eo, int width, int height);
+%macro VVC_SAO_EDGE_FILTER 2-3
+%if ARCH_X86_64
+cglobal vvc_sao_edge_filter_%1_8, 4, 9, 8, dst, src, dststride, offset, eo, a_stride, b_stride, height, tmp
+%define tmp2q heightq
+    VVC_SAO_EDGE_FILTER_INIT
+    mov          heightd, r6m
+
+%else ; ARCH_X86_32
+cglobal vvc_sao_edge_filter_%1_8, 1, 6, 8, dst, src, dststride, a_stride, b_stride, height
+%define eoq   srcq
+%define tmpq  heightq
+%define tmp2q dststrideq
+%define offsetq heightq
+    VVC_SAO_EDGE_FILTER_INIT
+    mov             srcq, srcm
+    mov          offsetq, r3m
+    mov       dststrideq, dststridem
+%endif ; ARCH
+
+%if mmsize > 16
+    vbroadcasti128    m0, [offsetq]
+%else
+    movu              m0, [offsetq]
+%endif
+    mova              m1, [pb_edge_shuffle]
+    packsswb          m0, m0
+    mova              m7, [pb_1]
+    pshufb            m0, m1
+    mova              m6, [pb_2]
+%if ARCH_X86_32
+    mov          heightd, r6m
+%endif
+
+align 16
+.loop:
+
+%if %1 == 8
+    movq              m1, [srcq]
+    movq              m2, [srcq + a_strideq]
+    movq              m3, [srcq + b_strideq]
+    VVC_SAO_EDGE_FILTER_COMPUTE %1
+    movq          [dstq], m3
+%endif
+
+%assign i 0
+%rep %2
+    mova              m1, [srcq + i]
+    movu              m2, [srcq + a_strideq + i]
+    movu              m3, [srcq + b_strideq + i]
+    VVC_SAO_EDGE_FILTER_COMPUTE %1
+    mov%3     [dstq + i], m3
+%assign i i+mmsize
+%endrep
+
+%if %1 == 48
+INIT_XMM cpuname
+
+    mova              m1, [srcq + i]
+    movu              m2, [srcq + a_strideq + i]
+    movu              m3, [srcq + b_strideq + i]
+    VVC_SAO_EDGE_FILTER_COMPUTE %1
+    mova      [dstq + i], m3
+%if cpuflag(avx2)
+INIT_YMM cpuname
+%endif
+%endif
+
+    add             dstq, dststrideq
+    add             srcq, EDGE_SRCSTRIDE
+    dec          heightd
+    jg .loop
+    RET
+%endmacro
+
+%if HAVE_AVX2_EXTERNAL
+INIT_XMM avx2
+VVC_SAO_EDGE_FILTER  8, 0
+INIT_YMM avx2
+VVC_SAO_EDGE_FILTER 16, 1, u
+VVC_SAO_EDGE_FILTER 32, 1, a
+VVC_SAO_EDGE_FILTER 48, 1, u
+VVC_SAO_EDGE_FILTER 64, 2, a
+VVC_SAO_EDGE_FILTER 80, 3, u
+VVC_SAO_EDGE_FILTER 96, 3, u
+VVC_SAO_EDGE_FILTER 112, 4, u
+VVC_SAO_EDGE_FILTER 128, 4, a
+%endif

--- a/libavcodec/x86/vvc/vvc_sao_10bit.asm
+++ b/libavcodec/x86/vvc/vvc_sao_10bit.asm
@@ -1,0 +1,355 @@
+;******************************************************************************
+;* SIMD optimized SAO functions for VVC 10/12bit decoding
+;*
+;* Copyright (c) 2013 Pierre-Edouard LEPERE
+;* Copyright (c) 2014 James Almer
+;* Copyright (c) 2023 Shaun Loo
+;*
+;* This file is part of FFmpeg.
+;*
+;* FFmpeg is free software; you can redistribute it and/or
+;* modify it under the terms of the GNU Lesser General Public
+;* License as published by the Free Software Foundation; either
+;* version 2.1 of the License, or (at your option) any later version.
+;*
+;* FFmpeg is distributed in the hope that it will be useful,
+;* but WITHOUT ANY WARRANTY; without even the implied warranty of
+;* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;* Lesser General Public License for more details.
+;*
+;* You should have received a copy of the GNU Lesser General Public
+;* License along with FFmpeg; if not, write to the Free Software
+;* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+;******************************************************************************
+
+%include "libavutil/x86/x86util.asm"
+
+SECTION_RODATA 32
+
+pw_m2:     times 16 dw -2
+pw_mask10: times 16 dw 0x03FF
+pw_mask12: times 16 dw 0x0FFF
+pb_eo:              db -1, 0, 1, 0, 0, -1, 0, 1, -1, -1, 1, 1, 1, -1, -1, 1
+cextern pw_m1
+cextern pw_1
+cextern pw_2
+
+SECTION .text
+
+;******************************************************************************
+;SAO Band Filter
+;******************************************************************************
+
+%macro VVC_SAO_BAND_FILTER_INIT 1
+    and            leftq, 31
+    movd             xm0, leftd
+    add            leftq, 1
+    and            leftq, 31
+    movd             xm1, leftd
+    add            leftq, 1
+    and            leftq, 31
+    movd             xm2, leftd
+    add            leftq, 1
+    and            leftq, 31
+    movd             xm3, leftd
+
+    SPLATW            m0, xm0
+    SPLATW            m1, xm1
+    SPLATW            m2, xm2
+    SPLATW            m3, xm3
+%if mmsize > 16
+    SPLATW            m4, [offsetq + 2]
+    SPLATW            m5, [offsetq + 4]
+    SPLATW            m6, [offsetq + 6]
+    SPLATW            m7, [offsetq + 8]
+%else
+    movq              m7, [offsetq + 2]
+    SPLATW            m4, m7, 0
+    SPLATW            m5, m7, 1
+    SPLATW            m6, m7, 2
+    SPLATW            m7, m7, 3
+%endif
+
+%if ARCH_X86_64
+    mova             m13, [pw_mask %+ %1]
+    pxor             m14, m14
+
+%else ; ARCH_X86_32
+    mova  [rsp+mmsize*0], m0
+    mova  [rsp+mmsize*1], m1
+    mova  [rsp+mmsize*2], m2
+    mova  [rsp+mmsize*3], m3
+    mova  [rsp+mmsize*4], m4
+    mova  [rsp+mmsize*5], m5
+    mova  [rsp+mmsize*6], m6
+    mova              m1, [pw_mask %+ %1]
+    pxor              m0, m0
+    %define m14 m0
+    %define m13 m1
+    %define  m9 m2
+    %define  m8 m3
+%endif ; ARCH
+DEFINE_ARGS dst, src, dststride, srcstride, offset, height
+    mov          heightd, r7m
+%endmacro
+
+;void ff_vvc_sao_band_filter_<width>_<depth>_<opt>(uint8_t *_dst, const uint8_t *_src, ptrdiff_t _stride_dst, ptrdiff_t _stride_src,
+;                                                   int16_t *sao_offset_val, int sao_left_class, int width, int height);
+%macro VVC_SAO_BAND_FILTER 3
+cglobal vvc_sao_band_filter_%2_%1, 6, 6, 15, 7*mmsize*ARCH_X86_32, dst, src, dststride, srcstride, offset, left
+    VVC_SAO_BAND_FILTER_INIT %1
+
+align 16
+.loop:
+
+%assign i 0
+%assign j 0
+%rep %3
+%assign k 8+(j&1)
+%assign l 9-(j&1)
+    mova          m %+ k, [srcq + i]
+    psraw         m %+ l, m %+ k, %1-5
+%if ARCH_X86_64
+    pcmpeqw          m10, m %+ l, m0
+    pcmpeqw          m11, m %+ l, m1
+    pcmpeqw          m12, m %+ l, m2
+    pcmpeqw       m %+ l, m3
+    pand             m10, m4
+    pand             m11, m5
+    pand             m12, m6
+    pand          m %+ l, m7
+    por              m10, m11
+    por              m12, m %+ l
+    por              m10, m12
+    paddw         m %+ k, m10
+%else ; ARCH_X86_32
+    pcmpeqw           m4, m %+ l, [rsp+mmsize*0]
+    pcmpeqw           m5, m %+ l, [rsp+mmsize*1]
+    pcmpeqw           m6, m %+ l, [rsp+mmsize*2]
+    pcmpeqw       m %+ l, [rsp+mmsize*3]
+    pand              m4, [rsp+mmsize*4]
+    pand              m5, [rsp+mmsize*5]
+    pand              m6, [rsp+mmsize*6]
+    pand          m %+ l, m7
+    por               m4, m5
+    por               m6, m %+ l
+    por               m4, m6
+    paddw         m %+ k, m4
+%endif ; ARCH
+    CLIPW             m %+ k, m14, m13
+    mova      [dstq + i], m %+ k
+%assign i i+mmsize
+%assign j j+1
+%endrep
+
+    add             dstq, dststrideq
+    add             srcq, srcstrideq
+    dec          heightd
+    jg .loop
+    REP_RET
+%endmacro
+
+%if HAVE_AVX2_EXTERNAL
+INIT_XMM avx2
+VVC_SAO_BAND_FILTER 10,  8, 1
+INIT_YMM avx2
+VVC_SAO_BAND_FILTER 10, 16,  1
+VVC_SAO_BAND_FILTER 10, 32,  2
+VVC_SAO_BAND_FILTER 10, 48,  3
+VVC_SAO_BAND_FILTER 10, 64,  4
+VVC_SAO_BAND_FILTER 10, 80,  5
+VVC_SAO_BAND_FILTER 10, 96,  6
+VVC_SAO_BAND_FILTER 10, 112, 7
+VVC_SAO_BAND_FILTER 10, 128, 8
+
+INIT_XMM avx2
+VVC_SAO_BAND_FILTER 12,  8, 1
+INIT_YMM avx2
+VVC_SAO_BAND_FILTER 12, 16, 1
+VVC_SAO_BAND_FILTER 12, 32, 2
+VVC_SAO_BAND_FILTER 12, 48, 3
+VVC_SAO_BAND_FILTER 12, 64, 4
+VVC_SAO_BAND_FILTER 12, 80, 5
+VVC_SAO_BAND_FILTER 12, 96,  6
+VVC_SAO_BAND_FILTER 12, 112, 7
+VVC_SAO_BAND_FILTER 12, 128, 8
+%endif
+
+;******************************************************************************
+;SAO Edge Filter
+;******************************************************************************
+
+%define MAX_PB_SIZE  128
+%define PADDING_SIZE 64 ; AV_INPUT_BUFFER_PADDING_SIZE
+%define EDGE_SRCSTRIDE 2 * MAX_PB_SIZE + PADDING_SIZE
+
+%macro PMINUW 4
+%if cpuflag(sse4)
+    pminuw            %1, %2, %3
+%else
+    psubusw           %4, %2, %3
+    psubw             %1, %2, %4
+%endif
+%endmacro
+
+%macro VVC_SAO_EDGE_FILTER_INIT 0
+%if WIN64
+    movsxd           eoq, dword eom
+%elif ARCH_X86_64
+    movsxd           eoq, eod
+%else
+    mov              eoq, r4m
+%endif
+    lea            tmp2q, [pb_eo]
+    movsx      a_strideq, byte [tmp2q+eoq*4+1]
+    movsx      b_strideq, byte [tmp2q+eoq*4+3]
+    imul       a_strideq, EDGE_SRCSTRIDE >> 1
+    imul       b_strideq, EDGE_SRCSTRIDE >> 1
+    movsx           tmpq, byte [tmp2q+eoq*4]
+    add        a_strideq, tmpq
+    movsx           tmpq, byte [tmp2q+eoq*4+2]
+    add        b_strideq, tmpq
+%endmacro
+
+;void ff_vvc_sao_edge_filter_<width>_<depth>_<opt>(uint8_t *_dst, uint8_t *_src, ptrdiff_t stride_dst, int16_t *sao_offset_val,
+;                                                   int eo, int width, int height);
+%macro VVC_SAO_EDGE_FILTER 3
+%if ARCH_X86_64
+cglobal vvc_sao_edge_filter_%2_%1, 4, 9, 16, dst, src, dststride, offset, eo, a_stride, b_stride, height, tmp
+%define tmp2q heightq
+    VVC_SAO_EDGE_FILTER_INIT
+    mov          heightd, r6m
+    add        a_strideq, a_strideq
+    add        b_strideq, b_strideq
+
+%else ; ARCH_X86_32
+cglobal vvc_sao_edge_filter_%2_%1, 1, 6, 8, 5*mmsize, dst, src, dststride, a_stride, b_stride, height
+%define eoq   srcq
+%define tmpq  heightq
+%define tmp2q dststrideq
+%define offsetq heightq
+%define m8 m1
+%define m9 m2
+%define m10 m3
+%define m11 m4
+%define m12 m5
+    VVC_SAO_EDGE_FILTER_INIT
+    mov             srcq, srcm
+    mov          offsetq, r3m
+    mov       dststrideq, dststridem
+    add        a_strideq, a_strideq
+    add        b_strideq, b_strideq
+
+%endif ; ARCH
+
+%if mmsize > 16
+    SPLATW            m8, [offsetq+2]
+    SPLATW            m9, [offsetq+4]
+    SPLATW           m10, [offsetq+0]
+    SPLATW           m11, [offsetq+6]
+    SPLATW           m12, [offsetq+8]
+%else
+    movq             m10, [offsetq+0]
+    movd             m12, [offsetq+6]
+    SPLATW            m8, xm10, 1
+    SPLATW            m9, xm10, 2
+    SPLATW           m10, xm10, 0
+    SPLATW           m11, xm12, 0
+    SPLATW           m12, xm12, 1
+%endif
+    pxor              m0, m0
+%if ARCH_X86_64
+    mova             m13, [pw_m1]
+    mova             m14, [pw_1]
+    mova             m15, [pw_2]
+%else
+    mov          heightd, r6m
+    mova  [rsp+mmsize*0], m8
+    mova  [rsp+mmsize*1], m9
+    mova  [rsp+mmsize*2], m10
+    mova  [rsp+mmsize*3], m11
+    mova  [rsp+mmsize*4], m12
+%endif
+
+align 16
+.loop:
+
+%assign i 0
+%rep %3
+    mova              m1, [srcq + i]
+    movu              m2, [srcq+a_strideq + i]
+    movu              m3, [srcq+b_strideq + i]
+    PMINUW            m4, m1, m2, m6
+    PMINUW            m5, m1, m3, m7
+    pcmpeqw           m2, m4
+    pcmpeqw           m3, m5
+    pcmpeqw           m4, m1
+    pcmpeqw           m5, m1
+    psubw             m4, m2
+    psubw             m5, m3
+
+    paddw             m4, m5
+    pcmpeqw           m2, m4, [pw_m2]
+%if ARCH_X86_64
+    pcmpeqw           m3, m4, m13
+    pcmpeqw           m5, m4, m0
+    pcmpeqw           m6, m4, m14
+    pcmpeqw           m7, m4, m15
+    pand              m2, m8
+    pand              m3, m9
+    pand              m5, m10
+    pand              m6, m11
+    pand              m7, m12
+%else
+    pcmpeqw           m3, m4, [pw_m1]
+    pcmpeqw           m5, m4, m0
+    pcmpeqw           m6, m4, [pw_1]
+    pcmpeqw           m7, m4, [pw_2]
+    pand              m2, [rsp+mmsize*0]
+    pand              m3, [rsp+mmsize*1]
+    pand              m5, [rsp+mmsize*2]
+    pand              m6, [rsp+mmsize*3]
+    pand              m7, [rsp+mmsize*4]
+%endif
+    paddw             m2, m3
+    paddw             m5, m6
+    paddw             m2, m7
+    paddw             m2, m1
+    paddw             m2, m5
+    CLIPW             m2, m0, [pw_mask %+ %1]
+    mova      [dstq + i], m2
+%assign i i+mmsize
+%endrep
+
+    add             dstq, dststrideq
+    add             srcq, EDGE_SRCSTRIDE
+    dec          heightd
+    jg .loop
+    RET
+%endmacro
+
+%if HAVE_AVX2_EXTERNAL
+INIT_XMM avx2
+VVC_SAO_EDGE_FILTER 10,  8, 1
+INIT_YMM avx2
+VVC_SAO_EDGE_FILTER 10, 16, 1
+VVC_SAO_EDGE_FILTER 10, 32, 2
+VVC_SAO_EDGE_FILTER 10, 48, 3
+VVC_SAO_EDGE_FILTER 10, 64, 4
+VVC_SAO_EDGE_FILTER 10, 80, 5
+VVC_SAO_EDGE_FILTER 10, 96, 6
+VVC_SAO_EDGE_FILTER 10, 112, 7
+VVC_SAO_EDGE_FILTER 10, 128, 8
+
+INIT_XMM avx2
+VVC_SAO_EDGE_FILTER 12,  8, 1
+INIT_YMM avx2
+VVC_SAO_EDGE_FILTER 12, 16, 1
+VVC_SAO_EDGE_FILTER 12, 32, 2
+VVC_SAO_EDGE_FILTER 12, 48, 3
+VVC_SAO_EDGE_FILTER 12, 64, 4
+VVC_SAO_EDGE_FILTER 12, 80, 5
+VVC_SAO_EDGE_FILTER 12, 96, 6
+VVC_SAO_EDGE_FILTER 12, 112, 7
+VVC_SAO_EDGE_FILTER 12, 128, 8
+%endif

--- a/libavcodec/x86/vvc/vvcdsp_init.c
+++ b/libavcodec/x86/vvc/vvcdsp_init.c
@@ -172,6 +172,92 @@ FW_PUT_16BPC_AVX2(12);
 #define bf(fn, bd,  opt) fn##_##bd##_##opt
 #define BF(fn, bpc, opt) fn##_##bpc##bpc_##opt
 
+#define ALF_BPC_FUNCS(bpc, opt)                                                                                         \
+void BF(ff_vvc_alf_filter_luma, bpc, opt)(uint8_t *dst, ptrdiff_t dst_stride,                                           \
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,                                        \
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t vb_pos, ptrdiff_t pixel_max);               \
+void BF(ff_vvc_alf_filter_chroma, bpc, opt)(uint8_t *dst, ptrdiff_t dst_stride,                                         \
+    const uint8_t *src, ptrdiff_t src_stride, ptrdiff_t width, ptrdiff_t height,                                        \
+    const int16_t *filter, const int16_t *clip, ptrdiff_t stride, ptrdiff_t vb_pos, ptrdiff_t pixel_max);               \
+void BF(ff_vvc_alf_classify_grad, bpc, opt)(int *gradient_sum,                                                          \
+    const uint8_t *src, ptrdiff_t src_stride, intptr_t width, intptr_t height, intptr_t vb_pos);                        \
+void BF(ff_vvc_alf_classify, bpc, opt)(int *class_idx, int *transpose_idx, const int *gradient_sum,                     \
+    intptr_t width, intptr_t height, intptr_t vb_pos, intptr_t bit_depth);                                              \
+
+#define ALF_FUNCS(bpc, bd, opt)                                                                                         \
+static void bf(alf_classify, bd, opt)(int *class_idx, int *transpose_idx,                                               \
+    const uint8_t *src, ptrdiff_t src_stride, int width, int height, int vb_pos, int *gradient_tmp)                     \
+{                                                                                                                       \
+    BF(ff_vvc_alf_classify_grad, bpc, opt)(gradient_tmp, src, src_stride, width, height, vb_pos);                       \
+    BF(ff_vvc_alf_classify, bpc, opt)(class_idx, transpose_idx, gradient_tmp, width, height, vb_pos, bd);               \
+}                                                                                                                       \
+static void bf(alf_filter_luma, bd, opt)(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,  \
+    int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)                                \
+{                                                                                                                       \
+    const int param_stride  = (width >> 2) * ALF_NUM_COEFF_LUMA;                                                        \
+    BF(ff_vvc_alf_filter_luma, bpc, opt)(dst, dst_stride, src, src_stride, width, height,                               \
+        filter, clip, param_stride, vb_pos, (1 << bd)  - 1);                                                            \
+}                                                                                                                       \
+static void bf(alf_filter_chroma, bd, opt)(uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,\
+    int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos)                                \
+{                                                                                                                       \
+    BF(ff_vvc_alf_filter_chroma, bpc, opt)(dst, dst_stride, src, src_stride, width, height,                             \
+        filter, clip, 0, vb_pos,(1 << bd)  - 1);                                                                        \
+}                                                                                                                       \
+
+ALF_BPC_FUNCS(8,  avx2)
+ALF_BPC_FUNCS(16, avx2)
+
+ALF_FUNCS(8,  8,  avx2)
+ALF_FUNCS(16, 10, avx2)
+ALF_FUNCS(16, 12, avx2)
+
+#define ALF_INIT(bd) do {                                                       \
+        c->alf.filter[LUMA] = alf_filter_luma_##bd##_avx2;                      \
+        c->alf.filter[CHROMA] = alf_filter_chroma_##bd##_avx2;                  \
+        c->alf.classify = alf_classify_##bd##_avx2;                             \
+    } while (0)
+
+#define SAO_FILTER_FUNCS(w, bd, opt)                                                  \
+void ff_vvc_sao_band_filter_##w##_##bd##_##opt(                                       \
+    uint8_t *_dst, const uint8_t *_src, ptrdiff_t _stride_dst, ptrdiff_t _stride_src, \
+    const int16_t *sao_offset_val, int sao_left_class, int width, int height);        \
+void ff_vvc_sao_edge_filter_##w##_##bd##_##opt(                                       \
+    uint8_t *_dst, const uint8_t *_src, ptrdiff_t stride_dst,                         \
+    const int16_t *sao_offset_val, int eo, int width, int height);                    \
+
+#define SAO_FUNCS(bd, opt)                                                            \
+    SAO_FILTER_FUNCS(8,   bd, opt)                                                    \
+    SAO_FILTER_FUNCS(16,  bd, opt)                                                    \
+    SAO_FILTER_FUNCS(32,  bd, opt)                                                    \
+    SAO_FILTER_FUNCS(48,  bd, opt)                                                    \
+    SAO_FILTER_FUNCS(64,  bd, opt)                                                    \
+    SAO_FILTER_FUNCS(80,  bd, opt)                                                    \
+    SAO_FILTER_FUNCS(96,  bd, opt)                                                    \
+    SAO_FILTER_FUNCS(112, bd, opt)                                                    \
+    SAO_FILTER_FUNCS(128, bd, opt)                                                    \
+
+SAO_FUNCS(8,  avx2)
+SAO_FUNCS(10, avx2)
+SAO_FUNCS(12, avx2)
+
+#define SAO_FILTER_INIT(type, bd, opt) do {                                       \
+    c->sao.type##_filter[0]       = ff_vvc_sao_##type##_filter_8_##bd##_##opt;    \
+    c->sao.type##_filter[1]       = ff_vvc_sao_##type##_filter_16_##bd##_##opt;   \
+    c->sao.type##_filter[2]       = ff_vvc_sao_##type##_filter_32_##bd##_##opt;   \
+    c->sao.type##_filter[3]       = ff_vvc_sao_##type##_filter_48_##bd##_##opt;   \
+    c->sao.type##_filter[4]       = ff_vvc_sao_##type##_filter_64_##bd##_##opt;   \
+    c->sao.type##_filter[5]       = ff_vvc_sao_##type##_filter_80_##bd##_##opt;   \
+    c->sao.type##_filter[6]       = ff_vvc_sao_##type##_filter_96_##bd##_##opt;   \
+    c->sao.type##_filter[7]       = ff_vvc_sao_##type##_filter_112_##bd##_##opt;  \
+    c->sao.type##_filter[8]       = ff_vvc_sao_##type##_filter_128_##bd##_##opt;  \
+} while (0)
+
+#define SAO_INIT(bd, opt) do {                                                    \
+    SAO_FILTER_INIT(edge, bd, opt);                                               \
+    SAO_FILTER_INIT(band, bd, opt);                                               \
+} while (0)
+
 #define AVG_BPC_FUNC(bpc, opt)                                                                      \
 void BF(ff_vvc_avg, bpc, opt)(uint8_t *dst, ptrdiff_t dst_stride,                                   \
     const int16_t *src0, const int16_t *src1, intptr_t width, intptr_t height, intptr_t pixel_max); \
@@ -238,14 +324,35 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
         if (EXTERNAL_AVX2(cpu_flags)) {
             switch (bd) {
                 case 8:
+                ALF_INIT(8);
                     AVG_INIT(8, avx2);
+                c->sao.band_filter[0] = ff_vvc_sao_band_filter_8_8_avx2;
+                c->sao.band_filter[1] = ff_vvc_sao_band_filter_16_8_avx2;
                     break;
                 case 10:
+                ALF_INIT(10);
                     AVG_INIT(10, avx2);
+                c->sao.band_filter[0] = ff_vvc_sao_band_filter_8_10_avx2;
                     break;
                 case 12:
+                ALF_INIT(12);
                     AVG_INIT(12, avx2);
                     break;
+                default:
+                    break;
+            }
+        }
+
+        if (EXTERNAL_AVX2_FAST(cpu_flags)) {
+            switch (bd) {
+                case 8:
+                    SAO_INIT(8, avx2);
+                    break;
+                case 10:
+                    SAO_INIT(10, avx2);
+                    break;
+                case 12:
+                    SAO_INIT(12, avx2);
                 default:
                     break;
             }

--- a/libavcodec/x86/vvc/vvcdsp_init.c
+++ b/libavcodec/x86/vvc/vvcdsp_init.c
@@ -291,6 +291,20 @@ AVG_FUNCS(16, 12, avx2)
     c->inter.w_avg  = bf(w_avg, bd, opt);                               \
 } while (0)
 
+int ff_vvc_sad_8_16bpc_avx2(const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+int ff_vvc_sad_16_16bpc_avx2(const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+int ff_vvc_sad_128_16bpc_avx2(const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+int ff_vvc_sad_64_16bpc_avx2(const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+int ff_vvc_sad_32_16bpc_avx2(const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+
+#define SAD_INIT() do {                                                 \
+    c->inter.sad[1] = ff_vvc_sad_8_16bpc_avx2;                          \
+    c->inter.sad[2] = ff_vvc_sad_16_16bpc_avx2;                         \
+    c->inter.sad[3] = ff_vvc_sad_32_16bpc_avx2;                         \
+    c->inter.sad[4] = ff_vvc_sad_64_16bpc_avx2;                         \
+    c->inter.sad[5] = ff_vvc_sad_128_16bpc_avx2;                        \
+} while (0)
+
 void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
 {
     const int cpu_flags = av_get_cpu_flags();
@@ -326,17 +340,20 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
                 case 8:
                 ALF_INIT(8);
                     AVG_INIT(8, avx2);
-                c->sao.band_filter[0] = ff_vvc_sao_band_filter_8_8_avx2;
-                c->sao.band_filter[1] = ff_vvc_sao_band_filter_16_8_avx2;
+                    c->sao.band_filter[0] = ff_vvc_sao_band_filter_8_8_avx2;
+                    c->sao.band_filter[1] = ff_vvc_sao_band_filter_16_8_avx2;
+                    SAD_INIT();
                     break;
                 case 10:
                 ALF_INIT(10);
                     AVG_INIT(10, avx2);
-                c->sao.band_filter[0] = ff_vvc_sao_band_filter_8_10_avx2;
+                    c->sao.band_filter[0] = ff_vvc_sao_band_filter_8_10_avx2;
+                    SAD_INIT();
                     break;
                 case 12:
                 ALF_INIT(12);
                     AVG_INIT(12, avx2);
+                    SAD_INIT();
                     break;
                 default:
                     break;
@@ -347,12 +364,15 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
             switch (bd) {
                 case 8:
                     SAO_INIT(8, avx2);
+                    SAD_INIT();
                     break;
                 case 10:
                     SAO_INIT(10, avx2);
+                    SAD_INIT();
                     break;
                 case 12:
                     SAO_INIT(12, avx2);
+                    SAD_INIT();
                 default:
                     break;
             }

--- a/libavcodec/x86/xvc_mc.asm
+++ b/libavcodec/x86/xvc_mc.asm
@@ -1,0 +1,990 @@
+; /*
+; * Provide SSE luma and chroma mc functions for HEVC/VVC decoding
+; * Copyright (c) 2013 Pierre-Edouard LEPERE
+; * Copyright (c) 2023 Nuo Mi
+; *
+; * This file is part of FFmpeg.
+; *
+; * FFmpeg is free software; you can redistribute it and/or
+; * modify it under the terms of the GNU Lesser General Public
+; * License as published by the Free Software Foundation; either
+; * version 2.1 of the License, or (at your option) any later version.
+; *
+; * FFmpeg is distributed in the hope that it will be useful,
+; * but WITHOUT ANY WARRANTY; without even the implied warranty of
+; * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+; * Lesser General Public License for more details.
+; *
+; * You should have received a copy of the GNU Lesser General Public
+; * License along with FFmpeg; if not, write to the Free Software
+; * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+; */
+%include "libavutil/x86/x86util.asm"
+
+SECTION_RODATA 32
+cextern pw_255
+cextern pw_512
+cextern pw_2048
+cextern pw_1023
+cextern pw_1024
+cextern pw_4096
+cextern pw_8192
+%define scale_8 pw_512
+%define scale_10 pw_2048
+%define scale_12 pw_8192
+%define max_pixels_8 pw_255
+%define max_pixels_10 pw_1023
+max_pixels_12:          times 16 dw ((1 << 12)-1)
+cextern pb_0
+
+SECTION .text
+%macro SIMPLE_LOAD 4    ;width, bitd, tab, r1
+%if %1 == 2 || (%2 == 8 && %1 <= 4)
+    movd              %4, [%3]                                               ; load data from source
+%elif %1 == 4 || (%2 == 8 && %1 <= 8)
+    movq              %4, [%3]                                               ; load data from source
+%elif notcpuflag(avx)
+    movu              %4, [%3]                                               ; load data from source
+%elif %1 <= 8 || (%2 == 8 && %1 <= 16)
+    movdqu           %4, [%3]
+%else
+    movu              %4, [%3]
+%endif
+%endmacro
+
+%macro MC_4TAP_FILTER 4 ; bitdepth, filter, a, b,
+    vpbroadcastw   %3, [%2q + 0 * 2]  ; coeff 0, 1
+    vpbroadcastw   %4, [%2q + 1 * 2]  ; coeff 2, 3
+%if %1 != 8
+    pmovsxbw       %3, xmm%3
+    pmovsxbw       %4, xmm%4
+%endif
+%endmacro
+
+%macro MC_4TAP_HV_FILTER 1
+    vpbroadcastw  m12, [vfq + 0 * 2]  ; vf 0, 1
+    vpbroadcastw  m13, [vfq + 1 * 2]  ; vf 2, 3
+    vpbroadcastw  m14, [hfq + 0 * 2]  ; hf 0, 1
+    vpbroadcastw  m15, [hfq + 1 * 2]  ; hf 2, 3
+
+    pmovsxbw      m12, xm12
+    pmovsxbw      m13, xm13
+%if %1 != 8
+    pmovsxbw      m14, xm14
+    pmovsxbw      m15, xm15
+%endif
+    lea           r3srcq, [srcstrideq*3]
+%endmacro
+
+%macro MC_8TAP_SAVE_FILTER 5    ;offset, mm registers
+    mova [rsp + %1 + 0*mmsize], %2
+    mova [rsp + %1 + 1*mmsize], %3
+    mova [rsp + %1 + 2*mmsize], %4
+    mova [rsp + %1 + 3*mmsize], %5
+%endmacro
+
+%macro MC_8TAP_FILTER 2-3 ;bitdepth, filter, offset
+    vpbroadcastw                      m12, [%2q + 0 * 2]  ; coeff 0, 1
+    vpbroadcastw                      m13, [%2q + 1 * 2]  ; coeff 2, 3
+    vpbroadcastw                      m14, [%2q + 2 * 2]  ; coeff 4, 5
+    vpbroadcastw                      m15, [%2q + 3 * 2]  ; coeff 6, 7
+%if %0 == 3
+    MC_8TAP_SAVE_FILTER                %3, m12, m13, m14, m15
+%endif
+
+%if %1 != 8
+    pmovsxbw                          m12, xm12
+    pmovsxbw                          m13, xm13
+    pmovsxbw                          m14, xm14
+    pmovsxbw                          m15, xm15
+    %if %0 == 3
+    MC_8TAP_SAVE_FILTER     %3 + 4*mmsize, m12, m13, m14, m15
+    %endif
+%elif %0 == 3
+    pmovsxbw                          m8, xm12
+    pmovsxbw                          m9, xm13
+    pmovsxbw                         m10, xm14
+    pmovsxbw                         m11, xm15
+    MC_8TAP_SAVE_FILTER     %3 + 4*mmsize, m8, m9, m10, m11
+%endif
+
+%endmacro
+
+%macro MC_4TAP_LOAD 4
+%if (%1 == 8 && %4 <= 4)
+%define %%load movd
+%elif (%1 == 8 && %4 <= 8) || (%1 > 8 && %4 <= 4)
+%define %%load movq
+%else
+%define %%load movdqu
+%endif
+
+    %%load            m0, [%2q ]
+%ifnum %3
+    %%load            m1, [%2q+  %3]
+    %%load            m2, [%2q+2*%3]
+    %%load            m3, [%2q+3*%3]
+%else
+    %%load            m1, [%2q+  %3q]
+    %%load            m2, [%2q+2*%3q]
+    %%load            m3, [%2q+r3srcq]
+%endif
+%if %1 == 8
+%if %4 > 8
+    SBUTTERFLY        bw, 0, 1, 7
+    SBUTTERFLY        bw, 2, 3, 7
+%else
+    punpcklbw         m0, m1
+    punpcklbw         m2, m3
+%endif
+%else
+%if %4 > 4
+    SBUTTERFLY        wd, 0, 1, 7
+    SBUTTERFLY        wd, 2, 3, 7
+%else
+    punpcklwd         m0, m1
+    punpcklwd         m2, m3
+%endif
+%endif
+%endmacro
+
+%macro MC_8TAP_H_LOAD 4
+%assign %%stride (%1+7)/8
+%if %1 == 8
+%if %3 <= 4
+%define %%load movd
+%elif %3 == 8
+%define %%load movq
+%else
+%define %%load movu
+%endif
+%else
+%if %3 == 2
+%define %%load movd
+%elif %3 == 4
+%define %%load movq
+%else
+%define %%load movu
+%endif
+%endif
+    %%load            m0, [%2-3*%%stride]        ;load data from source
+    %%load            m1, [%2-2*%%stride]
+    %%load            m2, [%2-%%stride  ]
+    %%load            m3, [%2           ]
+    %%load            m4, [%2+%%stride  ]
+    %%load            m5, [%2+2*%%stride]
+    %%load            m6, [%2+3*%%stride]
+    %%load            m7, [%2+4*%%stride]
+
+%if %1 == 8
+%if %3 > 8
+    SBUTTERFLY        wd, 0, 1, %4
+    SBUTTERFLY        wd, 2, 3, %4
+    SBUTTERFLY        wd, 4, 5, %4
+    SBUTTERFLY        wd, 6, 7, %4
+%else
+    punpcklbw         m0, m1
+    punpcklbw         m2, m3
+    punpcklbw         m4, m5
+    punpcklbw         m6, m7
+%endif
+%else
+%if %3 > 4
+    SBUTTERFLY        dq, 0, 1, %4
+    SBUTTERFLY        dq, 2, 3, %4
+    SBUTTERFLY        dq, 4, 5, %4
+    SBUTTERFLY        dq, 6, 7, %4
+%else
+    punpcklwd         m0, m1
+    punpcklwd         m2, m3
+    punpcklwd         m4, m5
+    punpcklwd         m6, m7
+%endif
+%endif
+%endmacro
+
+%macro MC_8TAP_V_LOAD 5
+    lea              %5q, [%2]
+    sub              %5q, r3srcq
+    movu              m0, [%5q            ]      ;load x- 3*srcstride
+    movu              m1, [%5q+   %3q     ]      ;load x- 2*srcstride
+    movu              m2, [%5q+ 2*%3q     ]      ;load x-srcstride
+    movu              m3, [%2       ]      ;load x
+    movu              m4, [%2+   %3q]      ;load x+stride
+    movu              m5, [%2+ 2*%3q]      ;load x+2*stride
+    movu              m6, [%2+r3srcq]      ;load x+3*stride
+    movu              m7, [%2+ 4*%3q]      ;load x+4*stride
+%if %1 == 8
+%if %4 > 8
+    SBUTTERFLY        bw, 0, 1, 8
+    SBUTTERFLY        bw, 2, 3, 8
+    SBUTTERFLY        bw, 4, 5, 8
+    SBUTTERFLY        bw, 6, 7, 8
+%else
+    punpcklbw         m0, m1
+    punpcklbw         m2, m3
+    punpcklbw         m4, m5
+    punpcklbw         m6, m7
+%endif
+%else
+%if %4 > 4
+    SBUTTERFLY        wd, 0, 1, 8
+    SBUTTERFLY        wd, 2, 3, 8
+    SBUTTERFLY        wd, 4, 5, 8
+    SBUTTERFLY        wd, 6, 7, 8
+%else
+    punpcklwd         m0, m1
+    punpcklwd         m2, m3
+    punpcklwd         m4, m5
+    punpcklwd         m6, m7
+%endif
+%endif
+%endmacro
+
+%macro PEL_12STORE2 3
+    movd           [%1], %2
+%endmacro
+%macro PEL_12STORE4 3
+    movq           [%1], %2
+%endmacro
+%macro PEL_12STORE8 3
+    movdqu         [%1], %2
+%endmacro
+%macro PEL_12STORE16 3
+%if cpuflag(avx2)
+    movu            [%1], %2
+%else
+    PEL_12STORE8      %1, %2, %3
+    movdqu       [%1+16], %3
+%endif
+%endmacro
+
+%macro PEL_10STORE2 3
+    movd           [%1], %2
+%endmacro
+%macro PEL_10STORE4 3
+    movq           [%1], %2
+%endmacro
+%macro PEL_10STORE8 3
+    movdqu         [%1], %2
+%endmacro
+%macro PEL_10STORE16 3
+%if cpuflag(avx2)
+    movu            [%1], %2
+%else
+    PEL_10STORE8      %1, %2, %3
+    movdqu       [%1+16], %3
+%endif
+%endmacro
+%macro PEL_10STORE32 3
+    PEL_10STORE16     %1, %2, %3
+    movu         [%1+32], %3
+%endmacro
+
+%macro PEL_8STORE2 3
+    pextrw          [%1], %2, 0
+%endmacro
+%macro PEL_8STORE4 3
+    movd            [%1], %2
+%endmacro
+%macro PEL_8STORE8 3
+    movq           [%1], %2
+%endmacro
+%macro PEL_8STORE16 3
+%if cpuflag(avx2)
+    movdqu        [%1], %2
+%else
+    movu          [%1], %2
+%endif ; avx
+%endmacro
+%macro PEL_8STORE32 3
+    movu          [%1], %2
+%endmacro
+
+%macro LOOP_END 3
+    add              %1q, 2*MAX_PB_SIZE          ; dst += dststride
+    add              %2q, %3q                    ; src += srcstride
+    dec          heightd                         ; cmp height
+    jnz               .loop                      ; height loop
+%endmacro
+
+
+%macro MC_PIXEL_COMPUTE 2-3 ;width, bitdepth
+%if %2 == 8
+%if cpuflag(avx2) && %0 ==3
+%if %1 > 16
+    vextracti128 xm1, m0, 1
+    pmovzxbw      m1, xm1
+    psllw         m1, 14-%2
+%endif
+    pmovzxbw      m0, xm0
+%else ; not avx
+%if %1 > 8
+    punpckhbw     m1, m0, m2
+    psllw         m1, 14-%2
+%endif
+    punpcklbw     m0, m2
+%endif
+%endif ;avx
+    psllw         m0, 14-%2
+%endmacro
+
+%macro MC_4TAP_COMPUTE 4-8 ; bitdepth, width, filter1, filter2, HV/m0, m2, m1, m3
+%if %0 == 8
+%define %%reg0 %5
+%define %%reg2 %6
+%define %%reg1 %7
+%define %%reg3 %8
+%else
+%define %%reg0 m0
+%define %%reg2 m2
+%define %%reg1 m1
+%define %%reg3 m3
+%endif
+%if %1 == 8
+%if cpuflag(avx2) && (%0 == 5)
+%if %2 > 16
+    vperm2i128    m10, m0, m1, q0301
+%endif
+    vinserti128    m0, m0, xm1, 1
+    mova           m1, m10
+%if %2 > 16
+    vperm2i128    m10, m2, m3, q0301
+%endif
+    vinserti128    m2, m2, xm3, 1
+    mova           m3, m10
+%endif
+    pmaddubsw      %%reg0, %3   ;x1*c1+x2*c2
+    pmaddubsw      %%reg2, %4   ;x3*c3+x4*c4
+    paddw          %%reg0, %%reg2
+%if %2 > 8
+    pmaddubsw      %%reg1, %3
+    pmaddubsw      %%reg3, %4
+    paddw          %%reg1, %%reg3
+%endif
+%else
+    pmaddwd        %%reg0, %3
+    pmaddwd        %%reg2, %4
+    paddd          %%reg0, %%reg2
+%if %2 > 4
+    pmaddwd        %%reg1, %3
+    pmaddwd        %%reg3, %4
+    paddd          %%reg1, %%reg3
+%if %1 != 8
+    psrad          %%reg1, %1-8
+%endif
+%endif
+%if %1 != 8
+    psrad          %%reg0, %1-8
+%endif
+    packssdw       %%reg0, %%reg1
+%endif
+%endmacro
+
+%macro MC_8TAP_HV_COMPUTE 4     ; width, bitdepth, filter
+
+%if %2 == 8
+    pmaddubsw         m0, [%3q+0*mmsize]    ;x1*c1+x2*c2
+    pmaddubsw         m2, [%3q+1*mmsize]    ;x3*c3+x4*c4
+    pmaddubsw         m4, [%3q+2*mmsize]    ;x5*c5+x6*c6
+    pmaddubsw         m6, [%3q+3*mmsize]    ;x7*c7+x8*c8
+    paddw             m0, m2
+    paddw             m4, m6
+    paddw             m0, m4
+%else
+    pmaddwd           m0, [%3q+4*mmsize]
+    pmaddwd           m2, [%3q+5*mmsize]
+    pmaddwd           m4, [%3q+6*mmsize]
+    pmaddwd           m6, [%3q+7*mmsize]
+    paddd             m0, m2
+    paddd             m4, m6
+    paddd             m0, m4
+%if %2 != 8
+    psrad             m0, %2-8
+%endif
+%if %1 > 4
+    pmaddwd           m1, [%3q+4*mmsize]
+    pmaddwd           m3, [%3q+5*mmsize]
+    pmaddwd           m5, [%3q+6*mmsize]
+    pmaddwd           m7, [%3q+7*mmsize]
+    paddd             m1, m3
+    paddd             m5, m7
+    paddd             m1, m5
+%if %2 != 8
+    psrad             m1, %2-8
+%endif
+%endif
+    p%4               m0, m1
+%endif
+%endmacro
+
+
+%macro MC_8TAP_COMPUTE 2-3     ; width, bitdepth
+%if %2 == 8
+%if cpuflag(avx2) && (%0 == 3)
+
+    vperm2i128 m10, m0,  m1, q0301
+    vinserti128 m0, m0, xm1, 1
+    SWAP 1, 10
+
+    vperm2i128 m10, m2,  m3, q0301
+    vinserti128 m2, m2, xm3, 1
+    SWAP 3, 10
+
+
+    vperm2i128 m10, m4,  m5, q0301
+    vinserti128 m4, m4, xm5, 1
+    SWAP 5, 10
+
+    vperm2i128 m10, m6,  m7, q0301
+    vinserti128 m6, m6, xm7, 1
+    SWAP 7, 10
+%endif
+
+    pmaddubsw         m0, m12   ;x1*c1+x2*c2
+    pmaddubsw         m2, m13   ;x3*c3+x4*c4
+    pmaddubsw         m4, m14   ;x5*c5+x6*c6
+    pmaddubsw         m6, m15   ;x7*c7+x8*c8
+    paddw             m0, m2
+    paddw             m4, m6
+    paddw             m0, m4
+%if %1 > 8
+    pmaddubsw         m1, m12
+    pmaddubsw         m3, m13
+    pmaddubsw         m5, m14
+    pmaddubsw         m7, m15
+    paddw             m1, m3
+    paddw             m5, m7
+    paddw             m1, m5
+%endif
+%else
+    pmaddwd           m0, m12
+    pmaddwd           m2, m13
+    pmaddwd           m4, m14
+    pmaddwd           m6, m15
+    paddd             m0, m2
+    paddd             m4, m6
+    paddd             m0, m4
+%if %2 != 8
+    psrad             m0, %2-8
+%endif
+%if %1 > 4
+    pmaddwd           m1, m12
+    pmaddwd           m3, m13
+    pmaddwd           m5, m14
+    pmaddwd           m7, m15
+    paddd             m1, m3
+    paddd             m5, m7
+    paddd             m1, m5
+%if %2 != 8
+    psrad             m1, %2-8
+%endif
+%endif
+%endif
+%endmacro
+%macro UNI_COMPUTE 5
+    pmulhrsw          %3, %5
+%if %1 > 8 || (%2 > 8 && %1 > 4)
+    pmulhrsw          %4, %5
+%endif
+%if %2 == 8
+    packuswb          %3, %4
+%else
+    CLIPW             %3, [pb_0], [max_pixels_%2]
+%if (%1 > 8 && notcpuflag(avx)) || %1 > 16
+    CLIPW             %4, [pb_0], [max_pixels_%2]
+%endif
+%endif
+%endmacro
+
+
+; ******************************
+; void %1_put_pixels(int16_t *dst, const uint8_t *_src, ptrdiff_t srcstride,
+;                         int height, const int8_t *hf, const int8_t *vf, int width)
+; ******************************
+
+%macro PUT_PIXELS 3
+    MC_PIXELS       %1, %2, %3
+    MC_UNI_PIXELS   %1, %2, %3
+%endmacro
+
+%macro MC_PIXELS 3
+cglobal %1_put_pixels%2_%3, 4, 4, 3, dst, src, srcstride,height
+    pxor              m2, m2
+.loop:
+    SIMPLE_LOAD       %2, %3, srcq, m0
+    MC_PIXEL_COMPUTE  %2, %3, 1
+    PEL_10STORE%2     dstq, m0, m1
+    LOOP_END         dst, src, srcstride
+    RET
+%endmacro
+
+%macro MC_UNI_PIXELS 3
+cglobal %1_put_uni_pixels%2_%3, 5, 5, 2, dst, dststride, src, srcstride,height
+.loop:
+    SIMPLE_LOAD       %2, %3, srcq, m0
+    PEL_%3STORE%2   dstq, m0, m1
+    add             dstq, dststrideq             ; dst += dststride
+    add             srcq, srcstrideq             ; src += srcstride
+    dec          heightd                         ; cmp height
+    jnz               .loop                      ; height loop
+    RET
+%endmacro
+
+%macro PUT_4TAP 3
+%if cpuflag(avx2)
+%define XMM_REGS  11
+%else
+%define XMM_REGS  8
+%endif
+
+; ******************************
+; void %1_put_4tap_hX(int16_t *dst,
+;      const uint8_t *_src, ptrdiff_t _srcstride, int height, int8_t *hf, int8_t *vf, int width);
+; ******************************
+cglobal %1_put_4tap_h%2_%3, 5, 6, XMM_REGS, dst, src, srcstride, height, hf
+%assign %%stride ((%3 + 7)/8)
+    MC_4TAP_FILTER       %3, hf, m4, m5
+.loop:
+    MC_4TAP_LOAD         %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE      %3, %2, m4, m5, 1
+    PEL_10STORE%2      dstq, m0, m1
+    LOOP_END            dst, src, srcstride
+    RET
+
+; ******************************
+; void %1_put_uni_4tap_hX(uint8_t *dst, ptrdiff_t dststride,
+;      const uint8_t *_src, ptrdiff_t _srcstride, int height, int8_t *hf, int8_t *vf, int width);
+; ******************************
+cglobal %1_put_uni_4tap_h%2_%3, 6, 7, XMM_REGS, dst, dststride, src, srcstride, height, hf
+%assign %%stride ((%3 + 7)/8)
+    movdqa            m6, [scale_%3]
+    MC_4TAP_FILTER    %3, hf, m4, m5
+.loop:
+    MC_4TAP_LOAD      %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE   %3, %2, m4, m5
+    UNI_COMPUTE       %2, %3, m0, m1, m6
+    PEL_%3STORE%2   dstq, m0, m1
+    add             dstq, dststrideq             ; dst += dststride
+    add             srcq, srcstrideq             ; src += srcstride
+    dec          heightd                         ; cmp height
+    jnz               .loop                      ; height loop
+    RET
+
+; ******************************
+; void %1_put_4tap_v(int16_t *dst, ptrdiff_t dststride,
+;      const uint8_t *_src, ptrdiff_t _srcstride, int height, int8_t *hf, int8_t *vf, int width)
+; ******************************
+cglobal %1_put_4tap_v%2_%3, 4, 6, XMM_REGS, dst, src, srcstride, height, r3src, vf
+    movifnidn        vfq, vfmp
+    sub             srcq, srcstrideq
+    MC_4TAP_FILTER    %3, vf, m4, m5
+    lea           r3srcq, [srcstrideq*3]
+.loop:
+    MC_4TAP_LOAD      %3, srcq, srcstride, %2
+    MC_4TAP_COMPUTE   %3, %2, m4, m5, 1
+    PEL_10STORE%2     dstq, m0, m1
+    LOOP_END          dst, src, srcstride
+    RET
+
+; ******************************
+; void %1_put_uni_4tap_vX(uint8_t *dst, ptrdiff_t dststride,
+;      const uint8_t *_src, ptrdiff_t _srcstride, int height, int8_t *hf, int8_t *vf, int width);
+; ******************************
+cglobal %1_put_uni_4tap_v%2_%3, 5, 7, XMM_REGS, dst, dststride, src, srcstride, height, r3src, vf
+    movifnidn        vfq, vfmp
+    movdqa            m6, [scale_%3]
+    sub             srcq, srcstrideq
+    MC_4TAP_FILTER       %3, vf, m4, m5
+    lea           r3srcq, [srcstrideq*3]
+.loop:
+    MC_4TAP_LOAD      %3, srcq, srcstride, %2
+    MC_4TAP_COMPUTE   %3, %2, m4, m5
+    UNI_COMPUTE       %2, %3, m0, m1, m6
+    PEL_%3STORE%2   dstq, m0, m1
+    add             dstq, dststrideq             ; dst += dststride
+    add             srcq, srcstrideq             ; src += srcstride
+    dec          heightd                         ; cmp height
+    jnz               .loop                      ; height loop
+    RET
+%endmacro
+
+%macro PUT_4TAP_HV 3
+; ******************************
+; void put_4tap_hv(int16_t *dst, ptrdiff_t dststride,
+;      const uint8_t *_src, ptrdiff_t _srcstride, int height, int8_t *hf, int8_t *vf, int width)
+; ******************************
+cglobal %1_put_4tap_hv%2_%3, 6, 7, 16 , dst, src, srcstride, height, hf, vf, r3src
+%assign %%stride ((%3 + 7)/8)
+    sub                 srcq, srcstrideq
+    MC_4TAP_HV_FILTER    %3
+    MC_4TAP_LOAD         %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE      %3, %2, m14, m15
+%if (%2 > 8 && (%3 == 8))
+    SWAP              m8, m1
+%endif
+    SWAP              m4, m0
+    add             srcq, srcstrideq
+    MC_4TAP_LOAD         %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE      %3, %2, m14, m15
+%if (%2 > 8 && (%3 == 8))
+    SWAP              m9, m1
+%endif
+    SWAP              m5, m0
+    add             srcq, srcstrideq
+    MC_4TAP_LOAD         %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE      %3, %2, m14, m15
+%if (%2 > 8 && (%3 == 8))
+    SWAP             m10, m1
+%endif
+    SWAP              m6, m0
+    add             srcq, srcstrideq
+.loop:
+    MC_4TAP_LOAD         %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE      %3, %2, m14, m15
+%if (%2 > 8 && (%3 == 8))
+    SWAP             m11, m1
+%endif
+    SWAP              m7, m0
+    punpcklwd         m0, m4, m5
+    punpcklwd         m2, m6, m7
+%if %2 > 4
+    punpckhwd         m1, m4, m5
+    punpckhwd         m3, m6, m7
+%endif
+    MC_4TAP_COMPUTE      14, %2, m12, m13
+%if (%2 > 8 && (%3 == 8))
+    punpcklwd         m4, m8, m9
+    punpcklwd         m2, m10, m11
+    punpckhwd         m8, m8, m9
+    punpckhwd         m3, m10, m11
+    MC_4TAP_COMPUTE      14, %2, m12, m13, m4, m2, m8, m3
+%if cpuflag(avx2)
+    vinserti128       m2, m0, xm4, 1
+    vperm2i128        m3, m0, m4, q0301
+    PEL_10STORE%2     dstq, m2, m3
+%else
+    PEL_10STORE%2     dstq, m0, m4
+%endif
+%else
+    PEL_10STORE%2     dstq, m0, m1
+%endif
+    movdqa            m4, m5
+    movdqa            m5, m6
+    movdqa            m6, m7
+%if (%2 > 8 && (%3 == 8))
+    mova              m8, m9
+    mova              m9, m10
+    mova             m10, m11
+%endif
+    LOOP_END         dst, src, srcstride
+    RET
+
+cglobal %1_put_uni_4tap_hv%2_%3, 7, 8, 16 , dst, dststride, src, srcstride, height, hf, vf, r3src
+%assign %%stride ((%3 + 7)/8)
+    sub                srcq, srcstrideq
+    MC_4TAP_HV_FILTER    %3
+    MC_4TAP_LOAD         %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE      %3, %2, m14, m15
+%if (%2 > 8 && (%3 == 8))
+    SWAP                 m8, m1
+%endif
+    SWAP                 m4, m0
+    add                srcq, srcstrideq
+    MC_4TAP_LOAD         %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE      %3, %2, m14, m15
+%if (%2 > 8 && (%3 == 8))
+    SWAP                 m9, m1
+%endif
+    SWAP                 m5, m0
+    add                srcq, srcstrideq
+    MC_4TAP_LOAD         %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE      %3, %2, m14, m15
+%if (%2 > 8 && (%3 == 8))
+    SWAP                m10, m1
+%endif
+    SWAP                 m6, m0
+    add                srcq, srcstrideq
+.loop:
+    MC_4TAP_LOAD         %3, srcq-%%stride, %%stride, %2
+    MC_4TAP_COMPUTE      %3, %2, m14, m15
+%if (%2 > 8 && (%3 == 8))
+    SWAP                m11, m1
+%endif
+    mova                 m7, m0
+    punpcklwd            m0, m4, m5
+    punpcklwd            m2, m6, m7
+%if %2 > 4
+    punpckhwd            m1, m4, m5
+    punpckhwd            m3, m6, m7
+%endif
+    MC_4TAP_COMPUTE      14, %2, m12, m13
+%if (%2 > 8 && (%3 == 8))
+    punpcklwd            m4, m8, m9
+    punpcklwd            m2, m10, m11
+    punpckhwd            m8, m8, m9
+    punpckhwd            m3, m10, m11
+    MC_4TAP_COMPUTE      14, %2, m12, m13, m4, m2, m8, m3
+    UNI_COMPUTE          %2, %3, m0, m4, [scale_%3]
+%else
+    UNI_COMPUTE          %2, %3, m0, m1, [scale_%3]
+%endif
+    PEL_%3STORE%2      dstq, m0, m1
+    mova                 m4, m5
+    mova                 m5, m6
+    mova                 m6, m7
+%if (%2 > 8 && (%3 == 8))
+    mova                 m8, m9
+    mova                 m9, m10
+    mova                m10, m11
+%endif
+    add                dstq, dststrideq             ; dst += dststride
+    add                srcq, srcstrideq             ; src += srcstride
+    dec             heightd                         ; cmp height
+    jnz               .loop                         ; height loop
+    RET
+%endmacro
+
+; ******************************
+; void put_8tap_hX_X_X(int16_t *dst, const uint8_t *_src, ptrdiff_t srcstride,
+;                       int height, const int8_t *hf, const int8_t *vf, int width)
+; ******************************
+
+%macro PUT_8TAP 3
+cglobal %1_put_8tap_h%2_%3, 5, 5, 16, dst, src, srcstride, height, hf
+
+    MC_8TAP_FILTER          %3, hf
+.loop:
+    MC_8TAP_H_LOAD          %3, srcq, %2, 10
+    MC_8TAP_COMPUTE         %2, %3, 1
+%if %3 > 8
+    packssdw                m0, m1
+%endif
+    PEL_10STORE%2         dstq, m0, m1
+    LOOP_END               dst, src, srcstride
+    RET
+
+; ******************************
+; void put_uni_8tap_hX_X_X(int16_t *dst, ptrdiff_t dststride, const uint8_t *_src, ptrdiff_t srcstride,
+;                       int height, const int8_t *hf, const int8_t *vf, int width)
+; ******************************
+cglobal %1_put_uni_8tap_h%2_%3, 6, 7, 16 , dst, dststride, src, srcstride, height, hf
+    mova                 m9, [scale_%3]
+    MC_8TAP_FILTER       %3, hf
+.loop:
+    MC_8TAP_H_LOAD       %3, srcq, %2, 10
+    MC_8TAP_COMPUTE      %2, %3
+%if %3 > 8
+    packssdw             m0, m1
+%endif
+    UNI_COMPUTE          %2, %3, m0, m1, m9
+    PEL_%3STORE%2      dstq, m0, m1
+    add                dstq, dststrideq             ; dst += dststride
+    add                srcq, srcstrideq             ; src += srcstride
+    dec             heightd                         ; cmp height
+    jnz               .loop                         ; height loop
+    RET
+
+
+; ******************************
+; void put_8tap_vX_X_X(int16_t *dst, const uint8_t *_src, ptrdiff_t srcstride,
+;                      int height, const int8_t *hf, const int8_t *vf, int width)
+; ******************************
+
+cglobal %1_put_8tap_v%2_%3, 6, 8, 16, dst, src, srcstride, height, r3src, vf
+    mov                  vfq, r5mp
+    MC_8TAP_FILTER        %3, vf
+    lea               r3srcq, [srcstrideq*3]
+.loop:
+    MC_8TAP_V_LOAD        %3, srcq, srcstride, %2, r7
+    MC_8TAP_COMPUTE       %2, %3, 1
+%if %3 > 8
+    packssdw              m0, m1
+%endif
+    PEL_10STORE%2       dstq, m0, m1
+    LOOP_END             dst, src, srcstride
+    RET
+
+; ******************************
+; void put_uni_8tap_vX_X_X(int16_t *dst, ptrdiff_t dststride, const uint8_t *_src, ptrdiff_t srcstride,
+;                       int height, const int8_t *hf, const int8_t *vf, int width)
+; ******************************
+cglobal %1_put_uni_8tap_v%2_%3, 5, 9, 16, dst, dststride, src, srcstride, height, r3src, vf
+    mov              vfq, r6mp
+    MC_8TAP_FILTER    %3, vf
+    movdqa            m9, [scale_%3]
+    lea           r3srcq, [srcstrideq*3]
+.loop:
+    MC_8TAP_V_LOAD    %3, srcq, srcstride, %2, r8
+    MC_8TAP_COMPUTE   %2, %3
+%if %3 > 8
+    packssdw          m0, m1
+%endif
+    UNI_COMPUTE       %2, %3, m0, m1, m9
+    PEL_%3STORE%2   dstq, m0, m1
+    add             dstq, dststrideq             ; dst += dststride
+    add             srcq, srcstrideq             ; src += srcstride
+    dec          heightd                         ; cmp height
+    jnz               .loop                      ; height loop
+    RET
+
+%endmacro
+
+
+; ******************************
+; void put_8tap_hvX_X(int16_t *dst, const uint8_t *_src, ptrdiff_t srcstride,
+;                     int height, const int8_t *hf, const int8_t *vf, int width)
+; ******************************
+%macro PUT_8TAP_HV 3
+cglobal %1_put_8tap_hv%2_%3, 6, 6, 16, 0 - mmsize*16, dst, src, srcstride, height, hf, vf, r3src
+    MC_8TAP_FILTER           %3, hf, 0
+    lea                     hfq, [rsp]
+    MC_8TAP_FILTER           %3, vf, 8*mmsize
+    lea                     vfq, [rsp + 8*mmsize]
+
+    lea                  r3srcq, [srcstrideq*3]
+    sub                    srcq, r3srcq
+
+    MC_8TAP_H_LOAD           %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE       %2, %3, hf, ackssdw
+    SWAP                     m8, m0
+    add                    srcq, srcstrideq
+    MC_8TAP_H_LOAD           %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE       %2, %3, hf, ackssdw
+    SWAP                     m9, m0
+    add                    srcq, srcstrideq
+    MC_8TAP_H_LOAD           %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE       %2, %3, hf, ackssdw
+    SWAP                    m10, m0
+    add                    srcq, srcstrideq
+    MC_8TAP_H_LOAD           %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE       %2, %3, hf, ackssdw
+    SWAP                    m11, m0
+    add                    srcq, srcstrideq
+    MC_8TAP_H_LOAD           %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE       %2, %3, hf, ackssdw
+    SWAP                    m12, m0
+    add                    srcq, srcstrideq
+    MC_8TAP_H_LOAD           %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE       %2, %3, hf, ackssdw
+    SWAP                    m13, m0
+    add                    srcq, srcstrideq
+    MC_8TAP_H_LOAD           %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE       %2, %3, hf, ackssdw
+    SWAP                    m14, m0
+    add                    srcq, srcstrideq
+.loop:
+    MC_8TAP_H_LOAD           %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE       %2, %3, hf, ackssdw
+    SWAP                    m15, m0
+    punpcklwd                m0, m8, m9
+    punpcklwd                m2, m10, m11
+    punpcklwd                m4, m12, m13
+    punpcklwd                m6, m14, m15
+%if %2 > 4
+    punpckhwd                m1, m8, m9
+    punpckhwd                m3, m10, m11
+    punpckhwd                m5, m12, m13
+    punpckhwd                m7, m14, m15
+%endif
+%if %2 <= 4
+    movq                     m8, m9
+    movq                     m9, m10
+    movq                    m10, m11
+    movq                    m11, m12
+    movq                    m12, m13
+    movq                    m13, m14
+    movq                    m14, m15
+%else
+    movdqa                   m8, m9
+    movdqa                   m9, m10
+    movdqa                  m10, m11
+    movdqa                  m11, m12
+    movdqa                  m12, m13
+    movdqa                  m13, m14
+    movdqa                  m14, m15
+%endif
+    MC_8TAP_HV_COMPUTE       %2, 14, vf, ackssdw
+    PEL_10STORE%2          dstq, m0, m1
+
+    LOOP_END                dst, src, srcstride
+    RET
+
+
+cglobal %1_put_uni_8tap_hv%2_%3, 7, 9, 16, 0 - 16*mmsize, dst, dststride, src, srcstride, height, hf, vf, r3src
+    MC_8TAP_FILTER           %3, hf, 0
+    lea                     hfq, [rsp]
+    MC_8TAP_FILTER           %3, vf, 8*mmsize
+    lea                     vfq, [rsp + 8*mmsize]
+    lea           r3srcq, [srcstrideq*3]
+    sub             srcq, r3srcq
+    MC_8TAP_H_LOAD       %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE   %2, %3, hf, ackssdw
+    SWAP              m8, m0
+    add             srcq, srcstrideq
+    MC_8TAP_H_LOAD       %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE   %2, %3, hf, ackssdw
+    SWAP              m9, m0
+    add             srcq, srcstrideq
+    MC_8TAP_H_LOAD       %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE   %2, %3, hf, ackssdw
+    SWAP             m10, m0
+    add             srcq, srcstrideq
+    MC_8TAP_H_LOAD       %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE   %2, %3, hf, ackssdw
+    SWAP             m11, m0
+    add             srcq, srcstrideq
+    MC_8TAP_H_LOAD       %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE   %2, %3, hf, ackssdw
+    SWAP             m12, m0
+    add             srcq, srcstrideq
+    MC_8TAP_H_LOAD       %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE   %2, %3, hf, ackssdw
+    SWAP             m13, m0
+    add             srcq, srcstrideq
+    MC_8TAP_H_LOAD       %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE   %2, %3, hf, ackssdw
+    SWAP             m14, m0
+    add             srcq, srcstrideq
+.loop:
+    MC_8TAP_H_LOAD       %3, srcq, %2, 15
+    MC_8TAP_HV_COMPUTE   %2, %3, hf, ackssdw
+    SWAP             m15, m0
+    punpcklwd         m0, m8, m9
+    punpcklwd         m2, m10, m11
+    punpcklwd         m4, m12, m13
+    punpcklwd         m6, m14, m15
+%if %2 > 4
+    punpckhwd         m1, m8, m9
+    punpckhwd         m3, m10, m11
+    punpckhwd         m5, m12, m13
+    punpckhwd         m7, m14, m15
+%endif
+    MC_8TAP_HV_COMPUTE   %2, 14, vf, ackusdw
+    UNI_COMPUTE       %2, %3, m0, m1, [scale_%3]
+    PEL_%3STORE%2   dstq, m0, m1
+
+%if %2 <= 4
+    movq              m8, m9
+    movq              m9, m10
+    movq             m10, m11
+    movq             m11, m12
+    movq             m12, m13
+    movq             m13, m14
+    movq             m14, m15
+%else
+    mova            m8, m9
+    mova            m9, m10
+    mova           m10, m11
+    mova           m11, m12
+    mova           m12, m13
+    mova           m13, m14
+    mova           m14, m15
+%endif
+    add             dstq, dststrideq             ; dst += dststride
+    add             srcq, srcstrideq             ; src += srcstride
+    dec          heightd                         ; cmp height
+    jnz               .loop                      ; height loop
+    RET
+
+%endmacro

--- a/tests/checkasm/Makefile
+++ b/tests/checkasm/Makefile
@@ -40,7 +40,7 @@ AVCODECOBJS-$(CONFIG_V210_DECODER)      += v210dec.o
 AVCODECOBJS-$(CONFIG_V210_ENCODER)      += v210enc.o
 AVCODECOBJS-$(CONFIG_VORBIS_DECODER)    += vorbisdsp.o
 AVCODECOBJS-$(CONFIG_VP9_DECODER)       += vp9dsp.o
-AVCODECOBJS-$(CONFIG_VVC_DECODER)       += vvc_mc.o
+AVCODECOBJS-$(CONFIG_VVC_DECODER)       += vvc_alf.o vvc_sao.o vvc_mc.o vvc_itx.o
 
 CHECKASMOBJS-$(CONFIG_AVCODEC)          += $(AVCODECOBJS-yes)
 

--- a/tests/checkasm/Makefile
+++ b/tests/checkasm/Makefile
@@ -40,7 +40,7 @@ AVCODECOBJS-$(CONFIG_V210_DECODER)      += v210dec.o
 AVCODECOBJS-$(CONFIG_V210_ENCODER)      += v210enc.o
 AVCODECOBJS-$(CONFIG_VORBIS_DECODER)    += vorbisdsp.o
 AVCODECOBJS-$(CONFIG_VP9_DECODER)       += vp9dsp.o
-AVCODECOBJS-$(CONFIG_VVC_DECODER)       += vvc_alf.o vvc_sao.o vvc_mc.o vvc_itx.o
+AVCODECOBJS-$(CONFIG_VVC_DECODER)       += vvc_alf.o vvc_sao.o vvc_mc.o vvc_itx.o vvc_sad.o
 
 CHECKASMOBJS-$(CONFIG_AVCODEC)          += $(AVCODECOBJS-yes)
 

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -195,7 +195,10 @@ static const struct {
         { "vorbisdsp", checkasm_check_vorbisdsp },
     #endif
     #if CONFIG_VVC_DECODER
+        { "vvc_alf", checkasm_check_vvc_alf },
+        { "vvc_sao", checkasm_check_vvc_sao },
         { "vvc_mc", checkasm_check_vvc_mc },
+        { "vvc_itx", checkasm_check_vvc_itx },
     #endif
 #endif
 #if CONFIG_AVFILTER

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -199,6 +199,8 @@ static const struct {
         { "vvc_sao", checkasm_check_vvc_sao },
         { "vvc_mc", checkasm_check_vvc_mc },
         { "vvc_itx", checkasm_check_vvc_itx },
+        { "vvc_sad", checkasm_check_vvc_sad },
+
     #endif
 #endif
 #if CONFIG_AVFILTER

--- a/tests/checkasm/checkasm.h
+++ b/tests/checkasm/checkasm.h
@@ -131,7 +131,10 @@ void checkasm_check_vp8dsp(void);
 void checkasm_check_vp9dsp(void);
 void checkasm_check_videodsp(void);
 void checkasm_check_vorbisdsp(void);
+void checkasm_check_vvc_alf(void);
+void checkasm_check_vvc_sao(void);
 void checkasm_check_vvc_mc(void);
+void checkasm_check_vvc_itx(void);
 
 struct CheckasmPerf;
 

--- a/tests/checkasm/checkasm.h
+++ b/tests/checkasm/checkasm.h
@@ -135,6 +135,7 @@ void checkasm_check_vvc_alf(void);
 void checkasm_check_vvc_sao(void);
 void checkasm_check_vvc_mc(void);
 void checkasm_check_vvc_itx(void);
+void checkasm_check_vvc_sad(void);
 
 struct CheckasmPerf;
 

--- a/tests/checkasm/vvc_alf.c
+++ b/tests/checkasm/vvc_alf.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2023 Nuo Mi <nuomi2021@gmail.com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+
+#include "libavutil/intreadwrite.h"
+#include "libavutil/mem_internal.h"
+
+#include "libavcodec/avcodec.h"
+
+#include "checkasm.h"
+
+#include "libavcodec/vvc/vvc_ctu.h"
+
+static const uint32_t pixel_mask[3] = { 0xffffffff, 0x03ff03ff, 0x0fff0fff };
+
+#define SIZEOF_PIXEL ((bit_depth + 7) / 8)
+#define SRC_PIXEL_STRIDE (MAX_CTU_SIZE + 2 * ALF_PADDING_SIZE)
+#define DST_PIXEL_STRIDE (SRC_PIXEL_STRIDE + 4)
+#define SRC_BUF_SIZE (SRC_PIXEL_STRIDE * (MAX_CTU_SIZE + 3 * 2) * 2) //+3 * 2 for top and bottom row, *2 for high bit depth
+#define DST_BUF_SIZE (DST_PIXEL_STRIDE * (MAX_CTU_SIZE + 3 * 2) * 2)
+#define LUMA_PARAMS_SIZE (MAX_CTU_SIZE * MAX_CTU_SIZE / ALF_BLOCK_SIZE / ALF_BLOCK_SIZE * ALF_NUM_COEFF_LUMA)
+
+#define randomize_buffers(buf0, buf1, size)                 \
+    do {                                                    \
+        uint32_t mask = pixel_mask[(bit_depth - 8) >> 1];   \
+        int k;                                              \
+        for (k = 0; k < size; k += 4) {                     \
+            uint32_t r = rnd() & mask;                      \
+            AV_WN32A(buf0 + k, r);                          \
+            AV_WN32A(buf1 + k, r);                          \
+        }                                                   \
+    } while (0)
+
+#define randomize_buffers2(buf, size, filter)               \
+    do {                                                    \
+        int k;                                              \
+        if (filter) {                                       \
+            for (k = 0; k < size; k++) {                    \
+                int8_t r = rnd();                           \
+                buf[k] = r;                                 \
+            }                                               \
+        } else {                                            \
+            for (k = 0; k < size; k++) {                    \
+                int r = rnd() % FF_ARRAY_ELEMS(clip_set);   \
+                buf[k] = clip_set[r];                       \
+            }                                               \
+        }                                                   \
+    } while (0)
+
+static void check_alf_filter(VVCDSPContext *c, const int bit_depth)
+{
+    LOCAL_ALIGNED_32(uint8_t, dst0, [DST_BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, dst1, [DST_BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, src0, [SRC_BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, src1, [SRC_BUF_SIZE]);
+    int16_t filter[LUMA_PARAMS_SIZE];
+    int16_t clip[LUMA_PARAMS_SIZE];
+
+    const int16_t clip_set[] = {
+        1 << bit_depth, 1 << (bit_depth - 3), 1 << (bit_depth - 5), 1 << (bit_depth - 7)
+    };
+
+    ptrdiff_t src_stride = SRC_PIXEL_STRIDE * SIZEOF_PIXEL;
+    ptrdiff_t dst_stride = DST_PIXEL_STRIDE * SIZEOF_PIXEL;
+    int offset = (3 * SRC_PIXEL_STRIDE + 3) * SIZEOF_PIXEL;
+
+    declare_func_emms(AV_CPU_FLAG_AVX2, void, uint8_t *dst, ptrdiff_t dst_stride, const uint8_t *src, ptrdiff_t src_stride,
+        int width, int height, const int16_t *filter, const int16_t *clip, const int vb_pos);
+
+    randomize_buffers(src0, src1, SRC_BUF_SIZE);
+    randomize_buffers2(filter, LUMA_PARAMS_SIZE, 1);
+    randomize_buffers2(clip, LUMA_PARAMS_SIZE, 0);
+
+    for (int h = 4; h <= MAX_CTU_SIZE; h += 4) {
+        for (int w = 4; w <= MAX_CTU_SIZE; w += 4) {
+            const int ctu_size = MAX_CTU_SIZE;
+            if (check_func(c->alf.filter[LUMA], "vvc_alf_filter_luma_%dx%d_%d", w, h, bit_depth)) {
+                const int vb_pos = ctu_size - ALF_VB_POS_ABOVE_LUMA;
+                memset(dst0, 0, DST_BUF_SIZE);
+                memset(dst1, 0, DST_BUF_SIZE);
+                call_ref(dst0, dst_stride, src0 + offset, src_stride, w, h, filter, clip, vb_pos);
+                call_new(dst1, dst_stride, src1 + offset, src_stride, w, h, filter, clip, vb_pos);
+                for (int i = 0; i < h; i++) {
+                    if (memcmp(dst0 + i * dst_stride, dst1 + i * dst_stride, w * SIZEOF_PIXEL))
+                        fail();
+                }
+                bench_new(dst1, dst_stride, src1 + offset, src_stride, w, h, filter, clip, vb_pos);
+            }
+            if (check_func(c->alf.filter[CHROMA], "vvc_alf_filter_chroma_%dx%d_%d", w, h, bit_depth)) {
+                const int vb_pos = ctu_size - ALF_VB_POS_ABOVE_CHROMA;
+                memset(dst0, 0, DST_BUF_SIZE);
+                memset(dst1, 0, DST_BUF_SIZE);
+                call_ref(dst0, dst_stride, src0 + offset, src_stride, w, h, filter, clip, vb_pos);
+                call_new(dst1, dst_stride, src1 + offset, src_stride, w, h, filter, clip, vb_pos);
+                for (int i = 0; i < h; i++) {
+                    if (memcmp(dst0 + i * dst_stride, dst1 + i * dst_stride, w * SIZEOF_PIXEL))
+                        fail();
+                }
+                bench_new(dst1, dst_stride, src1 + offset, src_stride, w, h, filter, clip, vb_pos);
+            }
+        }
+    }
+}
+
+static void check_alf_classify(VVCDSPContext *c, const int bit_depth)
+{
+    LOCAL_ALIGNED_32(int, class_idx0, [SRC_BUF_SIZE]);
+    LOCAL_ALIGNED_32(int, transpose_idx0, [SRC_BUF_SIZE]);
+    LOCAL_ALIGNED_32(int, class_idx1, [SRC_BUF_SIZE]);
+    LOCAL_ALIGNED_32(int, transpose_idx1, [SRC_BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, src0, [SRC_BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, src1, [SRC_BUF_SIZE]);
+    LOCAL_ALIGNED_32(int32_t, alf_gradient_tmp, [ALF_GRADIENT_SIZE * ALF_GRADIENT_SIZE * ALF_NUM_DIR]);
+
+    ptrdiff_t stride = SRC_PIXEL_STRIDE * SIZEOF_PIXEL;
+    int offset = (3 * SRC_PIXEL_STRIDE + 3) * SIZEOF_PIXEL;
+
+    declare_func_emms(AV_CPU_FLAG_AVX2, void, int *class_idx, int *transpose_idx,
+        const uint8_t *src, ptrdiff_t src_stride, int width, int height, int vb_pos, int *gradient_tmp);
+
+    randomize_buffers(src0, src1, SRC_BUF_SIZE);
+
+    for (int h = 4; h <= MAX_CTU_SIZE; h += 4) {
+        for (int w = 4; w <= MAX_CTU_SIZE; w += 4) {
+            const int id_size = w * h / ALF_BLOCK_SIZE / ALF_BLOCK_SIZE * sizeof(int);
+            const int vb_pos  = MAX_CTU_SIZE - ALF_BLOCK_SIZE;
+            if (check_func(c->alf.classify, "vvc_alf_classify_%dx%d_%d", w, h, bit_depth)) {
+                memset(class_idx0, 0, id_size);
+                memset(class_idx1, 0, id_size);
+                memset(transpose_idx0, 0, id_size);
+                memset(transpose_idx1, 0, id_size);
+                call_ref(class_idx0, transpose_idx0, src0 + offset, stride, w, h, vb_pos, alf_gradient_tmp);
+
+                call_new(class_idx1, transpose_idx1, src1 + offset, stride, w, h, vb_pos, alf_gradient_tmp);
+
+                if (memcmp(class_idx0, class_idx1, id_size))
+                    fail();
+                if (memcmp(transpose_idx0, transpose_idx1, id_size))
+                    fail();
+                bench_new(class_idx1, transpose_idx1, src1 + offset, stride, w, h, vb_pos, alf_gradient_tmp);
+            }
+        }
+    }
+}
+
+void checkasm_check_vvc_alf(void)
+{
+    int bit_depth;
+    VVCDSPContext h;
+    for (bit_depth = 8; bit_depth <= 12; bit_depth += 2) {
+        ff_vvc_dsp_init(&h, bit_depth);
+        check_alf_filter(&h, bit_depth);
+    }
+    report("alf_filter");
+    for (bit_depth = 8; bit_depth <= 12; bit_depth += 2) {
+        ff_vvc_dsp_init(&h, bit_depth);
+        check_alf_classify(&h, bit_depth);
+    }
+    report("alf_classify");
+}

--- a/tests/checkasm/vvc_itx.c
+++ b/tests/checkasm/vvc_itx.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Nuo Mi <nuomi2021@gmail.com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "checkasm.h"
+#include "libavcodec/vvc/vvc_ctu.h"
+#include "libavcodec/vvc/vvcdsp.h"
+
+static void randomize_coeffs(int *c0, int *c1,
+    const int w, const int h, const size_t nzw, const int nzh, intptr_t log2_transform_range)
+{
+    for (int ht = 0; ht < h; ht++) {
+        for (int wd = 0; wd < w; wd++) {
+            if (wd < nzw && ht < nzh)
+                *c0 = *c1 = av_clip_intp2(rnd(), log2_transform_range);
+            c0++;
+            c1++;
+        }
+    }
+}
+
+static const char* name(int tr)
+{
+    static const char *name[] = {
+        "dct2",
+        "dst7",
+        "dct8",
+    };
+    return name[tr];
+}
+
+static const int zero_out_size(const int tr, const int size)
+{
+    return FFMIN(tr == DCT2 ? 32 : 16, size);
+}
+
+static enum TxType tr_end(const int size)
+{
+    return size >= 4 && size <= 32 ? DCT8 : DCT2;
+}
+
+static void check_itx_2d(void)
+{
+    VVCDSPContext dsp;
+    LOCAL_ALIGNED_32(int, c0, [MAX_TB_SIZE * MAX_TB_SIZE]);
+    LOCAL_ALIGNED_32(int, c1, [MAX_TB_SIZE * MAX_TB_SIZE]);
+
+    declare_func_emms(AV_CPU_FLAG_AVX2, void, int *coeffs,
+        size_t nzw, size_t nzh, intptr_t log2_transform_range, intptr_t bd);
+
+    for (int bd = 8; bd <= 12; bd += 2) {
+        const intptr_t log2_transform_range = rnd() ? FFMAX(15, FFMIN(20, bd + 6)) : 15;
+        ff_vvc_dsp_init(&dsp, bd);
+        for (int w = 2; w <= 64; w <<= 1) {
+            for (int h = 2; h <= 64; h <<= 1) {
+                for (int trh = DCT2; trh <= tr_end(w); trh++) {
+                    for (int trv = DCT2; trv <= tr_end(h); trv++) {
+                        const size_t nzw = rnd() % zero_out_size(trh, w) + 1;
+                        const size_t nzh = rnd() % zero_out_size(trv, h) + 1;
+                        randomize_coeffs(c0, c1, w, h, nzw, nzh, log2_transform_range);
+                        if (check_func(dsp.itx.itx[trh][trv][av_log2(w)][av_log2(h)],
+                            "vvc_itx_%s_%s_%dx%d_%d", name(trh), name(trv), w, h, bd)) {
+                            call_ref(c0, nzw, nzh, log2_transform_range, bd);
+                            call_new(c1, nzw, nzh, log2_transform_range, bd);
+                            for (int i = 0; i < h; i++) {
+                                if (memcmp(c0 + i * w, c1 + i * w, w * sizeof(int)))
+                                    fail();
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+
+}
+
+void checkasm_check_vvc_itx(void)
+{
+    check_itx_2d();
+}

--- a/tests/checkasm/vvc_mc.c
+++ b/tests/checkasm/vvc_mc.c
@@ -21,16 +21,15 @@
 
 #include <string.h>
 
-#include "checkasm.h"
-#include "libavcodec/avcodec.h"
-#include "libavcodec/vvc/vvc_ctu.h"
-#include "libavcodec/vvc/vvc_data.h"
-
-#include "libavutil/common.h"
-#include "libavutil/internal.h"
-#include "libavutil/internal.h"
 #include "libavutil/intreadwrite.h"
 #include "libavutil/mem_internal.h"
+
+#include "libavcodec/avcodec.h"
+
+#include "checkasm.h"
+
+#include "libavcodec/vvc/vvc_ctu.h"
+#include "libavcodec/vvc/vvc_data.h"
 
 static const uint32_t pixel_mask[] = { 0xffffffff, 0x03ff03ff, 0x0fff0fff, 0x3fff3fff, 0xffffffff };
 static const int sizes[] = { 2, 4, 8, 16, 32, 64, 128 };

--- a/tests/checkasm/vvc_sad.c
+++ b/tests/checkasm/vvc_sad.c
@@ -1,0 +1,189 @@
+#include <string.h>
+
+#include "libavutil/intreadwrite.h"
+#include "libavutil/mem_internal.h"
+
+#include "libavcodec/avcodec.h"
+#include "checkasm.h"
+#include "libavcodec/vvc/vvc_ctu.h"
+
+static const uint32_t pixel_mask[] = { 0xffffffff, 0x03ff03ff, 0x0fff0fff };
+
+#define SIZEOF_PIXEL ((bit_depth + 7) / 8)
+
+#define randomize_buffers(buf0, buf1, size, mask)           \
+    do {                                                    \
+        int k;                                              \
+        for (k = 0; k < size; k += 2) {                     \
+            uint32_t r = rnd() & mask;                      \
+            AV_WN32A(buf0 + k,     r);                      \
+            AV_WN32A(buf1 + k, r);                          \
+        }                                                   \
+    } while (0)
+
+#define randomize_pixels(buf0, buf1, size)                  \
+    do {                                                    \
+        uint32_t mask = pixel_mask[(bit_depth - 8) >> 1];   \
+        randomize_buffers(buf0, buf1, size, mask);          \
+    } while (0)
+
+
+
+static void check_vvc_sad_8_16bpc(void)
+{
+    const int bit_depth = 10;
+    VVCDSPContext c;
+    ff_vvc_dsp_init(&c, bit_depth);
+
+    LOCAL_ALIGNED_32(uint16_t, src0, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2]);
+    LOCAL_ALIGNED_32(uint16_t, src1, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2]);
+
+    memset(src0, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+    memset(src1, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    randomize_pixels(src0, src1, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    declare_func_emms(AV_CPU_FLAG_AVX2,int, const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+
+    if(check_func(c.inter.sad[1], "vvc_sad_8_16bpc"))
+    {
+            int result0 =  call_ref(src0 + 128 * 2, src1 + 128 * 2, 2, 2, 8, 16);
+            int result1 =  call_new(src0 + 128 * 2, src1 + 128 * 2, 2, 2, 8, 16);
+
+            if(result1 != result0)
+            {
+                fail();
+            }
+            bench_new(src0 + 128 * 2, src1 + 128 * 2, 2, 2, 8, 16);
+    }
+    report("check_vvc_sad_8_16bpc");
+}
+
+static void check_vvc_sad_16_16bpc(void)
+{
+    const int bit_depth = 10;
+    VVCDSPContext c;
+    ff_vvc_dsp_init(&c, bit_depth);
+
+    LOCAL_ALIGNED_32(uint16_t, src0, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2]);
+    LOCAL_ALIGNED_32(uint16_t, src1, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2]);
+
+    memset(src0, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+    memset(src1, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    randomize_pixels(src0, src1, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    declare_func_emms(AV_CPU_FLAG_AVX2,int, const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+
+    if(check_func(c.inter.sad[2], "vvc_sad_16_16bpc"))
+    {
+        int result0 = call_ref(src0 + 2 * 128, src1 + 2 * 128, 2, 2, 16, 16);
+        int result1 = call_new(src0 + 2 * 128, src1 + 2 * 128, 2, 2, 16, 16);
+
+        if(result1 != result0)
+        {
+            fail();
+        }
+        bench_new(src0 + 128 * 2, src1 + 128 * 2, 2, 2, 16, 16);
+    }
+    report("check_vvc_sad_16_16bpc");
+}
+
+static void check_vvc_sad_32_16bpc(void)
+{
+    const int bit_depth = 10;
+    VVCDSPContext c;
+    ff_vvc_dsp_init(&c, bit_depth);
+
+    LOCAL_ALIGNED_32(uint16_t, src0, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2]);
+    LOCAL_ALIGNED_32(uint16_t, src1, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2]);
+
+    memset(src0, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+    memset(src1, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    randomize_pixels(src0, src1, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    declare_func_emms(AV_CPU_FLAG_AVX2,int, const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+
+    if(check_func(c.inter.sad[3], "vvc_sad_32_16bpc"))
+    {
+        int result0 = call_ref(src0 + 2 * 128, src1 + 2 * 128, 2, 1, 32, 32);
+        int result1 = call_new(src0 + 2 * 128, src1 + 2 * 128, 2, 1, 32, 32);
+
+        if(result1 != result0)
+        {
+            fail();
+        }
+        bench_new(src0 + 128 * 2, src1 + 128 * 2, 2, 2, 32, 32);
+    }
+    report("check_vvc_sad_32_16bpc");
+}
+
+static void check_vvc_sad_64_16bpc(void)
+{
+    const int bit_depth = 10;
+    VVCDSPContext c;
+    ff_vvc_dsp_init(&c, bit_depth);
+
+    LOCAL_ALIGNED_32(uint16_t, src0, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2]);
+    LOCAL_ALIGNED_32(uint16_t, src1, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2]);
+
+    memset(src0, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+    memset(src1, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    randomize_pixels(src0, src1, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    declare_func_emms(AV_CPU_FLAG_AVX2,int, const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+
+    if(check_func(c.inter.sad[4], "vvc_sad_64_16bpc"))
+    {
+        int result0 = call_ref(src0 + 2 * 128, src1 + 2 * 128, 2, 1, 64, 32);
+        int result1 = call_new(src0 + 2 * 128, src1 + 2 * 128, 2, 1, 64, 32);
+
+        if(result1 != result0)
+        {
+            fail();
+        }
+        bench_new(src0 + 128 * 2, src1 + 128 * 2, 2, 2, 64, 64);
+    }
+    report("check_vvc_sad_64_16bpc");
+}
+
+static void check_vvc_sad_128_16bpc(void)
+{
+    const int bit_depth = 10;
+    VVCDSPContext c;
+    ff_vvc_dsp_init(&c, bit_depth);
+
+    LOCAL_ALIGNED_32(uint16_t, src0, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2 * 2]);
+    LOCAL_ALIGNED_32(uint16_t, src1, [MAX_CTU_SIZE * MAX_CTU_SIZE * 2 * 2]);
+
+    memset(src0, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+    memset(src1, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    randomize_pixels(src0, src1, MAX_CTU_SIZE * MAX_CTU_SIZE * 2);
+
+    declare_func_emms(AV_CPU_FLAG_AVX2,int, const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
+
+    if(check_func(c.inter.sad[5], "vvc_sad_128_16bpc"))
+    {
+        int result0 = call_ref(src0 + 2 * 128, src1 + 2 * 128, 2, 1, 128, 128);
+        int result1 = call_new(src0 + 2 * 128, src1 + 2 * 128, 2, 1, 128, 128);
+
+        if(result1 != result0)
+        {
+            fail();
+        }
+        bench_new(src0 + 128 * 2, src1 + 128 * 2, 2, 2, 128, 128);
+    }
+    report("check_vvc_sad_128_16bpc");
+}
+
+void checkasm_check_vvc_sad(void)
+{
+    check_vvc_sad_8_16bpc();
+    check_vvc_sad_16_16bpc();
+    check_vvc_sad_32_16bpc();
+    check_vvc_sad_64_16bpc();
+    check_vvc_sad_128_16bpc();
+}

--- a/tests/checkasm/vvc_sao.c
+++ b/tests/checkasm/vvc_sao.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2018 Yingming Fan <yingmingfan@gmail.com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+
+#include "libavutil/intreadwrite.h"
+#include "libavutil/mem_internal.h"
+
+#include "libavcodec/avcodec.h"
+
+#include "checkasm.h"
+#include "libavcodec/vvc/vvc_ctu.h"
+
+static const uint32_t pixel_mask[3] = { 0xffffffff, 0x03ff03ff, 0x0fff0fff };
+static const uint32_t sao_size[9] = {8, 16, 32, 48, 64, 80, 96, 112, 128};
+
+#define SIZEOF_PIXEL ((bit_depth + 7) / 8)
+#define PIXEL_STRIDE (2*MAX_PB_SIZE + AV_INPUT_BUFFER_PADDING_SIZE) //same with sao_edge src_stride
+#define BUF_SIZE (PIXEL_STRIDE * (128+2) * 2) //+2 for top and bottom row, *2 for high bit depth
+#define OFFSET_THRESH (1 << (bit_depth - 5))
+#define OFFSET_LENGTH 9
+
+#define randomize_buffers(buf0, buf1, size)                 \
+    do {                                                    \
+        uint32_t mask = pixel_mask[(bit_depth - 8) >> 1];   \
+        int k;                                              \
+        for (k = 0; k < size; k += 4) {                     \
+            uint32_t r = rnd() & mask;                      \
+            AV_WN32A(buf0 + k, r);                          \
+            AV_WN32A(buf1 + k, r);                          \
+        }                                                   \
+    } while (0)
+
+#define randomize_buffers2(buf, size)                       \
+    do {                                                    \
+        uint32_t max_offset = OFFSET_THRESH;                \
+        int k;                                              \
+        if (bit_depth == 8) {                               \
+            for (k = 0; k < size; k++) {                    \
+                uint8_t r = rnd() % max_offset;             \
+                buf[k] = r;                                 \
+            }                                               \
+        } else {                                            \
+            for (k = 0; k < size; k++) {                    \
+                uint16_t r = rnd() % max_offset;            \
+                buf[k] = r;                                 \
+            }                                               \
+        }                                                   \
+    } while (0)
+
+static void check_sao_band(VVCDSPContext h, int bit_depth)
+{
+    int i;
+    LOCAL_ALIGNED_32(uint8_t, dst0, [BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, dst1, [BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, src0, [BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, src1, [BUF_SIZE]);
+    int16_t offset_val[OFFSET_LENGTH];
+    int left_class = rnd()%32;
+
+    for (i = 0; i <= 8; i++) {
+        int block_size = sao_size[i];
+        int prev_size = i > 0 ? sao_size[i - 1] : 0;
+        ptrdiff_t stride = PIXEL_STRIDE*SIZEOF_PIXEL;
+        declare_func_emms(AV_CPU_FLAG_MMX, void, uint8_t *dst, uint8_t *src, ptrdiff_t dst_stride, ptrdiff_t src_stride,
+                          int16_t *sao_offset_val, int sao_left_class, int width, int height);
+
+        if (check_func(h.sao.band_filter[i], "vvc_sao_band_%d_%d", block_size, bit_depth)) {
+
+            for (int w = prev_size + 4; w <= block_size; w += 4) {
+                randomize_buffers(src0, src1, BUF_SIZE);
+                randomize_buffers2(offset_val, OFFSET_LENGTH);
+                memset(dst0, 0, BUF_SIZE);
+                memset(dst1, 0, BUF_SIZE);
+
+                call_ref(dst0, src0, stride, stride, offset_val, left_class, w, block_size);
+                call_new(dst1, src1, stride, stride, offset_val, left_class, w, block_size);
+                for (int j = 0; j < block_size; j++) {
+                    if (memcmp(dst0 + j*stride, dst1 + j*stride, w*SIZEOF_PIXEL))
+                        fail();
+                }
+            }
+            bench_new(dst1, src1, stride, stride, offset_val, left_class, block_size, block_size);
+        }
+    }
+}
+
+static void check_sao_edge(VVCDSPContext h, int bit_depth)
+{
+    int i;
+    LOCAL_ALIGNED_32(uint8_t, dst0, [BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, dst1, [BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, src0, [BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, src1, [BUF_SIZE]);
+    int16_t offset_val[OFFSET_LENGTH];
+    int eo = rnd()%4;
+
+    for (i = 0; i <= 8; i++) {
+        int block_size = sao_size[i];
+        int prev_size = i > 0 ? sao_size[i - 1] : 0;
+        ptrdiff_t stride = PIXEL_STRIDE*SIZEOF_PIXEL;
+        int offset = (AV_INPUT_BUFFER_PADDING_SIZE + PIXEL_STRIDE)*SIZEOF_PIXEL;
+        declare_func_emms(AV_CPU_FLAG_MMX, void, uint8_t *dst, uint8_t *src, ptrdiff_t stride_dst,
+                          int16_t *sao_offset_val, int eo, int width, int height);
+
+        for (int w = prev_size + 4; w <= block_size; w += 4) {
+            randomize_buffers(src0, src1, BUF_SIZE);
+            randomize_buffers2(offset_val, OFFSET_LENGTH);
+            memset(dst0, 0, BUF_SIZE);
+            memset(dst1, 0, BUF_SIZE);
+
+            if (check_func(h.sao.edge_filter[i], "vvc_sao_edge_%d_%d", block_size, bit_depth)) {
+                call_ref(dst0, src0 + offset, stride, offset_val, eo, w, block_size);
+                call_new(dst1, src1 + offset, stride, offset_val, eo, w, block_size);
+                for (int j = 0; j < block_size; j++) {
+                    if (memcmp(dst0 + j*stride, dst1 + j*stride, w*SIZEOF_PIXEL))
+                        fail();
+                }
+            }
+            bench_new(dst1, src1 + offset, stride, offset_val, eo, block_size, block_size);
+        }
+    }
+}
+
+void checkasm_check_vvc_sao(void)
+{
+    int bit_depth;
+
+    for (bit_depth = 8; bit_depth <= 12; bit_depth += 2) {
+        VVCDSPContext h;
+
+        ff_vvc_dsp_init(&h, bit_depth);
+        check_sao_band(h, bit_depth);
+    }
+    report("sao_band");
+
+    for (bit_depth = 8; bit_depth <= 12; bit_depth += 2) {
+        VVCDSPContext h;
+        ff_vvc_dsp_init(&h, bit_depth);
+        check_sao_edge(h, bit_depth);
+    }
+    report("sao_edge");
+
+}


### PR DESCRIPTION
As per https://github.com/ffvvc/FFmpeg/issues/212#issuecomment-2061103820 this is based on ffmpeg/main and pulling into ffvvc/up

Adds AVX2 assembly for SAD used in DMVR (decoder-side motion vector refinement). The main difference is that in VVC, SAD is only calculated on even rows of the PU to reduce complexity. Implements SAD via min/max/sub for 16bit values.

DMVR is restricted to PUs whose width >= 8, height >=8 and width * height >= 128 (ie 8x8 is not a valid size).

```

AVX2:
 - vvc_sad.check_vvc_sad_8_16bpc   [OK]
 - vvc_sad.check_vvc_sad_16_16bpc  [OK]
 - vvc_sad.check_vvc_sad_32_16bpc  [OK]
 - vvc_sad.check_vvc_sad_64_16bpc  [OK]
 - vvc_sad.check_vvc_sad_128_16bpc [OK]
checkasm: all 5 tests passed
vvc_sad_8_16bpc_c: 122.5
vvc_sad_8_16bpc_avx2: 12.5
vvc_sad_16_16bpc_c: 262.5
vvc_sad_16_16bpc_avx2: 22.5
vvc_sad_32_16bpc_c: 1012.5
vvc_sad_32_16bpc_avx2: 92.5
vvc_sad_64_16bpc_c: 3922.5
vvc_sad_64_16bpc_avx2: 372.5
vvc_sad_128_16bpc_c: 16682.5
vvc_sad_128_16bpc_avx2: 1892.5
```

```
//before
BQTerrace_1920x1080_60_10_420_22_RA.vvc | 80.3 |
Chimera_8bit_1080P_1000_frames.vvc | 157.3 |
NovosobornayaSquare_1920x1080.bin | 160.0 |
RitualDance_1920x1080_60_10_420_37_RA.266 | 146.7 |	

//after
BQTerrace_1920x1080_60_10_420_22_RA.vvc | 81.3 |
Chimera_8bit_1080P_1000_frames.vvc | 165.0 |
NovosobornayaSquare_1920x1080.bin | 164.7 |
RitualDance_1920x1080_60_10_420_37_RA.266 | 150.0 |

```

Ran on AMD 7940HS 