### PR TITLE
Constrain vvc_sad checkasm to valid block sizes

### DIFF
--- a/libavcodec/x86/vvc/vvc_sad.asm
+++ b/libavcodec/x86/vvc/vvc_sad.asm
@@ -29,6 +29,7 @@ SECTION_RODATA
 pw_1: times 2 dw 1
 
 ; DMVR SAD is only calculated on even rows to reduce complexity
+; Additionally the only valid sizes are 8x16, 16x8, and 16x16
 SECTION .text
 
 %macro MIN_MAX_SAD 3
@@ -77,7 +78,7 @@ cglobal vvc_sad, 6, 9, 5, src1, src2, dx, dy, block_w, block_h, off1, off2, row_
     vpbroadcastd       m4, [pw_1]
 
     cmp          block_wd, 16
-    jge    vvc_sad_16_128
+    je         vvc_sad_16
 
     vvc_sad_8:
         .loop_height:
@@ -100,7 +101,7 @@ cglobal vvc_sad, 6, 9, 5, src1, src2, dx, dy, block_w, block_h, off1, off2, row_
         movd          eax, xm0
     RET
 
-    vvc_sad_16_128:
+    vvc_sad_16:
         sar      block_wd, 4
         .loop_height:
         mov         off1q, src1q

--- a/tests/checkasm/vvc_mc.c
+++ b/tests/checkasm/vvc_mc.c
@@ -337,11 +337,12 @@ static void check_vvc_sad(void)
     memset(src1, 0, MAX_CTU_SIZE * MAX_CTU_SIZE * 4 * sizeof(uint16_t));
 
     randomize_pixels(src0, src1, MAX_CTU_SIZE * MAX_CTU_SIZE * 4);
-     for (int h = 8; h <= MAX_CTU_SIZE; h *= 2) {
-        for (int w = 8; w <= MAX_CTU_SIZE; w *= 2) {
+    for (int h = 8; h <= 16; h *= 2) {
+        for (int w = 8; w <= 16; w *= 2) {
             for(int offy = 0; offy <= 4; offy++) {
                 for(int offx = 0; offx <= 4; offx++) {
-                    if(check_func(c.inter.sad, "sad_%dx%d", w, h)) {
+                    if(w * h >= 128) {
+                        if(check_func(c.inter.sad, "sad_%dx%d", w, h)) {
                         int result0;
                         int result1;
 
@@ -350,13 +351,14 @@ static void check_vvc_sad(void)
 
                         if (result1 != result0)
                             fail();
-                        if(w == h && offx == 0 && offy == 0)
+                        if(offx == 0 && offy == 0)
                             bench_new(src0 + PIXEL_STRIDE * 2 + 2, src1 + PIXEL_STRIDE * 2 + 2, offx, offy, w, h);
+                        }
                     }
                 }
             }
         }
-     }
+    }
 
     report("sad");
 }


### PR DESCRIPTION
https://github.com/ffvvc/FFmpeg/issues/228

From issue above, valid block sizes are 8x16, 16x8, 16x16

This changes the checkasm to only test the valid block sizes.

This also relabels vvc_sad_16_128 to vvc_sad_16 and adds a comment to vvc_sad.asm to clarify the valid block sizes.