### PR TITLE
draft (wip) - vvc_deblocking - chroma

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,110 @@
+name: test
+run-name: ${{ github.workflow }} - ${{ github.sha }}
+on:
+  push:
+    branches: [ main, up ]
+  pull_request:
+    branches: [ main, up ]
+  workflow_dispatch:
+
+
+jobs:
+  ffvvc-test:
+    name: ffvvc-test / ${{ matrix.os.name }}/${{ matrix.compiler.name }}/${{ matrix.assembler.name }}
+    env:
+      configure_flags: --enable-ffmpeg --disable-everything --enable-decoder=vvc --enable-parser=vvc --enable-demuxer=vvc --enable-protocol=file,pipe --enable-encoder=rawvideo,wrapped_avframe --enable-muxer=rawvideo,md5,null
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4 }
+          - { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
+        compiler:
+          - { name: gcc, flags: --cc=gcc }
+          - { name: clang, flags: --cc=clang }
+          - { name: msvc, flags: --toolchain=msvc }
+          - { name: clang-usan, flags: '--toolchain=clang-usan' }
+          - { name: clang-asan, flags: '--toolchain=clang-asan' }
+        assembler:
+          - { name: no asm, flags: --disable-asm }
+          - { name: yasm, flags: --as=yasm }
+          - { name: nasm, flags: --as=nasm }
+        exclude:
+          # GitHub's Actions runners do not support AVX2.
+          - os: { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4}
+            compiler: { name: msvc, flags: --toolchain=msvc }
+          - os: { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4 }
+            assembler: { name: yasm, flags: --as=yasm }
+          - os: { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4 }
+            assembler: { name: nasm, flags: --as=nasm }
+          # Address sanitizer cannot be run with handwritten assembly.
+          - compiler: { name: clang-asan, flags: '--toolchain=clang-asan' }
+            assembler: { name: nasm, flags: --as=nasm }
+          - compiler: { name: clang-asan, flags: '--toolchain=clang-asan' }
+            assembler: { name: yasm, flags: --as=yasm }
+          # Windows only supports MSVC.
+          - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
+            compiler: { name: gcc, flags: --cc=gcc }
+          - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
+            compiler: { name: clang, flags: --cc=clang }
+          - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
+            compiler: { name: clang-usan, flags: '--toolchain=clang-usan' }
+          - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
+            compiler: { name: clang-asan, flags: '--toolchain=clang-asan' }
+
+    runs-on: ${{ matrix.os.runner }}
+    defaults:
+      run:
+        shell: ${{ matrix.os.shell }}
+
+    steps:
+    - name: Get MSVC
+      if: ${{ matrix.compiler.name == 'msvc' && matrix.os.name == 'windows' }}
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Set up MSYS2
+      if: ${{ matrix.os.shell == 'msys2 {0}' }}
+      uses: msys2/setup-msys2@v2
+      with:
+        release: false
+        msystem: UCRT64
+        path-type: inherit
+        install: >-
+          make
+          diffutils
+
+    - name: Setup python package
+      run: python3 -m pip install tqdm pyyaml
+
+    - name: Get assembler
+      if: ${{ matrix.os.shell == 'msys2 {0}' && matrix.assembler.name != 'no asm' }}
+      run: pacman --noconfirm -S ${{ matrix.assembler.name }}
+
+    - name: Get source
+      uses: actions/checkout@v3
+      with:
+        path: FFmpeg
+
+    - name: Configure
+      run: cd FFmpeg && ./configure ${{ matrix.compiler.flags }} ${{ matrix.assembler.flags }} ${{ env.configure_flags }} || (tail ffbuild/config.log; false)
+
+    - name: Build
+      run: cd FFmpeg && make -j8
+
+    - name: Get tests
+      uses: actions/checkout@v3
+      with:
+        repository: ffvvc/tests
+        path: tests
+
+    - name: Unit test
+      run: python3 tests/tools/ffmpeg.py --threads ${{ matrix.os.runner_threads }} --ffmpeg-path=./FFmpeg/ffmpeg tests/conformance/passed
+
+    - name: Check ASM
+      run: cd FFmpeg && make checkasm -j && ./tests/checkasm/checkasm
+
+    - name: Negative test
+      run: python3 tests/tools/ffmpeg.py --threads ${{ matrix.os.runner_threads }} --ffmpeg-path=./FFmpeg/ffmpeg tests/conformance/failed || true
+
+    - name: Check for fuzz regressions
+      run: python3 tests/tools/ffmpeg.py --threads ${{ matrix.os.runner_threads }} --ffmpeg-path=./FFmpeg/ffmpeg --no-output-check --allow-decode-error tests/fuzz/passed

--- a/libavcodec/vvc/dsp.h
+++ b/libavcodec/vvc/dsp.h
@@ -140,7 +140,10 @@ typedef struct VVCLFDSPContext {
 
     void (*filter_luma[2 /* h, v */])(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
         const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int hor_ctu_edge);
+        
     void (*filter_chroma[2 /* h, v */])(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
+        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
+    void (*filter_chroma_asm[2 /* h, v */])(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
         const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
 } VVCLFDSPContext;
 

--- a/libavcodec/x86/vvc/Makefile
+++ b/libavcodec/x86/vvc/Makefile
@@ -6,4 +6,5 @@ OBJS-$(CONFIG_VVC_DECODER)             += x86/vvc/vvcdsp_init.o \
 X86ASM-OBJS-$(CONFIG_VVC_DECODER)      += x86/vvc/vvc_alf.o      \
                                           x86/vvc/vvc_mc.o       \
                                           x86/vvc/vvc_sad.o      \
-                                          x86/h26x/h2656_inter.o
+                                          x86/vvc/vvc_deblock.o  \
+                                          x86/h26x/h2656_inter.o 

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -1,0 +1,383 @@
+; from hevc_deblock.asm, grap all the tranpose macros
+
+%include "libavutil/x86/x86util.asm"
+
+SECTION_RODATA
+
+cextern pw_1023
+%define pw_pixel_max_10 pw_1023
+pw_pixel_max_12: times 8 dw ((1 << 12)-1)
+pw_m2:           times 8 dw -2
+pd_1 :           times 4 dd  1
+
+cextern pw_4
+cextern pw_8
+cextern pw_m1
+
+SECTION .text
+INIT_XMM sse2
+; INIT_YMM avx2
+
+
+; in: 8 rows of 4 bytes in %4..%11
+; out: 4 rows of 8 words in m0..m3
+%macro TRANSPOSE4x8B_LOAD 8
+    movd             m0, %1
+    movd             m2, %2
+    movd             m1, %3
+    movd             m3, %4
+
+    punpcklbw        m0, m2
+    punpcklbw        m1, m3
+    punpcklwd        m0, m1
+
+    movd             m4, %5
+    movd             m6, %6
+    movd             m5, %7
+    movd             m3, %8
+
+    punpcklbw        m4, m6
+    punpcklbw        m5, m3
+    punpcklwd        m4, m5
+
+    punpckhdq        m2, m0, m4
+    punpckldq        m0, m4
+
+    pxor             m5, m5
+    punpckhbw        m1, m0, m5
+    punpcklbw        m0, m5
+    punpckhbw        m3, m2, m5
+    punpcklbw        m2, m5
+%endmacro
+
+; in: 4 rows of 8 words in m0..m3
+; out: 8 rows of 4 bytes in %1..%8
+%macro TRANSPOSE8x4B_STORE 8
+    packuswb         m0, m2
+    packuswb         m1, m3
+    SBUTTERFLY bw, 0, 1, 2
+    SBUTTERFLY wd, 0, 1, 2
+
+    movd             %1, m0
+    pshufd           m0, m0, 0x39
+    movd             %2, m0
+    pshufd           m0, m0, 0x39
+    movd             %3, m0
+    pshufd           m0, m0, 0x39
+    movd             %4, m0
+
+    movd             %5, m1
+    pshufd           m1, m1, 0x39
+    movd             %6, m1
+    pshufd           m1, m1, 0x39
+    movd             %7, m1
+    pshufd           m1, m1, 0x39
+    movd             %8, m1
+%endmacro
+
+; in: 8 rows of 4 words in %4..%11
+; out: 4 rows of 8 words in m0..m3
+%macro TRANSPOSE4x8W_LOAD 8
+    movq             m0, %1
+    movq             m2, %2
+    movq             m1, %3
+    movq             m3, %4
+
+    punpcklwd        m0, m2
+    punpcklwd        m1, m3
+    punpckhdq        m2, m0, m1
+    punpckldq        m0, m1
+
+    movq             m4, %5
+    movq             m6, %6
+    movq             m5, %7
+    movq             m3, %8
+
+    punpcklwd        m4, m6
+    punpcklwd        m5, m3
+    punpckhdq        m6, m4, m5
+    punpckldq        m4, m5
+
+    punpckhqdq       m1, m0, m4
+    punpcklqdq       m0, m4
+    punpckhqdq       m3, m2, m6
+    punpcklqdq       m2, m6
+
+%endmacro
+
+; in: 4 rows of 8 words in m0..m3
+; out: 8 rows of 4 words in %1..%8
+%macro TRANSPOSE8x4W_STORE 9
+    TRANSPOSE4x4W     0, 1, 2, 3, 4
+
+    pxor             m5, m5; zeros reg
+    CLIPW            m0, m5, %9
+    CLIPW            m1, m5, %9
+    CLIPW            m2, m5, %9
+    CLIPW            m3, m5, %9
+
+    movq             %1, m0
+    movhps           %2, m0
+    movq             %3, m1
+    movhps           %4, m1
+    movq             %5, m2
+    movhps           %6, m2
+    movq             %7, m3
+    movhps           %8, m3
+%endmacro
+
+; in: 8 rows of 8 bytes in %1..%8
+; out: 8 rows of 8 words in m0..m7
+%macro TRANSPOSE8x8B_LOAD 8
+    movq             m7, %1
+    movq             m2, %2
+    movq             m1, %3
+    movq             m3, %4
+
+    punpcklbw        m7, m2
+    punpcklbw        m1, m3
+    punpcklwd        m3, m7, m1
+    punpckhwd        m7, m1
+
+    movq             m4, %5
+    movq             m6, %6
+    movq             m5, %7
+    movq            m15, %8
+
+    punpcklbw        m4, m6
+    punpcklbw        m5, m15
+    punpcklwd        m9, m4, m5
+    punpckhwd        m4, m5
+
+    punpckldq        m1, m3, m9;  0, 1
+    punpckhdq        m3, m9;  2, 3
+
+    punpckldq        m5, m7, m4;  4, 5
+    punpckhdq        m7, m4;  6, 7
+
+    pxor            m13, m13
+
+    punpcklbw        m0, m1, m13; 0 in 16 bit
+    punpckhbw        m1, m13; 1 in 16 bit
+
+    punpcklbw        m2, m3, m13; 2
+    punpckhbw        m3, m13; 3
+
+    punpcklbw        m4, m5, m13; 4
+    punpckhbw        m5, m13; 5
+
+    punpcklbw        m6, m7, m13; 6
+    punpckhbw        m7, m13; 7
+%endmacro
+
+
+; in: 8 rows of 8 words in m0..m8
+; out: 8 rows of 8 bytes in %1..%8
+%macro TRANSPOSE8x8B_STORE 8
+    packuswb         m0, m4
+    packuswb         m1, m5
+    packuswb         m2, m6
+    packuswb         m3, m7
+    TRANSPOSE2x4x4B   0, 1, 2, 3, 4
+
+    movq             %1, m0
+    movhps           %2, m0
+    movq             %3, m1
+    movhps           %4, m1
+    movq             %5, m2
+    movhps           %6, m2
+    movq             %7, m3
+    movhps           %8, m3
+%endmacro
+
+; in: 8 rows of 8 words in %1..%8
+; out: 8 rows of 8 words in m0..m7
+%macro TRANSPOSE8x8W_LOAD 8
+    movdqu           m0, %1
+    movdqu           m1, %2
+    movdqu           m2, %3
+    movdqu           m3, %4
+    movdqu           m4, %5
+    movdqu           m5, %6
+    movdqu           m6, %7
+    movdqu           m7, %8
+    TRANSPOSE8x8W     0, 1, 2, 3, 4, 5, 6, 7, 8
+%endmacro
+
+; in: 8 rows of 8 words in m0..m8
+; out: 8 rows of 8 words in %1..%8
+%macro TRANSPOSE8x8W_STORE 9
+    TRANSPOSE8x8W     0, 1, 2, 3, 4, 5, 6, 7, 8
+
+    pxor             m8, m8
+    CLIPW            m0, m8, %9
+    CLIPW            m1, m8, %9
+    CLIPW            m2, m8, %9
+    CLIPW            m3, m8, %9
+    CLIPW            m4, m8, %9
+    CLIPW            m5, m8, %9
+    CLIPW            m6, m8, %9
+    CLIPW            m7, m8, %9
+
+    movdqu           %1, m0
+    movdqu           %2, m1
+    movdqu           %3, m2
+    movdqu           %4, m3
+    movdqu           %5, m4
+    movdqu           %6, m5
+    movdqu           %7, m6
+    movdqu           %8, m7
+%endmacro
+
+
+; in: %2 clobbered
+; out: %1
+; mask in m11
+; clobbers m10
+%macro MASKED_COPY 2
+    pand             %2, m11 ; and mask
+    pandn           m10, m11, %1; and -mask
+    por              %2, m10
+    mova             %1, %2
+%endmacro
+
+; in: %2 clobbered
+; out: %1
+; mask in %3, will be clobbered
+%macro MASKED_COPY2 3
+    pand             %2, %3 ; and mask
+    pandn            %3, %1; and -mask
+    por              %2, %3
+    mova             %1, %2
+%endmacro
+
+
+ALIGN 16
+; input in m0 ... m3 and tcs in r2. Output in m1 and m2
+%macro CHROMA_DEBLOCK_BODY 1
+    psubw            m4, m2, m1; q0 - p0
+    psubw            m5, m0, m3; p1 - q1
+    psllw            m4, 2; << 2
+    paddw            m5, m4;
+
+    ;tc calculations
+    movq             m6, [tcq]; tc0
+    punpcklwd        m6, m6
+    pshufd           m6, m6, 0xA0; tc0, tc1
+%if cpuflag(ssse3)
+    psignw           m4, m6, [pw_m1]; -tc0, -tc1
+%else
+    pmullw           m4, m6, [pw_m1]; -tc0, -tc1
+%endif
+    ;end tc calculations
+
+    paddw            m5, [pw_4]; +4
+    psraw            m5, 3; >> 3
+
+%if %1 > 8
+    psllw            m4, %1-8; << (BIT_DEPTH - 8)
+    psllw            m6, %1-8; << (BIT_DEPTH - 8)
+%endif
+    pmaxsw           m5, m4
+    pminsw           m5, m6
+    paddw            m1, m5; p0 + delta0
+    psubw            m2, m5; q0 - delta0
+%endmacro
+
+
+
+;-----------------------------------------------------------------------------
+; void ff_hevc_v_loop_filter_chroma(uint8_t *_pix, ptrdiff_t _stride, int32_t *tc,
+;                                   uint8_t *_no_p, uint8_t *_no_q);
+;-----------------------------------------------------------------------------
+%macro LOOP_FILTER_CHROMA 0
+cglobal hevc_v_loop_filter_chroma_8, 3, 5, 7, pix, stride, tc, pix0, r3stride
+    sub            pixq, 2
+    lea       r3strideq, [3*strideq]
+    mov           pix0q, pixq
+    add            pixq, r3strideq
+    TRANSPOSE4x8B_LOAD  PASS8ROWS(pix0q, pixq, strideq, r3strideq)
+    CHROMA_DEBLOCK_BODY 8
+    TRANSPOSE8x4B_STORE PASS8ROWS(pix0q, pixq, strideq, r3strideq)
+    RET
+
+cglobal hevc_v_loop_filter_chroma_10, 3, 5, 7, pix, stride, tc, pix0, r3stride
+    sub            pixq, 4
+    lea       r3strideq, [3*strideq]
+    mov           pix0q, pixq
+    add            pixq, r3strideq
+    TRANSPOSE4x8W_LOAD  PASS8ROWS(pix0q, pixq, strideq, r3strideq)
+    CHROMA_DEBLOCK_BODY 10
+    TRANSPOSE8x4W_STORE PASS8ROWS(pix0q, pixq, strideq, r3strideq), [pw_pixel_max_10]
+    RET
+
+cglobal hevc_v_loop_filter_chroma_12, 3, 5, 7, pix, stride, tc, pix0, r3stride
+    sub            pixq, 4
+    lea       r3strideq, [3*strideq]
+    mov           pix0q, pixq
+    add            pixq, r3strideq
+    TRANSPOSE4x8W_LOAD  PASS8ROWS(pix0q, pixq, strideq, r3strideq)
+    CHROMA_DEBLOCK_BODY 12
+    TRANSPOSE8x4W_STORE PASS8ROWS(pix0q, pixq, strideq, r3strideq), [pw_pixel_max_12]
+    RET
+
+;-----------------------------------------------------------------------------
+; void ff_hevc_h_loop_filter_chroma(uint8_t *_pix, ptrdiff_t _stride, int32_t *tc,
+;                                   uint8_t *_no_p, uint8_t *_no_q);
+;-----------------------------------------------------------------------------
+cglobal hevc_h_loop_filter_chroma_8, 3, 4, 7, pix, stride, tc, pix0
+    mov           pix0q, pixq
+    sub           pix0q, strideq
+    sub           pix0q, strideq
+    movq             m0, [pix0q];    p1
+    movq             m1, [pix0q+strideq]; p0
+    movq             m2, [pixq];    q0
+    movq             m3, [pixq+strideq]; q1
+    pxor             m5, m5; zeros reg
+    punpcklbw        m0, m5
+    punpcklbw        m1, m5
+    punpcklbw        m2, m5
+    punpcklbw        m3, m5
+    CHROMA_DEBLOCK_BODY  8
+    packuswb         m1, m2
+    movh[pix0q+strideq], m1
+    movhps       [pixq], m1
+    RET
+
+cglobal hevc_h_loop_filter_chroma_10, 3, 4, 7, pix, stride, tc, pix0
+    mov          pix0q, pixq
+    sub          pix0q, strideq
+    sub          pix0q, strideq
+    movu            m0, [pix0q];    p1
+    movu            m1, [pix0q+strideq]; p0
+    movu            m2, [pixq];    q0
+    movu            m3, [pixq+strideq]; q1
+    CHROMA_DEBLOCK_BODY 10
+    pxor            m5, m5; zeros reg
+    CLIPW           m1, m5, [pw_pixel_max_10]
+    CLIPW           m2, m5, [pw_pixel_max_10]
+    movu [pix0q+strideq], m1
+    movu        [pixq], m2
+    RET
+
+cglobal hevc_h_loop_filter_chroma_12, 3, 4, 7, pix, stride, tc, pix0
+    mov          pix0q, pixq
+    sub          pix0q, strideq
+    sub          pix0q, strideq
+    movu            m0, [pix0q];    p1
+    movu            m1, [pix0q+strideq]; p0
+    movu            m2, [pixq];    q0
+    movu            m3, [pixq+strideq]; q1
+    CHROMA_DEBLOCK_BODY 12
+    pxor            m5, m5; zeros reg
+    CLIPW           m1, m5, [pw_pixel_max_12]
+    CLIPW           m2, m5, [pw_pixel_max_12]
+    movu [pix0q+strideq], m1
+    movu        [pixq], m2
+    RET
+%endmacro
+
+INIT_XMM sse2
+LOOP_FILTER_CHROMA
+INIT_XMM avx
+LOOP_FILTER_CHROMA

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -274,10 +274,6 @@ ALIGN 16
     paddw            m5, [pw_4]; +4
     psraw            m5, 3; >> 3
 
-%if %1 > 8
-    psllw            m4, %1-8; << (BIT_DEPTH - 8)
-    psllw            m6, %1-8; << (BIT_DEPTH - 8)
-%endif
     pmaxsw           m5, m4
     pminsw           m5, m6
     paddw            m1, m5; p0 + delta0
@@ -291,7 +287,7 @@ ALIGN 16
 ;                                   uint8_t *_no_p, uint8_t *_no_q);
 ;-----------------------------------------------------------------------------
 %macro LOOP_FILTER_CHROMA 0
-cglobal hevc_v_loop_filter_chroma_8, 3, 5, 7, pix, stride, tc, pix0, r3stride
+cglobal vvc_v_loop_filter_chroma_8, 4, 6, 7, pix, stride, beta, tc, pix0, r3stride
     sub            pixq, 2
     lea       r3strideq, [3*strideq]
     mov           pix0q, pixq
@@ -301,7 +297,7 @@ cglobal hevc_v_loop_filter_chroma_8, 3, 5, 7, pix, stride, tc, pix0, r3stride
     TRANSPOSE8x4B_STORE PASS8ROWS(pix0q, pixq, strideq, r3strideq)
     RET
 
-cglobal hevc_v_loop_filter_chroma_10, 3, 5, 7, pix, stride, tc, pix0, r3stride
+cglobal vvc_v_loop_filter_chroma_10, 4, 6, 7, pix, stride, beta, tc, pix0, r3stride
     sub            pixq, 4
     lea       r3strideq, [3*strideq]
     mov           pix0q, pixq
@@ -311,7 +307,7 @@ cglobal hevc_v_loop_filter_chroma_10, 3, 5, 7, pix, stride, tc, pix0, r3stride
     TRANSPOSE8x4W_STORE PASS8ROWS(pix0q, pixq, strideq, r3strideq), [pw_pixel_max_10]
     RET
 
-cglobal hevc_v_loop_filter_chroma_12, 3, 5, 7, pix, stride, tc, pix0, r3stride
+cglobal vvc_v_loop_filter_chroma_12, 4, 6, 7, pix, stride, beta, tc, pix0, r3stride
     sub            pixq, 4
     lea       r3strideq, [3*strideq]
     mov           pix0q, pixq
@@ -321,11 +317,14 @@ cglobal hevc_v_loop_filter_chroma_12, 3, 5, 7, pix, stride, tc, pix0, r3stride
     TRANSPOSE8x4W_STORE PASS8ROWS(pix0q, pixq, strideq, r3strideq), [pw_pixel_max_12]
     RET
 
+;        (uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
+;        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
+
 ;-----------------------------------------------------------------------------
 ; void ff_hevc_h_loop_filter_chroma(uint8_t *_pix, ptrdiff_t _stride, int32_t *tc,
 ;                                   uint8_t *_no_p, uint8_t *_no_q);
 ;-----------------------------------------------------------------------------
-cglobal hevc_h_loop_filter_chroma_8, 3, 4, 7, pix, stride, tc, pix0
+cglobal vvc_h_loop_filter_chroma_8, 3, 4, 7, pix, stride, beta, tc, pix0
     mov           pix0q, pixq
     sub           pix0q, strideq
     sub           pix0q, strideq
@@ -344,7 +343,7 @@ cglobal hevc_h_loop_filter_chroma_8, 3, 4, 7, pix, stride, tc, pix0
     movhps       [pixq], m1
     RET
 
-cglobal hevc_h_loop_filter_chroma_10, 3, 4, 7, pix, stride, tc, pix0
+cglobal vvc_h_loop_filter_chroma_10, 3, 4, 7, pix, stride, beta, tc, pix0
     mov          pix0q, pixq
     sub          pix0q, strideq
     sub          pix0q, strideq
@@ -360,7 +359,7 @@ cglobal hevc_h_loop_filter_chroma_10, 3, 4, 7, pix, stride, tc, pix0
     movu        [pixq], m2
     RET
 
-cglobal hevc_h_loop_filter_chroma_12, 3, 4, 7, pix, stride, tc, pix0
+cglobal vvc_h_loop_filter_chroma_12, 3, 4, 7, pix, stride, beta, tc, pix0
     mov          pix0q, pixq
     sub          pix0q, strideq
     sub          pix0q, strideq

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -9,9 +9,11 @@ cextern pw_1023
 pw_pixel_max_12: times 8 dw ((1 << 12)-1)
 pw_2 :           times 8 dw  2
 pw_m2:           times 8 dw -2
-pd_1 :           times 4 dd  1
-pd_5 :           times 4 dd  5
+pw_1 :           times 8 dw  1
+pw_5 :           times 8 dw  5
 pd_3 :           times 4 dd  3
+pd_1 :           times 4 dd 1
+
 
 cextern pw_4
 cextern pw_8
@@ -265,8 +267,7 @@ ALIGN 16
     paddw            m13, [pw_4] ; +4
     psraw            m13, 3      ; >> 3
 
-    pmaxsw           m13, m8
-    pminsw           m13, m9
+    CLIPW            m13, m8, m9
     paddw            m14, m3, m13 ; p0 + delta0
     psubw            m15, m4, m13 ; q0 - delta0
     MASKED_COPY       m3, m14
@@ -275,7 +276,7 @@ ALIGN 16
 
 %macro CLIP_RESTORE 4  ; toclip, value, -tc, +tc
     paddw           %3, %2
-    paddd           %4, %2
+    paddw           %4, %2
     CLIPW           %1, %3, %4
     psubw           %3, %2
     psubw           %4, %2
@@ -290,67 +291,88 @@ ALIGN 16
     paddw         m12, m3
     paddw         m12, m4
     paddw         m12, [pw_4]
-    movu          m15, m12      ; p3 +  p2 + p1 +  p0 +   q0 + 4
+    movu          m15, m12      ; p3 +  p2 + p1 +  p0 + q0 + 4
     paddw         m12, m3
     paddw         m12, m5       ; q1
     paddw         m12, m6       ; q2
-    psrlw         m12, 3
+    psraw         m12, 3
     CLIP_RESTORE  m12, m3, m8, m9
     
     ; p1
-    paddw        m13, m15, m10
-    paddw        m13, m2
-    paddw        m13, m5
-    psrlw         m0, 3
+    paddw        m13, m15, m0 ; + p3
+    paddw        m13, m2      ; + p1
+    paddw        m13, m5      ; + q1
+    psraw        m13, 3
     CLIP_RESTORE  m13, m2, m8, m9
 
     ; p2
-    psllw         m14, m15, 1
-    paddw         m14, m10
-    paddw         m14, m1
+    psllw         m14, m0, 1 ; 2*p3
+    paddw         m14, m15
+    paddw         m14, m1    ; + p2
+    psraw         m14, 3
     CLIP_RESTORE  m14, m1, m8, m9
 
     ; q0
     ; clobber m0 / P3 - not used anymore
-    paddw         m0, m3, m4
-    paddw         m0, m5
-    paddw         m0, m6
-    paddw         m0, m7
+    paddw         m0, m3, m4    ; p0 + q0
+    paddw         m0, m5        ; + q1
+    paddw         m0, m6        ; + q2
+    paddw         m0, m7        ; + q3
     paddw         m0, [pw_4]
-    movu          m15, m0  ; p0 + q0 + q1 + q2 + q3+ 4
-    paddw         m0, m1   ; p2 free
-    paddw         m0, m2
-    paddw         m0, m3
-    psrlw         m0, 3
+    movu          m15, m0       ; p0 + q0 + q1 + q2 + q3 + 4
+    paddw         m0, m1        ; + p2  -- p2 is unused after this point
+    paddw         m0, m2        ; + p1
+    paddw         m0, m4        ; + q0
+    psraw         m0, 3
     CLIP_RESTORE  m0, m4, m8, m9
 
     ; q1
     ; clobber m1 / P2 - last use was q0 calc
-    paddw         m1, m2, m15; p1 + ...
-    paddw         m1, m5
-    paddw         m1, m7
-    psrlw         m1, 3
+    paddw         m1, m2, m15; p0 + ...   + p1
+    paddw         m1, m5     ; + q1
+    paddw         m1, m7     ; + q3
+    psraw         m1, 3
     CLIP_RESTORE  m1, m5, m8, m9
 
     ; q2
     ; clobber m15 - sum is fully used
-    paddw         m15, m7
-    paddw         m15, m7
-    paddw         m15, m6
-    psrlw         m15, 3
+    paddw         m15, m7  ; + q3
+    paddw         m15, m7  ; + q3
+    paddw         m15, m6  ; + q2
+    psraw         m15, 3 
     CLIP_RESTORE  m15, m6, m8, m9
 
-    MASKED_COPY m3, m12 ; p0 
-    MASKED_COPY m2, m13 ; p1
-    MASKED_COPY m1, m14 ; p2
     MASKED_COPY m4, m0  ; q0
     MASKED_COPY m5, m1  ; q1
     MASKED_COPY m6, m15 ; q2
+    MASKED_COPY m3, m12 ; p0 
+    MASKED_COPY m2, m13 ; p1
+    MASKED_COPY m1, m14 ; p2
 %endmacro
 
 ; m11 strong mask, m8/m9 -tc, tc
 ; p3 to q3 in m0, m7 - clobbers p3
 %macro SPATIAL_ACTIVITY 1
+    pxor            m10, m10
+    movd            m11, [max_len_pq]
+    punpcklbw       m11, m11, m10
+    punpcklwd       m11, m11, m10
+
+    pcmpeqd         m11, [pd_1]
+
+    cmp           shiftd, 1
+    je           .max_len_pq_spatial_shift
+    punpcklqdq       m11, m11, m11
+    pshufhw          m13, m11, q2222
+    pshuflw          m13, m13, q0000
+    movu             m11, m13
+
+.max_len_pq_spatial_shift:
+    movu             m12, m2
+    movu             m13, m2
+    MASKED_COPY      m0, m12
+    MASKED_COPY      m1, m13
+
     psllw            m9, m2, 1   
     psubw           m10, m1, m9
     paddw           m10, m3 
@@ -376,17 +398,19 @@ ALIGN 16
     punpcklqdq       m11, m11, m11
     pshufhw          m13, m11, q2222
     pshuflw          m13, m13, q0000
-
+    jmp           .load_beta
 .max_len_shift:
     pshufhw          m13, m11, q2301
     pshuflw          m13, m13, q2301
-    movu             m11, m13
 
+.load_beta:
+    movu             m11, m13
     ; Load beta
-    movu             m8, [betaq]  ; quad load 8 values for shift
+    movu             m8, [betaq]
 %if %1 > 8
     psllw            m8, %1 - 8   ; replace with bit_depth
 %endif
+
     cmp           shiftd, 1
     je           .beta_load_shift
     
@@ -394,9 +418,10 @@ ALIGN 16
     pshufhw         m13,  m8, q2222
     pshuflw         m13, m13, q0000
 
+; dsam calcs
     pshufhw         m14,  m9, q0033
-    pshufhw          m9,  m9, q3300
     pshuflw         m14, m14, q0033
+    pshufhw          m9,  m9, q3300
     pshuflw          m9,  m9, q3300
 
     jmp  .spatial_activity
@@ -405,9 +430,8 @@ ALIGN 16
     pshufhw         m13, m8,  q2200
     pshuflw         m13, m13, q2200
 
-    pshufhw         m14,  m9, q3210
+    movu            m14, m9
     pshufhw          m9,  m9, q2301                              
-    pshuflw         m14, m14, q3210
     pshuflw          m9,  m9, q2301 
 
 .spatial_activity:
@@ -420,20 +444,7 @@ ALIGN 16
     psllw           m8, m9, 1    ;  d0, d1, d2, d3, ...
     
     pcmpgtw       m15, m8        ; d0 ..  < beta_2, d0... < beta_2, d3... <
-    pand          m11, m15
-
-    cmp           shiftd, 1
-    je    .beta2_mask_shuffle   
-  
-    pshuflw       m15, m15, q0033    ; d3 < ... d3 < ...
-    pshufhw       m15, m15, q0033    ; 
-    pand          m11, m15
-    jmp     .beta3_comparison
-
-.beta2_mask_shuffle:
-    pshuflw       m15, m15, q2301    ; d3 < ... d3 < ...
-    pshufhw       m15, m15, q2301    ; 
-    pand          m11, m15                      
+    pand          m11, m15                 
 
 .beta3_comparison:
     ; beta_3
@@ -454,20 +465,6 @@ ALIGN 16
     pshuflw         m12, m12, q3300 
 .beta3_no_first_shuffle:
     pcmpgtw         m13, m12
-    pand            m11, m13
-
-    cmp           shiftd, 1
-    je    .beta3_mask_shift_shuffle
-
-    pshufhw         m13, m13, q0033
-    pshuflw         m13, m13, q0033
-    pand            m11, m13
-
-    jmp   .tc25_comparison
-
-.beta3_mask_shift_shuffle:
-    pshufhw         m13, m13, q2301
-    pshuflw         m13, m13, q2301
     pand            m11, m13
 
     ; tc25 
@@ -493,8 +490,8 @@ ALIGN 16
 
 .tc25_calculation:
     movu             m9, m8
-    pmulld           m8, [pd_5]
-    paddd            m8, [pd_1]
+    pmullw           m8, [pw_5]
+    paddw            m8, [pw_1]
     psrlw            m8, 1          ; ((tc * 5 + 1) >> 1);
 
     psubw           m12, m3, m4     ;      p0 - q0
@@ -510,15 +507,17 @@ ALIGN 16
     pcmpgtw          m15, m8, m12
     pand             m11, m15
 
+    ; final shift mask
+    movu          m15, m11
     cmp           shiftd, 1
-    je  .tc25_shift_mask
+    je  .final_shift_mask
 
     pshufhw         m15, m15, q0033 
     pshuflw         m15, m15, q0033 
     pand            m11, m15
     jmp   .prep_clipping_masks
 
-.tc25_shift_mask:
+.final_shift_mask:
     pshufhw         m15, m15, q2301 
     pshuflw         m15, m15, q2301
     pand            m11, m15
@@ -536,17 +535,17 @@ ALIGN 16
     paddw          m0, [pw_4] ;      p0 + q0 + q1 + q2 + 4
     paddw          m0, m2     ; p1 + p0 + q0 + q1 + q2 + 4
     movu           m15, m0 
-    paddw          m0, m2
-    paddw          m0, m2
-    paddw          m0, m3
+    paddw          m0, m2     ; + p1
+    paddw          m0, m2     ; + p1
+    paddw          m0, m3     ; + p0
     psrlw          m0, 3
 
     CLIP_RESTORE   m0, m3, m8, m9
 
     ; q0
-    paddw          m12, m2, m15
-    paddw          m12, m4   ;q0
-    paddw          m12, m7   ;q3
+    paddw          m12, m2, m15 ; + p1
+    paddw          m12, m4      ;  q0
+    paddw          m12, m7      ; q3
 
     psrlw          m12, 3
 
@@ -615,9 +614,9 @@ cglobal vvc_h_loop_filter_chroma_8, 9, 13, 16, pix, stride, beta, tc, no_p, no_q
     sub           pix0q, src3strideq
     sub           pix0q, strideq
 
+    movq             m0, [pix0q             ] ;  p1
+    movq             m1, [pix0q +   strideq] ;  p1
     movq             m2, [pix0q + 2 * strideq] ;  p1
-    movu             m0, m2                    ;  p3
-    movu             m1, m2                    ;  p2
     movq             m3, [pix0q + src3strideq] ;  p0
     movq             m4, [pixq]                ;  q0
     movq             m5, [pixq +     strideq]  ;  q1
@@ -635,8 +634,60 @@ cglobal vvc_h_loop_filter_chroma_8, 9, 13, 16, pix, stride, beta, tc, no_p, no_q
     punpcklbw        m7, m12
 
     SPATIAL_ACTIVITY 8
+
+    movq             m0, [pix0q    ] ;  p2
+    movq             m1, [pix0q + strideq   ] ;  p1
+    
+    pxor             m12, m12
+    punpcklbw        m0, m12
+    punpcklbw        m1, m12
+
+    sub rsp, 16
+    movu [rsp], m11
+
+    pxor            m10, m10
+    movd            m11, [max_len_pq]
+    punpcklbw       m11, m11, m10
+    punpcklwd       m11, m11, m10
+
+    pcmpeqd         m11, [pd_3]
+
+
+    cmp           shiftd, 1
+    je           .strong_chroma
+    punpcklqdq       m11, m11, m11
+    pshufhw          m13, m11, q2222
+    pshuflw          m13, m13, q0000
+    movu             m11, m13
+
+.strong_chroma:
+    pand             m11, [rsp]
+    STRONG_CHROMA
+
+    movq             m14, [pix0q + strideq   ] ;  p1
+    movq             m15, [pix0q + 2 * strideq   ] ;  p2
+    
+    pxor             m12, m12
+    punpcklbw        m14, m12
+    punpcklbw        m15, m12
+
+    MASKED_COPY      m14, m1
+    MASKED_COPY      m15, m2
+    movu             m1, m14
+    movu             m2, m15
+
+    packuswb        m12, m1, m2
+    movh            [pix0q + strideq   ], m12 ;  p1
+    movhps          [pix0q + 2 * strideq   ], m12 ;  p2
+
+
+    pcmpeqd  m12, m12, m12
+    pxor     m11, m11, m12
+    pand     m11, [rsp]
+
     ONE_SIDE_CHROMA
 
+    movu     m11, [rsp]
     pcmpeqd  m12, m12, m12
     pxor     m11, m11, m12
     
@@ -644,17 +695,16 @@ cglobal vvc_h_loop_filter_chroma_8, 9, 13, 16, pix, stride, beta, tc, no_p, no_q
     CHROMA_DEBLOCK_BODY 10
 
     movq             m12, [pix0q + src3strideq] ;  p0
-    movq             m13, [pixq]                ;  q0
+    movq             m0,  [pixq]                ;  q0
     movq             m14, [pixq +     strideq]  ;  q1
     movq             m15, [pixq + 2 * strideq]  ;  q2
 
     pxor             m11, m11
     punpcklbw        m12, m11
-    punpcklbw        m13, m11
+    punpcklbw        m0, m11
     punpcklbw        m14, m11
     punpcklbw        m15, m11
 
-    
 ; no_p
     pxor            m10, m10
     movd            m11, [no_pq]
@@ -697,49 +747,102 @@ cglobal vvc_h_loop_filter_chroma_8, 9, 13, 16, pix, stride, beta, tc, no_p, no_q
 .store_q:
     movu             m11, m13
 
-    MASKED_COPY   m13, m4
+    MASKED_COPY   m0, m4
     MASKED_COPY   m14, m5
     MASKED_COPY   m15, m6
 
-    packuswb         m12, m13
+    packuswb         m12, m0
     packuswb         m14, m15
 
     movh     [pix0q + src3strideq], m12
     movhps                  [pixq], m12
     movh      [pixq +     strideq], m14 ; m4
     movhps    [pixq + 2 * strideq], m14 ; m5
+
+    add rsp, 16
 RET
 
-cglobal vvc_h_loop_filter_chroma_10, 9, 13, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
+cglobal vvc_h_loop_filter_chroma_10, 9, 14, 16, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
     lea    src3strideq, [3 * strideq]
     mov           pix0q, pixq
     sub           pix0q, src3strideq
     sub           pix0q, strideq
 
-    ; for horizontal, p3 and p2 are p1
+    movu             m0, [pix0q]               ;  p3
+    movu             m1, [pix0q + strideq]     ;  p2
     movu             m2, [pix0q + 2 * strideq] ;  p1
-    movu             m0, m2                    ;  p3
-    movu             m1, m2                    ;  p2
     movu             m3, [pix0q + src3strideq] ;  p0
     movu             m4, [pixq]                ;  q0
     movu             m5, [pixq +     strideq]  ;  q1
     movu             m6, [pixq + 2 * strideq]  ;  q2
     movu             m7, [pixq + src3strideq]  ;  q3
 
+
     SPATIAL_ACTIVITY 10
+    
+    movu             m0, [pix0q]                    ;  p3
+    movu             m1, [pix0q + strideq]                    ;  p3
+
+    sub rsp, 16
+    movu [rsp], m11
+
+    movmskps         r13, m11
+    cmp              r13, 0
+    je              .chroma_weak
+
+    pxor            m10, m10
+    movd            m11, [max_len_pq]
+    punpcklbw       m11, m11, m10
+    punpcklwd       m11, m11, m10
+
+    pcmpeqd         m11, [pd_3]
+
+
+    cmp           shiftd, 1
+    je           .strong_chroma
+    punpcklqdq       m11, m11, m11
+    pshufhw          m13, m11, q2222
+    pshuflw          m13, m13, q0000
+    movu             m11, m13
+
+
+.strong_chroma:
+    pand             m11, [rsp]
+    movmskps         r13, m11
+    cmp              r13, 0
+    je              .ONE_SIDE_CHROMA
+    STRONG_CHROMA
+
+    ; store strong changes ... will need to adapt to no_p
+    pxor           m12, m12
+    CLIPW           m1, m12, [pw_pixel_max_10] ; p0
+    CLIPW           m2, m12, [pw_pixel_max_10] ; p0
+    MASKED_COPY   [pix0q +     strideq], m1
+    MASKED_COPY   [pix0q +   2*strideq], m2
+
+.ONE_SIDE_CHROMA:
+    ; invert mask & all strong mask, to get only one-sided mask
+    pcmpeqd  m12, m12, m12
+    pxor     m11, m11, m12
+    pand     m11, [rsp]
+
+    movmskps         r13, m11
+    cmp              r13, 0
+    je              .chroma_weak
+
     ONE_SIDE_CHROMA
 
+.chroma_weak:   
+    movu     m11, [rsp]
     pcmpeqd  m12, m12, m12
     pxor     m11, m11, m12
     
-    ; chroma weak
     CHROMA_DEBLOCK_BODY 10
     pxor           m12, m12
     CLIPW           m3, m12, [pw_pixel_max_10] ; p0
     CLIPW           m4, m12, [pw_pixel_max_10] ; q0
     CLIPW           m5, m12, [pw_pixel_max_10] ; p0
     CLIPW           m6, m12, [pw_pixel_max_10] ; p0
-
 
 ; no_p
     pxor            m10, m10
@@ -760,6 +863,7 @@ cglobal vvc_h_loop_filter_chroma_10, 9, 13, 16, pix, stride, beta, tc, no_p, no_
     pshuflw          m13, m13, q2301
 .store_p:
     movu             m11, m13
+
 
     MASKED_COPY   [pix0q + src3strideq], m3
 
@@ -784,36 +888,74 @@ cglobal vvc_h_loop_filter_chroma_10, 9, 13, 16, pix, stride, beta, tc, no_p, no_
     movu             m11, m13
 
     MASKED_COPY                  [pixq], m4
-    MASKED_COPY    [pixq +     strideq], m5 ; m4
-    MASKED_COPY    [pixq + 2 * strideq], m6 ; m5
-
+    MASKED_COPY    [pixq +     strideq], m5 ; 
+    MASKED_COPY    [pixq + 2 * strideq], m6 ; 
+    
+    add rsp, 16
 RET
 
-cglobal vvc_h_loop_filter_chroma_12, 9, 13, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
+cglobal vvc_h_loop_filter_chroma_12, 9, 13, 16, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
     lea    src3strideq, [3 * strideq]
     mov           pix0q, pixq
     sub           pix0q, src3strideq
     sub           pix0q, strideq
 
+    movu             m0, [pix0q]               ;  p3
+    movu             m1, [pix0q + strideq]     ;  p2
     movu             m2, [pix0q + 2 * strideq] ;  p1
-    movu             m0, m2                    ;  p3
-    movu             m1, m2                    ;  p3
     movu             m3, [pix0q + src3strideq] ;  p0
     movu             m4, [pixq]                ;  q0
     movu             m5, [pixq +     strideq]  ;  q1
     movu             m6, [pixq + 2 * strideq]  ;  q2
     movu             m7, [pixq + src3strideq]  ;  q3
-
-    SPATIAL_ACTIVITY 12
-    ONE_SIDE_CHROMA
     
+    SPATIAL_ACTIVITY 12
+
+    movu             m0, [pix0q]                    ;  p3
+    movu             m1, [pix0q + strideq]                    ;  p3
+
+    sub rsp, 16
+    movu [rsp], m11
+
+    pxor            m10, m10
+    movd            m11, [max_len_pq]
+    punpcklbw       m11, m11, m10
+    punpcklwd       m11, m11, m10
+
+    pcmpeqd         m11, [pd_3]
+
+    cmp           shiftd, 1
+    je           .strong_chroma
+    punpcklqdq       m11, m11, m11
+    pshufhw          m13, m11, q2222
+    pshuflw          m13, m13, q0000
+    movu             m11, m13
+
+.strong_chroma:
+    pand             m11, [rsp]
+    STRONG_CHROMA
+
+    ; store strong changes ... will need to adapt to no_p
+    pxor           m12, m12
+    CLIPW           m1, m12, [pw_pixel_max_12] ; p0
+    CLIPW           m2, m12, [pw_pixel_max_12] ; p0
+    MASKED_COPY   [pix0q +     strideq], m1
+    MASKED_COPY   [pix0q +   2*strideq], m2
+
+    ; invert mask & all strong mask, to get only one-sided mask
+    pcmpeqd  m12, m12, m12
+    pxor     m11, m11, m12
+    pand     m11, [rsp]
+
+    ONE_SIDE_CHROMA
+
+    movu     m11, [rsp]
     pcmpeqd  m12, m12, m12
     pxor     m11, m11, m12
     
-    ; chroma_weak
-    CHROMA_DEBLOCK_BODY 99999 ; doesn't do anything should unmacro it 
-    pxor           m12, m12; zeros reg
-
+    ; chroma weak
+    CHROMA_DEBLOCK_BODY 10
+    pxor           m12, m12
     CLIPW           m3, m12, [pw_pixel_max_12] ; p0
     CLIPW           m4, m12, [pw_pixel_max_12] ; q0
     CLIPW           m5, m12, [pw_pixel_max_12] ; p0
@@ -839,6 +981,7 @@ cglobal vvc_h_loop_filter_chroma_12, 9, 13, 16, pix, stride, beta, tc, no_p, no_
 .store_p:
     movu             m11, m13
 
+
     MASKED_COPY   [pix0q + src3strideq], m3
 
 ; no_q
@@ -862,8 +1005,10 @@ cglobal vvc_h_loop_filter_chroma_12, 9, 13, 16, pix, stride, beta, tc, no_p, no_
     movu             m11, m13
 
     MASKED_COPY                  [pixq], m4
-    MASKED_COPY    [pixq +     strideq], m5 ; m4
-    MASKED_COPY    [pixq + 2 * strideq], m6 ; m5
+    MASKED_COPY    [pixq +     strideq], m5 ; 
+    MASKED_COPY    [pixq + 2 * strideq], m6 ; 
+    
+    add rsp, 16
 RET
 %endmacro
 

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -7,8 +7,11 @@ SECTION_RODATA
 cextern pw_1023
 %define pw_pixel_max_10 pw_1023
 pw_pixel_max_12: times 8 dw ((1 << 12)-1)
+pw_2 :           times 8 dw  2
 pw_m2:           times 8 dw -2
 pd_1 :           times 4 dd  1
+pd_5 :           times 4 dd  5
+pd_3 :           times 4 dd  3
 
 cextern pw_4
 cextern pw_8
@@ -238,7 +241,14 @@ INIT_XMM sse2
     pand             %2, m11 ; and mask
     pandn           m10, m11, %1; and -mask
     por              %2, m10
-    mova             %1, %2
+    movu             %1, %2
+%endmacro
+
+%macro MASKED_COPY_NOT 2
+    pandn          %2, m11, %2 ; and -mask
+    pand           m10, m11, %1; and mask
+    por              %2, m10
+    movu             %1, %2
 %endmacro
 
 ; in: %2 clobbered
@@ -248,39 +258,102 @@ INIT_XMM sse2
     pand             %2, %3 ; and mask
     pandn            %3, %1; and -mask
     por              %2, %3
-    mova             %1, %2
+    movu             %1, %2
 %endmacro
 
 
 ALIGN 16
-; input in m0 ... m3 and tcs in r2. Output in m1 and m2
 %macro CHROMA_DEBLOCK_BODY 1
-    psubw            m4, m2, m1; q0 - p0
-    psubw            m5, m0, m3; p1 - q1
-    psllw            m4, 2; << 2
-    paddw            m5, m4;
+    psubw            m12, m4, m3; q0 - p0
+    psubw            m13, m2, m5; p1 - q1
+    psllw            m12, 2; << 2
+    paddw            m13, m12;
 
-    ;tc calculations
-    movq             m6, [tcq]; tc0
-    punpcklwd        m6, m6
-    pshufd           m6, m6, 0xA0; tc0, tc1
-%if cpuflag(ssse3)
-    psignw           m4, m6, [pw_m1]; -tc0, -tc1
-%else
-    pmullw           m4, m6, [pw_m1]; -tc0, -tc1
-%endif
-    ;end tc calculations
+    paddw            m13, [pw_4]; +4
+    psraw            m13, 3; >> 3
 
-    paddw            m5, [pw_4]; +4
-    psraw            m5, 3; >> 3
-
-    pmaxsw           m5, m4
-    pminsw           m5, m6
-    paddw            m1, m5; p0 + delta0
-    psubw            m2, m5; q0 - delta0
+    pmaxsw           m13, m8
+    pminsw           m13, m9
+    paddw            m14, m3, m13; p0 + delta0
+    psubw            m15, m4, m13; q0 - delta0
+    MASKED_COPY_NOT  m3, m14
+    MASKED_COPY_NOT  m4, m15
 %endmacro
 
+%macro CLIP_RESTORE 4  ; toclip, value, -tc, +tc
+    paddw           %3, %2
+    paddd           %4, %2
+    CLIPW           %1, %3, %4
+    psubw           %3, %2
+    psubw           %4, %2
 
+%endmacro
+
+%macro STRONG_CHROMA 0
+    ; --------  strong calcs -------    
+    ; p0
+    paddw         m12, m0, m1
+    paddw         m12, m2
+    paddw         m12, m3
+    paddw         m12, m4
+    paddw         m12, [pw_4]
+    movu          m15, m12      ; p3 +  p2 + p1 +  p0 +   q0 + 4
+    paddw         m12, m3
+    paddw         m12, m5       ; q1
+    paddw         m12, m6       ; q2
+    psrlw         m12, 3
+    CLIP_RESTORE  m12, m3, m8, m9
+    
+    ; p1
+    paddw        m13, m15, m10
+    paddw        m13, m2
+    paddw        m13, m5
+    psrlw         m0, 3
+    CLIP_RESTORE  m13, m2, m8, m9
+
+    ; p2
+    psllw         m14, m15, 1
+    paddw         m14, m10
+    paddw         m14, m1
+    CLIP_RESTORE  m14, m1, m8, m9
+
+    ; q0
+    ; clobber m0 / P3 - not used anymore
+    paddw         m0, m3, m4
+    paddw         m0, m5
+    paddw         m0, m6
+    paddw         m0, m7
+    paddw         m0, [pw_4]
+    movu          m15, m0  ; p0 + q0 + q1 + q2 + q3+ 4
+    paddw         m0, m1   ; p2 free
+    paddw         m0, m2
+    paddw         m0, m3
+    psrlw         m0, 3
+    CLIP_RESTORE  m0, m4, m8, m9
+
+    ; q1
+    ; clobber m1 / P2 - last use was q0 calc
+    paddw         m1, m2, m15; p1 + ...
+    paddw         m1, m5
+    paddw         m1, m7
+    psrlw         m1, 3
+    CLIP_RESTORE  m1, m5, m8, m9
+
+    ; q2
+    ; clobber m15 - sum is fully used
+    paddw         m15, m7
+    paddw         m15, m7
+    paddw         m15, m6
+    psrlw         m15, 3
+    CLIP_RESTORE  m15, m6, m8, m9
+
+    MASKED_COPY m3, m12 ; p0 
+    MASKED_COPY m2, m13 ; p1
+    MASKED_COPY m1, m14 ; p2
+    MASKED_COPY m4, m0  ; q0
+    MASKED_COPY m5, m1  ; q1
+    MASKED_COPY m6, m15 ; q2
+%endmacro
 
 ;-----------------------------------------------------------------------------
 ; void ff_hevc_v_loop_filter_chroma(uint8_t *_pix, ptrdiff_t _stride, int32_t *tc,
@@ -324,59 +397,840 @@ cglobal vvc_v_loop_filter_chroma_12, 4, 6, 7, pix, stride, beta, tc, pix0, r3str
 ; void ff_hevc_h_loop_filter_chroma(uint8_t *_pix, ptrdiff_t _stride, int32_t *tc,
 ;                                   uint8_t *_no_p, uint8_t *_no_q);
 ;-----------------------------------------------------------------------------
-cglobal vvc_h_loop_filter_chroma_8, 3, 4, 7, pix, stride, beta, tc, pix0
-    mov           pix0q, pixq
-    sub           pix0q, strideq
-    sub           pix0q, strideq
-    movq             m0, [pix0q];    p1
-    movq             m1, [pix0q+strideq]; p0
-    movq             m2, [pixq];    q0
-    movq             m3, [pixq+strideq]; q1
-    pxor             m5, m5; zeros reg
-    punpcklbw        m0, m5
-    punpcklbw        m1, m5
-    punpcklbw        m2, m5
-    punpcklbw        m3, m5
-    CHROMA_DEBLOCK_BODY  8
-    packuswb         m1, m2
-    movh[pix0q+strideq], m1
-    movhps       [pixq], m1
-    RET
+cglobal vvc_h_loop_filter_chroma_8, 9, 13, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
+    lea                  src3strideq, [3 * strideq]
+    mov                        pix0q, pixq
+    sub                        pix0q, src3strideq
+    sub                        pix0q, strideq
 
-cglobal vvc_h_loop_filter_chroma_10, 3, 4, 7, pix, stride, beta, tc, pix0
-    mov          pix0q, pixq
-    sub          pix0q, strideq
-    sub          pix0q, strideq
-    movu            m0, [pix0q];    p1
-    movu            m1, [pix0q+strideq]; p0
-    movu            m2, [pixq];    q0
-    movu            m3, [pixq+strideq]; q1
+    movq             m0, [pix0q]               ;  p3
+    movq             m1, [pix0q +     strideq] ;  p2
+    movq             m2, [pix0q + 2 * strideq] ;  p1
+    movq             m3, [pix0q + src3strideq] ;  p0
+    movq             m4, [pixq]                ;  q0
+    movq             m5, [pixq +     strideq]  ;  q1
+    movq             m6, [pixq + 2 * strideq]  ;  q2
+    movq             m7, [pixq + src3strideq]  ;  q3
+
+    pxor             m12, m12; zeros reg
+    punpcklbw        m0, m12
+    punpcklbw        m1, m12
+    punpcklbw        m2, m12
+    punpcklbw        m3, m12
+    punpcklbw        m4, m12
+    punpcklbw        m5, m12
+    punpcklbw        m6, m12
+    punpcklbw        m7, m12
+
+    ; for horizontal, max_len_p == 1 and p3 and p2 are p1
+    movu             m0, m2
+    movu             m1, m2
+
+    ; for max_len = 3 we need to determine whether to decrease the length 
+    psllw            m9, m2, 1   
+    psubw           m10, m1, m9
+    paddw           m10, m3 
+    ABS1            m10, m11
+
+    psllw            m9, m5, 1   
+    psubw           m11, m6, m9  
+    paddw           m11, m4      
+    ABS1            m11, m13
+
+    paddw           m9, m10, m11  ; m9 spatial activity sum for all cols
+
+    pxor            m10, m10
+    movd            m11, [max_len_qq]
+    punpcklbw       m11, m11, m10
+    punpcklwd       m11, m11, m10
+
+    pcmpeqd         m11, [pd_3];
+
+    cmp           shiftd, 1
+    je           .max_len_shift
+    punpcklqdq       m11, m11, m11
+    pshufhw          m13, m11, q2222
+    pshuflw          m13, m13, q0000
+
+.max_len_shift
+    pshufhw          m13, m11, q2301
+    pshuflw          m13, m13, q2301
+    movu             m11, m13
+
+    ; ----  load beta   --------
+    
+    movu             m8, [betaq]  ; quad load 8 values for shift
+
+    cmp           shiftd, 1
+    je           .beta_load_shift
+    
+    punpcklqdq       m8, m8, m8
+    pshufhw          m13, m8, q2222
+    pshuflw          m13, m13, q0000
+
+    pshufhw         m14,  m9, q0033  ;  d3 d3  d0 d0 in high (block 1) - low of block 9 copied
+    pshufhw          m9,  m9, q3300  ;    d0 d0 d3 d3 
+    pshuflw         m14, m14, q0033  ;   d3 d3  d0 d0 in low (block 2)
+    pshuflw          m9,  m9, q3300  ;    d0 d0 d3 d3
+
+    jmp  .spatial_activity
+
+.beta_load_shift:
+
+    pshufhw          m13, m8,  q2200
+    pshuflw          m13, m13, q2200
+
+    pshufhw         m14,  m9, q3210
+    pshufhw          m9,  m9, q2301                              
+    pshuflw         m14, m14, q3210
+    pshuflw          m9, m9,  q2301 
+
+.spatial_activity:
+            
+    paddw            m14, m9         ; d0 + d3, d0 + d3, d0 + d3, .....
+    pcmpgtw          m15, m13, m14    ; beta > d0 + d3, d0 + d3 (next block)
+    pand             m11, m15         ; save filtering and or at the end
+                                      ; if all 1s then jump
+                                      ; actually this is annoying
+                                      ; with strong mask, then flop the directions
+
+
+    ; ---- beta_2 comparison -----
+    psraw          m15, m13, 2   ; beta >> 2
+    psllw           m8, m9, 1    ;  d0, d1, d2, d3, ...
+    
+    pcmpgtw       m15, m8        ; d0 ..  < beta_2, d0... < beta_2, d3... <
+    pand          m11, m15
+
+    cmp           shiftd, 1
+    je    .beta2_mask_shuffle   
+  
+    pshuflw       m15, m15, q0033    ; d3 < ... d3 < ...
+    pshufhw       m15, m15, q0033    ; 
+    pand          m11, m15
+    jmp     .beta3_comparison
+
+.beta2_mask_shuffle:
+    pshuflw       m15, m15, q2301    ; d3 < ... d3 < ...
+    pshufhw       m15, m15, q2301    ; 
+    pand          m11, m15                      
+
+.beta3_comparison:
+    ; all zero then jump strong strong
+    ;----beta_3 comparison-----
+    psubw           m12, m0, m3     ; p3 - p0
+    ABS1            m12, m14        ; abs(p3 - p0)
+
+    psubw           m15, m7, m4     ; q3 - q0
+    ABS1            m15, m14        ; abs(q3 - q0)
+
+    paddw           m12, m15        ; abs(p3 - p0) + abs(q3 - q0)
+
+    psraw           m13, 3          ; beta >> 3
+
+    cmp           shiftd, 1
+    je    .beta3_no_first_shuffle
+
+    pshufhw         m12, m12, q3300 
+    pshuflw         m12, m12, q3300 
+    ; if shift, don't need to shuffle
+    ; endshift
+
+.beta3_no_first_shuffle:
+    pcmpgtw         m13, m12        ; clobber beta?
+    pand            m11, m13
+
+    cmp           shiftd, 1
+    je    .beta3_mask_shift_shuffle
+
+    pshufhw         m13, m13, q0033
+    pshuflw         m13, m13, q0033
+    pand            m11, m13
+
+    jmp   .tc25_comparison
+    ; if shift then shuffcle
+
+.beta3_mask_shift_shuffle:
+    pshufhw         m13, m13, q2301
+    pshuflw         m13, m13, q2301
+    pand            m11, m13
+    ;----beta_3 comparison end-----
+
+    ;----tc25 comparison---
+.tc25_comparison:
+    movu             m8, [tcq]   ; preprocess non shift so that I load more
+    paddw            m8, [pw_2]
+    psrlw            m8, 2
+    cmp           shiftd, 1
+    je   .tc25_load_shift
+
+    punpcklqdq       m8, m8, m8
+    pshufhw          m8, m8, q2222
+    pshuflw          m8, m8, q0000
+    jmp     .tc25_calculation
+
+.tc25_load_shift:
+
+    pshufhw          m8, m8,  q2200
+    pshuflw          m8, m8,  q2200
+
+.tc25_calculation:
+    movu             m9, m8
+    pmulld           m8, [pd_5]
+    paddd            m8, [pd_1]
+    psrlw            m8, 1          ; ((tc * 5 + 1) >> 1);
+
+    ; --- comparison
+    psubw           m12, m3, m4     ;      p0 - q0
+    ABS1            m12, m14        ; abs(p0 - q0)
+
+    cmp           shiftd, 1
+    je  .tc25_mask
+
+    pshufhw         m12, m12, q3300  
+    pshuflw         m12, m12, q3300
+
+.tc25_mask:
+
+    pcmpgtw          m15, m8, m12   ; tc25 comparisons
+    pand             m11, m15
+
+    cmp           shiftd, 1
+    je  .tc25_shift_mask
+
+    pshufhw         m15, m15, q0033 
+    pshuflw         m15, m15, q0033 
+    pand            m11, m15
+    jmp   .prep_clipping_masks
+
+.tc25_shift_mask:
+    pshufhw         m15, m15, q2301 
+    pshuflw         m15, m15, q2301
+    pand            m11, m15
+
+    ;----tc25 comparison end---
+    
+    ; get clipping mask ready
+
+.prep_clipping_masks:
+    psignw           m8, m9, [pw_m1]; -tc0, -tc1 ; m11 mask, m8/m9 tc
+
+    ; strong one-sided
+    ; p0   -  clobber p3 again
+    paddw          m0, m3, m4 ;      p0 + q0
+    paddw          m0, m5     ;      p0 + q0 + q1
+    paddw          m0, m6     ;      p0 + q0 + q1 + q2
+    paddw          m0, [pw_4] ;      p0 + q0 + q1 + q2 + 4
+    paddw          m0, m2     ; p1 + p0 + q0 + q1 + q2 + 4
+    movu           m15, m0 
+    paddw          m0, m2
+    paddw          m0, m2
+    paddw          m0, m3
+    psrlw          m0, 3
+
+    CLIP_RESTORE   m0, m3, m8, m9
+
+    ; q0
+    paddw          m12, m2, m15
+    paddw          m12, m4   ;q0
+    paddw          m12, m7   ;q3
+
+    psrlw          m12, 3
+
+    CLIP_RESTORE   m12, m4, m8, m9
+
+    ; q1
+    psllw          m13, m7, 1 ; 2*q3
+    paddw          m13, m15  
+    paddw          m13, m5   ; q1
+
+    psrlw          m13, 3
+
+    CLIP_RESTORE   m13, m5, m8, m9
+
+    ;q2 
+    psllw          m14, m7, 1  ;2*q3
+    paddw          m14, m7     ;3*q3
+    paddw          m14, m15    ; 
+    paddw          m14, m6  ; q2
+    psubw          m14, m2  ; sub p1
+
+    psrlw          m14, 3
+
+    CLIP_RESTORE   m14, m6, m8, m9
+
+    MASKED_COPY   m3, m0  ; m2
+    MASKED_COPY   m4, m12 ; m3
+    MASKED_COPY   m5, m13 ; m4
+    MASKED_COPY   m6, m14 ; m5
+
+    ; calculate weak
+.chroma_weak
     CHROMA_DEBLOCK_BODY 10
-    pxor            m5, m5; zeros reg
-    CLIPW           m1, m5, [pw_pixel_max_10]
-    CLIPW           m2, m5, [pw_pixel_max_10]
-    movu [pix0q+strideq], m1
-    movu        [pixq], m2
-    RET
+    pxor           m12, m12; zeros reg
 
-cglobal vvc_h_loop_filter_chroma_12, 3, 4, 7, pix, stride, beta, tc, pix0
-    mov          pix0q, pixq
-    sub          pix0q, strideq
-    sub          pix0q, strideq
-    movu            m0, [pix0q];    p1
-    movu            m1, [pix0q+strideq]; p0
-    movu            m2, [pixq];    q0
-    movu            m3, [pixq+strideq]; q1
-    CHROMA_DEBLOCK_BODY 12
-    pxor            m5, m5; zeros reg
-    CLIPW           m1, m5, [pw_pixel_max_12]
-    CLIPW           m2, m5, [pw_pixel_max_12]
-    movu [pix0q+strideq], m1
-    movu        [pixq], m2
-    RET
+    packuswb         m3, m4
+    packuswb         m5, m6
+
+
+    movh     [pix0q + src3strideq], m3
+    movhps                  [pixq], m3
+    movh      [pixq +     strideq], m5 ; m4
+    movhps    [pixq + 2 * strideq], m5 ; m5
+
+RET
+
+; (uint8_t *pix, ptrdiff_t stride,
+;     const int32_t *beta, const int32_t *tc, const uint8_t *no_p, const uint8_t *no_q,
+;     const uint8_t *max_len_p, const uint8_t *max_len_q, int shift)
+cglobal vvc_h_loop_filter_chroma_10, 9, 13, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
+
+    lea    src3strideq, [3 * strideq]
+    mov           pix0q, pixq
+    sub           pix0q, src3strideq
+    sub           pix0q, strideq
+
+    movu             m0, [pix0q]               ;  p3
+    movu             m1, [pix0q +     strideq] ;  p2
+    movu             m2, [pix0q + 2 * strideq] ;  p1
+    movu             m3, [pix0q + src3strideq] ;  p0
+    movu             m4, [pixq]                ;  q0
+    movu             m5, [pixq +     strideq]  ;  q1
+    movu             m6, [pixq + 2 * strideq]  ;  q2
+    movu             m7, [pixq + src3strideq]  ;  q3
+
+    ; for horizontal, max_len_p == 1 and p3 and p2 are p1
+    movu             m0, m2
+    movu             m1, m2
+
+    ; for max_len = 3 we need to determine whether to decrease the length 
+    psllw            m9, m2, 1   
+    psubw           m10, m1, m9
+    paddw           m10, m3 
+    ABS1            m10, m11
+
+    psllw            m9, m5, 1   
+    psubw           m11, m6, m9  
+    paddw           m11, m4      
+    ABS1            m11, m13
+
+    paddw           m9, m10, m11  ; m9 spatial activity sum for all cols
+
+    pxor            m10, m10
+    movd            m11, [max_len_qq]
+    punpcklbw       m11, m11, m10
+    punpcklwd       m11, m11, m10
+
+    pcmpeqd         m11, [pd_3];
+
+    cmp           shiftd, 1
+    je           .max_len_shift
+    punpcklqdq       m11, m11, m11
+    pshufhw          m13, m11, q2222
+    pshuflw          m13, m13, q0000
+
+.max_len_shift
+    pshufhw          m13, m11, q2301
+    pshuflw          m13, m13, q2301
+    movu             m11, m13
+
+    ; ----  load beta   --------
+    
+    movu             m8, [betaq]  ; quad load 8 values for shift
+    psllw            m8, 10 - 8   ; replace with bit_depth
+
+    cmp           shiftd, 1
+    je           .beta_load_shift
+    
+    punpcklqdq       m8, m8, m8
+    pshufhw          m13, m8, q2222
+    pshuflw          m13, m13, q0000
+
+    pshufhw         m14,  m9, q0033  ;  d3 d3  d0 d0 in high (block 1) - low of block 9 copied
+    pshufhw          m9,  m9, q3300  ;    d0 d0 d3 d3 
+    pshuflw         m14, m14, q0033  ;   d3 d3  d0 d0 in low (block 2)
+    pshuflw          m9,  m9, q3300  ;    d0 d0 d3 d3
+
+    jmp  .spatial_activity
+
+.beta_load_shift:
+
+    pshufhw          m13, m8,  q2200
+    pshuflw          m13, m13, q2200
+
+    pshufhw         m14,  m9, q3210
+    pshufhw          m9,  m9, q2301                              
+    pshuflw         m14, m14, q3210
+    pshuflw          m9, m9,  q2301 
+
+.spatial_activity:
+            
+    paddw            m14, m9         ; d0 + d3, d0 + d3, d0 + d3, .....
+    pcmpgtw          m15, m13, m14    ; beta > d0 + d3, d0 + d3 (next block)
+    pand             m11, m15         ; save filtering and or at the end
+                                      ; if all 1s then jump
+                                      ; actually this is annoying
+                                      ; with strong mask, then flop the directions
+
+
+    ; ---- beta_2 comparison -----
+    psraw          m15, m13, 2   ; beta >> 2
+    psllw           m8, m9, 1    ;  d0, d1, d2, d3, ...
+    
+    pcmpgtw       m15, m8        ; d0 ..  < beta_2, d0... < beta_2, d3... <
+    pand          m11, m15
+
+    cmp           shiftd, 1
+    je    .beta2_mask_shuffle   
+  
+    pshuflw       m15, m15, q0033    ; d3 < ... d3 < ...
+    pshufhw       m15, m15, q0033    ; 
+    pand          m11, m15
+    jmp     .beta3_comparison
+
+.beta2_mask_shuffle:
+    pshuflw       m15, m15, q2301    ; d3 < ... d3 < ...
+    pshufhw       m15, m15, q2301    ; 
+    pand          m11, m15                      
+
+.beta3_comparison:
+    ; all zero then jump strong strong
+    ;----beta_3 comparison-----
+    psubw           m12, m0, m3     ; p3 - p0
+    ABS1            m12, m14        ; abs(p3 - p0)
+
+    psubw           m15, m7, m4     ; q3 - q0
+    ABS1            m15, m14        ; abs(q3 - q0)
+
+    paddw           m12, m15        ; abs(p3 - p0) + abs(q3 - q0)
+
+    psraw           m13, 3          ; beta >> 3
+
+    cmp           shiftd, 1
+    je    .beta3_no_first_shuffle
+
+    pshufhw         m12, m12, q3300 
+    pshuflw         m12, m12, q3300 
+    ; if shift, don't need to shuffle
+    ; endshift
+
+.beta3_no_first_shuffle:
+    pcmpgtw         m13, m12        ; clobber beta?
+    pand            m11, m13
+
+    cmp           shiftd, 1
+    je    .beta3_mask_shift_shuffle
+
+    pshufhw         m13, m13, q0033
+    pshuflw         m13, m13, q0033
+    pand            m11, m13
+
+    jmp   .tc25_comparison
+    ; if shift then shuffcle
+
+.beta3_mask_shift_shuffle:
+    pshufhw         m13, m13, q2301
+    pshuflw         m13, m13, q2301
+    pand            m11, m13
+    ;----beta_3 comparison end-----
+
+    ;----tc25 comparison---
+.tc25_comparison:
+    movu             m8, [tcq]   ; preprocess non shift so that I load more
+    ; psllw            m8, 12 - 10; 
+    cmp           shiftd, 1
+    je   .tc25_load_shift
+
+    punpcklqdq       m8, m8, m8
+    pshufhw          m8, m8, q2222
+    pshuflw          m8, m8, q0000
+    jmp     .tc25_calculation
+
+.tc25_load_shift:
+
+    pshufhw          m8, m8,  q2200
+    pshuflw          m8, m8,  q2200
+
+.tc25_calculation:
+    movu             m9, m8
+    pmulld           m8, [pd_5]
+    paddd            m8, [pd_1]
+    psrlw            m8, 1          ; ((tc * 5 + 1) >> 1);
+
+    ; --- comparison
+    psubw           m12, m3, m4     ;      p0 - q0
+    ABS1            m12, m14        ; abs(p0 - q0)
+
+    cmp           shiftd, 1
+    je  .tc25_mask
+
+    pshufhw         m12, m12, q3300  
+    pshuflw         m12, m12, q3300
+
+.tc25_mask:
+
+    pcmpgtw          m15, m8, m12   ; tc25 comparisons
+    pand             m11, m15
+
+    cmp           shiftd, 1
+    je  .tc25_shift_mask
+
+    pshufhw         m15, m15, q0033 
+    pshuflw         m15, m15, q0033 
+    pand            m11, m15
+    jmp   .prep_clipping_masks
+
+.tc25_shift_mask:
+    pshufhw         m15, m15, q2301 
+    pshuflw         m15, m15, q2301
+    pand            m11, m15
+
+    ;----tc25 comparison end---
+    
+    ; get clipping mask ready
+
+.prep_clipping_masks:
+    psignw           m8, m9, [pw_m1]; -tc0, -tc1 ; m11 mask, m8/m9 tc
+
+    ; strong one-sided
+    ; p0   -  clobber p3 again
+    paddw          m0, m3, m4 ;      p0 + q0
+    paddw          m0, m5     ;      p0 + q0 + q1
+    paddw          m0, m6     ;      p0 + q0 + q1 + q2
+    paddw          m0, [pw_4] ;      p0 + q0 + q1 + q2 + 4
+    paddw          m0, m2     ; p1 + p0 + q0 + q1 + q2 + 4
+    movu           m15, m0 
+    paddw          m0, m2
+    paddw          m0, m2
+    paddw          m0, m3
+    psrlw          m0, 3
+
+    CLIP_RESTORE   m0, m3, m8, m9
+
+    ; q0
+    paddw          m12, m2, m15
+    paddw          m12, m4   ;q0
+    paddw          m12, m7   ;q3
+
+    psrlw          m12, 3
+
+    CLIP_RESTORE   m12, m4, m8, m9
+
+    ; q1
+    psllw          m13, m7, 1 ; 2*q3
+    paddw          m13, m15  
+    paddw          m13, m5   ; q1
+
+    psrlw          m13, 3
+
+    CLIP_RESTORE   m13, m5, m8, m9
+
+    ;q2 
+    psllw          m14, m7, 1  ;2*q3
+    paddw          m14, m7     ;3*q3
+    paddw          m14, m15    ; 
+    paddw          m14, m6  ; q2
+    psubw          m14, m2  ; sub p1
+
+    psrlw          m14, 3
+
+    CLIP_RESTORE   m14, m6, m8, m9
+
+    MASKED_COPY   m3, m0  ; m2
+    MASKED_COPY   m4, m12 ; m3
+    MASKED_COPY   m5, m13 ; m4
+    MASKED_COPY   m6, m14 ; m5
+
+    ; calculate weak
+.chroma_weak
+    
+    CHROMA_DEBLOCK_BODY 10
+    pxor           m12, m12; zeros reg
+
+    CLIPW           m3, m12, [pw_pixel_max_10] ; p0
+    CLIPW           m4, m12, [pw_pixel_max_10] ; q0
+    CLIPW           m5, m12, [pw_pixel_max_10] ; p0
+    CLIPW           m6, m12, [pw_pixel_max_10] ; p0
+
+    movu   [pix0q + src3strideq], m3
+    movu                  [pixq], m4
+    movu    [pixq +     strideq], m5 ; m4
+    movu    [pixq + 2 * strideq], m6 ; m5
+
+RET
+
+cglobal vvc_h_loop_filter_chroma_12, 9, 13, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
+    lea    src3strideq, [3 * strideq]
+    mov           pix0q, pixq
+    sub           pix0q, src3strideq
+    sub           pix0q, strideq
+
+    movu             m0, [pix0q]               ;  p3
+    movu             m1, [pix0q +     strideq] ;  p2
+    movu             m2, [pix0q + 2 * strideq] ;  p1
+    movu             m3, [pix0q + src3strideq] ;  p0
+    movu             m4, [pixq]                ;  q0
+    movu             m5, [pixq +     strideq]  ;  q1
+    movu             m6, [pixq + 2 * strideq]  ;  q2
+    movu             m7, [pixq + src3strideq]  ;  q3
+
+    ; for horizontal, max_len_p == 1 and p3 and p2 are p1
+    movu             m0, m2
+    movu             m1, m2
+
+    ; for max_len = 3 we need to determine whether to decrease the length
+    psllw            m9, m2, 1   
+    psubw           m10, m1, m9
+    paddw           m10, m3 
+    ABS1            m10, m11
+
+    psllw            m9, m5, 1   
+    psubw           m11, m6, m9  
+    paddw           m11, m4      
+    ABS1            m11, m13
+
+    paddw           m9, m10, m11  ; m9 spatial activity sum for all cols
+
+
+    pxor            m10, m10
+    movd            m11, [max_len_qq]
+    punpcklbw       m11, m11, m10
+    punpcklwd       m11, m11, m10
+
+    pcmpeqd         m11, [pd_3];
+
+    cmp           shiftd, 1
+    je           .max_len_shift
+    punpcklqdq       m11, m11, m11
+    pshufhw          m13, m11, q2222
+    pshuflw          m13, m13, q0000
+
+.max_len_shift
+    pshufhw          m13, m11, q2301
+    pshuflw          m13, m13, q2301
+    movu             m11, m13
+
+    ; ----  load beta   --------
+    
+    movu             m8, [betaq]  ; quad load 8 values for shift
+    psllw            m8, 12 - 8   ; replace with bit_depth
+
+    cmp           shiftd, 1
+    je           .beta_load_shift
+    
+    punpcklqdq       m8, m8, m8
+    pshufhw          m13, m8, q2222
+    pshuflw          m13, m13, q0000
+
+    pshufhw         m14,  m9, q0033  ;  d3 d3  d0 d0 in high (block 1) - low of block 9 copied
+    pshufhw          m9,  m9, q3300  ;    d0 d0 d3 d3 
+    pshuflw         m14, m14, q0033  ;   d3 d3  d0 d0 in low (block 2)
+    pshuflw          m9,  m9, q3300  ;    d0 d0 d3 d3
+
+    jmp  .spatial_activity
+
+.beta_load_shift:
+
+    pshufhw          m13, m8,  q2200
+    pshuflw          m13, m13, q2200
+
+.spatial_activity:            
+    paddw            m14, m9         ; d0 + d3, d0 + d3, d0 + d3, .....
+    pcmpgtw          m15, m13, m14    ; beta > d0 + d3, d0 + d3 (next block)
+    pand             m11, m15         ; save filtering and or at the end
+                                      ; if all 1s then jump
+                                      ; actually this is annoying
+                                      ; with strong mask, then flop the directions
+
+
+    ; ---- beta_2 comparison -----
+    psraw          m15, m13, 2   ; beta >> 2
+    psllw           m8, m9, 1    ;  d0, d1, d2, d3, ...
+    
+    pcmpgtw       m15, m8        ; d0 ..  < beta_2, d0... < beta_2, d3... <
+    pand          m11, m15
+
+    cmp           shiftd, 1
+    je    .beta2_mask_shuffle   
+  
+    pshuflw       m15, m15, q0033    ; d3 < ... d3 < ...
+    pshufhw       m15, m15, q0033    ; 
+    pand          m11, m15
+    jmp     .beta3_comparison
+
+.beta2_mask_shuffle:
+    pshuflw       m15, m15, q2301    ; d3 < ... d3 < ...
+    pshufhw       m15, m15, q2301    ; 
+    pand          m11, m15                      
+
+.beta3_comparison:
+    ; all zero then jump strong strong
+    ;----beta_3 comparison-----
+    psubw           m12, m0, m3     ; p3 - p0
+    ABS1            m12, m14        ; abs(p3 - p0)
+
+    psubw           m15, m7, m4     ; q3 - q0
+    ABS1            m15, m14        ; abs(q3 - q0)
+
+    paddw           m12, m15        ; abs(p3 - p0) + abs(q3 - q0)
+
+    psraw           m13, 3          ; beta >> 3
+
+    cmp           shiftd, 1
+    je    .beta3_no_first_shuffle
+
+    pshufhw         m12, m12, q3300 
+    pshuflw         m12, m12, q3300 
+    ; if shift, don't need to shuffle
+    ; endshift
+
+.beta3_no_first_shuffle:
+    pcmpgtw         m13, m12        ; clobber beta?
+    pand            m11, m13
+
+    cmp           shiftd, 1
+    je    .beta3_mask_shift_shuffle
+
+    pshufhw         m13, m13, q0033
+    pshuflw         m13, m13, q0033
+    pand            m11, m13
+
+    jmp   .tc25_comparison
+    ; if shift then shuffcle
+
+.beta3_mask_shift_shuffle:
+    pshufhw         m13, m13, q2301
+    pshuflw         m13, m13, q2301
+    pand            m11, m13
+    ;----beta_3 comparison end-----
+
+    ;----tc25 comparison---
+.tc25_comparison:
+    movu             m8, [tcq]   ; preprocess non shift so that I load more
+    psllw            m8, 12 - 10; 
+    cmp           shiftd, 1
+    je   .tc25_load_shift
+
+    punpcklqdq       m8, m8, m8
+    pshufhw          m8, m8, q2222
+    pshuflw          m8, m8, q0000
+    jmp     .tc25_calculation
+
+.tc25_load_shift:
+
+    pshufhw          m8, m8,  q2200
+    pshuflw          m8, m8,  q2200
+
+.tc25_calculation:
+    movu             m9, m8
+    pmulld           m8, [pd_5]
+    paddd            m8, [pd_1]
+    psrlw            m8, 1          ; ((tc * 5 + 1) >> 1);
+
+    ; --- comparison
+    psubw           m12, m3, m4     ;      p0 - q0
+    ABS1            m12, m14        ; abs(p0 - q0)
+
+    cmp           shiftd, 1
+    je  .tc25_mask
+
+    pshufhw         m12, m12, q3300  
+    pshuflw         m12, m12, q3300
+
+.tc25_mask:
+
+    pcmpgtw          m15, m8, m12   ; tc25 comparisons
+    pand             m11, m15
+
+    cmp           shiftd, 1
+    je  .tc25_shift_mask
+
+    pshufhw         m15, m15, q0033 
+    pshuflw         m15, m15, q0033 
+    pand            m11, m15
+    jmp   .prep_clipping_masks
+
+.tc25_shift_mask:
+    pshufhw         m15, m15, q2301 
+    pshuflw         m15, m15, q2301
+    pand            m11, m15
+
+    ;----tc25 comparison end---
+    
+    ; get clipping mask ready
+
+.prep_clipping_masks:
+    psignw           m8, m9, [pw_m1]; -tc0, -tc1 ; m11 mask, m8/m9 tc
+
+    ; strong one-sided
+    ; p0   -  clobber p3 again
+    paddw          m0, m3, m4 ;      p0 + q0
+    paddw          m0, m5     ;      p0 + q0 + q1
+    paddw          m0, m6     ;      p0 + q0 + q1 + q2
+    paddw          m0, [pw_4] ;      p0 + q0 + q1 + q2 + 4
+    paddw          m0, m2     ; p1 + p0 + q0 + q1 + q2 + 4
+    movu           m15, m0 
+    paddw          m0, m2
+    paddw          m0, m2
+    paddw          m0, m3
+    psrlw          m0, 3
+
+    CLIP_RESTORE   m0, m3, m8, m9
+
+    ; q0
+    paddw          m12, m2, m15
+    paddw          m12, m4   ;q0
+    paddw          m12, m7   ;q3
+
+    psrlw          m12, 3
+
+    CLIP_RESTORE   m12, m4, m8, m9
+
+    ; q1
+    psllw          m13, m7, 1 ; 2*q3
+    paddw          m13, m15  
+    paddw          m13, m5   ; q1
+
+    psrlw          m13, 3
+
+    CLIP_RESTORE   m13, m5, m8, m9
+
+    ;q2 
+    psllw          m14, m7, 1  ;2*q3
+    paddw          m14, m7     ;3*q3
+    paddw          m14, m15    ; 
+    paddw          m14, m6  ; q2
+    psubw          m14, m2  ; sub p1
+
+    psrlw          m14, 3
+
+    CLIP_RESTORE   m14, m6, m8, m9
+
+    MASKED_COPY   m3, m0  ; m2
+    MASKED_COPY   m4, m12 ; m3
+    MASKED_COPY   m5, m13 ; m4
+    MASKED_COPY   m6, m14 ; m5
+
+    ; calculate weak
+.chroma_weak
+    
+    CHROMA_DEBLOCK_BODY 99999 ; doesn't do anything should unmacro it 
+    pxor           m12, m12; zeros reg
+
+    CLIPW           m3, m12, [pw_pixel_max_12] ; p0
+    CLIPW           m4, m12, [pw_pixel_max_12] ; q0
+    CLIPW           m5, m12, [pw_pixel_max_12] ; p0
+    CLIPW           m6, m12, [pw_pixel_max_12] ; p0
+
+    movu   [pix0q + src3strideq], m3
+    movu                  [pixq], m4
+    movu    [pixq +     strideq], m5 ; m4
+    movu    [pixq + 2 * strideq], m6 ; m5
+RET
 %endmacro
 
-INIT_XMM sse2
-LOOP_FILTER_CHROMA
 INIT_XMM avx
+LOOP_FILTER_CHROMA
+
+INIT_XMM avx2
 LOOP_FILTER_CHROMA

--- a/libavcodec/x86/vvc/vvcdsp_init.c
+++ b/libavcodec/x86/vvc/vvcdsp_init.c
@@ -314,7 +314,23 @@ ALF_FUNCS(16, 12, avx2)
 
 int ff_vvc_sad_avx2(const int16_t *src0, const int16_t *src1, int dx, int dy, int block_w, int block_h);
 #define SAD_INIT() c->inter.sad = ff_vvc_sad_avx2
+
+// void ff_hevc_h_loop_filter_chroma(uint8_t *_pix, ptrdiff_t _stride, int32_t *tc,
+//                                   uint8_t *_no_p, uint8_t *_no_q);
+
+
 #endif
+
+void ff_vvc_h_loop_filter_chroma_10_avx(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
+        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
+
+void ff_vvc_h_loop_filter_chroma_12_avx(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
+        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
+void ff_vvc_v_loop_filter_chroma_10_avx(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
+        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
+
+void ff_vvc_v_loop_filter_chroma_12_avx(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
+        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
 
 void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
 {
@@ -337,17 +353,27 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
         if (EXTERNAL_SSE4(cpu_flags)) {
             MC_LINK_SSE4(10);
         }
+        if(EXTERNAL_AVX(cpu_flags)) {
+            c->lf.filter_chroma_asm[0] = ff_vvc_h_loop_filter_chroma_10_avx;
+            c->lf.filter_chroma_asm[1] = ff_vvc_v_loop_filter_chroma_10_avx;
+        }
         if (EXTERNAL_AVX2_FAST(cpu_flags)) {
             ALF_INIT(10);
             AVG_INIT(10, avx2);
             MC_LINKS_AVX2(10);
             MC_LINKS_16BPC_AVX2(10);
             SAD_INIT();
+
+
         }
         break;
     case 12:
         if (EXTERNAL_SSE4(cpu_flags)) {
             MC_LINK_SSE4(12);
+        }
+        if(EXTERNAL_AVX(cpu_flags)) {
+            c->lf.filter_chroma_asm[0] = ff_vvc_h_loop_filter_chroma_10_avx;
+            c->lf.filter_chroma_asm[1] = ff_vvc_v_loop_filter_chroma_10_avx;
         }
         if (EXTERNAL_AVX2_FAST(cpu_flags)) {
             ALF_INIT(12);
@@ -355,6 +381,7 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
             MC_LINKS_AVX2(12);
             MC_LINKS_16BPC_AVX2(12);
             SAD_INIT();
+
         }
         break;
     default:

--- a/libavcodec/x86/vvc/vvcdsp_init.c
+++ b/libavcodec/x86/vvc/vvcdsp_init.c
@@ -320,6 +320,11 @@ int ff_vvc_sad_avx2(const int16_t *src0, const int16_t *src1, int dx, int dy, in
 
 
 #endif
+void ff_vvc_h_loop_filter_chroma_8_avx(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
+        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
+
+void ff_vvc_v_loop_filter_chroma_8_avx(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
+        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
 
 void ff_vvc_h_loop_filter_chroma_10_avx(uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
         const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
@@ -335,12 +340,16 @@ void ff_vvc_v_loop_filter_chroma_12_avx(uint8_t *pix, ptrdiff_t stride, const in
 void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
 {
 #if ARCH_X86_64
+
     const int cpu_flags = av_get_cpu_flags();
 
     switch (bd) {
     case 8:
         if (EXTERNAL_SSE4(cpu_flags)) {
             MC_LINK_SSE4(8);
+        }
+        if(EXTERNAL_AVX(cpu_flags)) {
+            c->lf.filter_chroma[0] = ff_vvc_h_loop_filter_chroma_8_avx;
         }
         if (EXTERNAL_AVX2_FAST(cpu_flags)) {
             ALF_INIT(8);
@@ -354,8 +363,7 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
             MC_LINK_SSE4(10);
         }
         if(EXTERNAL_AVX(cpu_flags)) {
-            c->lf.filter_chroma_asm[0] = ff_vvc_h_loop_filter_chroma_10_avx;
-            c->lf.filter_chroma_asm[1] = ff_vvc_v_loop_filter_chroma_10_avx;
+            c->lf.filter_chroma[0] = ff_vvc_h_loop_filter_chroma_10_avx;
         }
         if (EXTERNAL_AVX2_FAST(cpu_flags)) {
             ALF_INIT(10);
@@ -364,7 +372,6 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
             MC_LINKS_16BPC_AVX2(10);
             SAD_INIT();
 
-
         }
         break;
     case 12:
@@ -372,8 +379,7 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
             MC_LINK_SSE4(12);
         }
         if(EXTERNAL_AVX(cpu_flags)) {
-            c->lf.filter_chroma_asm[0] = ff_vvc_h_loop_filter_chroma_10_avx;
-            c->lf.filter_chroma_asm[1] = ff_vvc_v_loop_filter_chroma_10_avx;
+            c->lf.filter_chroma[0] = ff_vvc_h_loop_filter_chroma_12_avx;
         }
         if (EXTERNAL_AVX2_FAST(cpu_flags)) {
             ALF_INIT(12);

--- a/tests/checkasm/Makefile
+++ b/tests/checkasm/Makefile
@@ -44,7 +44,7 @@ AVCODECOBJS-$(CONFIG_V210_DECODER)      += v210dec.o
 AVCODECOBJS-$(CONFIG_V210_ENCODER)      += v210enc.o
 AVCODECOBJS-$(CONFIG_VORBIS_DECODER)    += vorbisdsp.o
 AVCODECOBJS-$(CONFIG_VP9_DECODER)       += vp9dsp.o
-AVCODECOBJS-$(CONFIG_VVC_DECODER)       += vvc_alf.o vvc_mc.o
+AVCODECOBJS-$(CONFIG_VVC_DECODER)       += vvc_alf.o vvc_mc.o vvc_deblock.o
 
 CHECKASMOBJS-$(CONFIG_AVCODEC)          += $(AVCODECOBJS-yes)
 

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -215,6 +215,8 @@ static const struct {
     #if CONFIG_VVC_DECODER
         { "vvc_alf", checkasm_check_vvc_alf },
         { "vvc_mc",  checkasm_check_vvc_mc  },
+        { "vvc_deblock",  checkasm_check_vvc_deblock  },
+
     #endif
 #endif
 #if CONFIG_AVFILTER

--- a/tests/checkasm/checkasm.h
+++ b/tests/checkasm/checkasm.h
@@ -140,6 +140,7 @@ void checkasm_check_videodsp(void);
 void checkasm_check_vorbisdsp(void);
 void checkasm_check_vvc_alf(void);
 void checkasm_check_vvc_mc(void);
+void checkasm_check_vvc_deblock(void);
 
 struct CheckasmPerf;
 

--- a/tests/checkasm/vvc_deblock.c
+++ b/tests/checkasm/vvc_deblock.c
@@ -18,48 +18,29 @@
 
 #include <string.h>
 
-#include "checkasm.h"
-#include "libavcodec/vvc/ctu.h"
-#include "libavcodec/vvc/data.h"
 #include "libavcodec/vvc/dsp.h"
 
 #include "libavutil/common.h"
 #include "libavutil/intreadwrite.h"
 #include "libavutil/mem_internal.h"
 
+#include "checkasm.h"
+
 static const uint32_t pixel_mask[3] = {0xffffffff, 0x03ff03ff, 0x0fff0fff};
 
 #define SIZEOF_PIXEL ((bit_depth + 7) / 8)
 #define BUF_SIZE 16 * 16
 
-#define randomize_buffers(buf0, buf1, size)               \
-    do                                                    \
-    {                                                     \
-        uint32_t mask = pixel_mask[(bit_depth - 8) >> 1]; \
-        int k;                                            \
-        for (k = 0; k < size; k += 4 / sizeof(*buf0))     \
-        {                                                 \
-            uint32_t r = rnd() & mask;                    \
-            AV_WN32A(buf0 + k, r);                        \
-            AV_WN32A(buf1 + k, r);                        \
-        }                                                 \
+#define randomize_buffers(buf0, buf1, size)                 \
+    do {                                                    \
+        uint32_t mask = pixel_mask[(bit_depth - 8) >> 1];   \
+        int k;                                              \
+        for (k = 0; k < size; k += 4) {                     \
+            uint32_t r = rnd() & mask;                      \
+            AV_WN32A(buf0 + k, r);                          \
+            AV_WN32A(buf1 + k, r);                          \
+        }                                                   \
     } while (0)
-
-#define TC25(x) ((tc[x] * 5 + 1) >> 1)
-#define MASK(x) (uint16_t)(x & ((1 << (bit_depth)) - 1))
-#define GET(x) ((SIZEOF_PIXEL == 1) ? *(uint8_t *)(&x) : *(uint16_t *)(&x))
-#define SET(x, y)                  \
-    do                             \
-    {                              \
-        uint16_t z = MASK(y);      \
-        if (SIZEOF_PIXEL == 1)     \
-            *(uint8_t *)(&x) = z;  \
-        else                       \
-            *(uint16_t *)(&x) = z; \
-    } while (0)
-#define RANDCLIP(x, diff) av_clip(GET(x) - (diff), 0,       \
-                                  (1 << (bit_depth)) - 1) + \
-                              rnd() % FFMAX(2 * (diff), 1)
 
 #define P3 buf[-4 * xstride]
 #define P2 buf[-3 * xstride]
@@ -70,8 +51,64 @@ static const uint32_t pixel_mask[3] = {0xffffffff, 0x03ff03ff, 0x0fff0fff};
 #define Q2 buf[2 * xstride]
 #define Q3 buf[3 * xstride]
 
-static void check_deblock_chroma_horizontal()
-{   
+#define TC25(x) ((tc[x] * 5 + 1) >> 1)
+#define MASK(x) (uint16_t)(x & ((1 << (bit_depth)) - 1))
+#define GET(x) ((SIZEOF_PIXEL == 1) ? *(uint8_t*)(&x) : *(uint16_t*)(&x))
+#define SET(x, y) do { \
+    uint16_t z = MASK(y); \
+    if (SIZEOF_PIXEL == 1) \
+        *(uint8_t*)(&x) = z; \
+    else \
+        *(uint16_t*)(&x) = z; \
+} while (0)
+#define RANDCLIP(x, diff) av_clip(GET(x) - (diff), 0, \
+    (1 << (bit_depth)) - 1) + rnd() % FFMAX(2 * (diff), 1)
+static void randomize_chroma_buffers(int type, int beta[4], int32_t tc[4],
+   uint8_t *buf, ptrdiff_t xstride, ptrdiff_t ystride, const int shift, const int bit_depth)
+{
+    int i, j, b3, tc25, tc25diff, b3diff;
+    const int size = shift ? 4 : 2;
+    const int end = 8 / size;
+
+    for (j = 0; j < size; j++)
+    {
+        tc25 = TC25(j) << (bit_depth - 10);
+
+        tc25diff = FFMAX(tc25 - 1, 0);
+        // 2 or 4 lines per tc
+        for (i = 0; i < end; i++)
+        {
+            b3 = (beta[j] << (bit_depth - 8)) >> 3;
+
+            SET(P0, rnd() % (1 << bit_depth));
+            SET(Q0, RANDCLIP(P0, tc25diff));
+
+            // p3 - p0 up to beta3 budget
+            b3diff = rnd() % b3;
+            SET(P3, RANDCLIP(P0, b3diff));
+            // q3 - q0, reduced budget
+            b3diff = rnd() % FFMAX(b3 - b3diff, 1);
+            SET(Q3, RANDCLIP(Q0, b3diff));
+
+            // same concept, budget across 4 pixels
+            b3 -= b3diff = rnd() % FFMAX(b3, 1);
+            SET(P2, RANDCLIP(P0, b3diff));
+            b3 -= b3diff = rnd() % FFMAX(b3, 1);
+            SET(Q2, RANDCLIP(Q0, b3diff));
+
+            // extra reduced budget for weighted pixels
+            b3 -= b3diff = rnd() % FFMAX(b3 - (1 << (bit_depth - 8)), 1);
+            SET(P1, RANDCLIP(P0, b3diff));
+            b3 -= b3diff = rnd() % FFMAX(b3 - (1 << (bit_depth - 8)), 1);
+            SET(Q1, RANDCLIP(Q0, b3diff));
+
+            buf += ystride;
+        }
+    }
+}
+
+static void check_deblock_chroma(const VVCDSPContext *h, int bit_depth)
+{
     int32_t tc[4] = {(rnd() & 393) + 3, 600, (rnd() & 393) + 3, (rnd() & 393) + 3};
 
     uint8_t no_p[4] = {0, 0, 0, 0};
@@ -80,81 +117,41 @@ static void check_deblock_chroma_horizontal()
     uint8_t max_len_q[4] = {1, 3, 3, 1};
     int shift = 0;
     int beta[4] = {(rnd() & 81) + 8, (rnd() & 81) + 8, (rnd() & 81) + 8, (rnd() & 81) + 8 };
+    int xstride = SIZEOF_PIXEL * 8; // bytes
+    int ystride = 2;                // bytes
 
     LOCAL_ALIGNED_32(uint8_t, buf0, [BUF_SIZE]);
     LOCAL_ALIGNED_32(uint8_t, buf1, [BUF_SIZE]);
 
-    VVCDSPContext context;
-    int bit_depth;
-
     declare_func(void, uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
                  const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
 
-    const int size = shift ? 4 : 2;
-    const int end = 8 / size;
-
-    for (bit_depth = 8; bit_depth <= 12; bit_depth += 2)
+    if (check_func(h->lf.filter_chroma[0], "vvc_h_loop_filter_chroma_%d", bit_depth))
     {
-        int xstride = SIZEOF_PIXEL * 8; // bytes
-        int ystride = 2;                // bytes
 
-        ff_vvc_dsp_init(&context, bit_depth);
-        if (check_func(context.lf.filter_chroma[0], "vvc_h_loop_filter_chroma_%d", bit_depth))
-        {
-            int i, j, b3, tc25, tc25diff, b3diff;
-            randomize_buffers(buf0, buf1, BUF_SIZE);
-            uint8_t *buf = buf0 + xstride * 5;
+        uint8_t *buf = buf0 + xstride * 5;
 
-            for (j = 0; j < size; j++)
-            {
-                tc25 = TC25(j) << (bit_depth - 10);
+        randomize_buffers(buf0, buf1, BUF_SIZE);
+        randomize_chroma_buffers(0, beta, tc, buf, xstride, ystride, shift, bit_depth);
+        memcpy(buf0, buf1, BUF_SIZE);
 
-                tc25diff = FFMAX(tc25 - 1, 0);
-                // 2 or 4 lines per tc
-                for (i = 0; i < end; i++)
-                {
-                    b3 = (beta[j] << (bit_depth - 8)) >> 3;
+        call_ref(buf0 + xstride * 5, xstride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
+        call_new(buf1 + xstride * 5, xstride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
 
-                    SET(P0, rnd() % (1 << bit_depth));
-                    SET(Q0, RANDCLIP(P0, tc25diff));
+        if (memcmp(buf0, buf1, BUF_SIZE))
+            fail();
 
-                    // p3 - p0 up to beta3 budget
-                    b3diff = rnd() % b3;
-                    SET(P3, RANDCLIP(P0, b3diff));
-                    // q3 - q0, reduced budget
-                    b3diff = rnd() % FFMAX(b3 - b3diff, 1);
-                    SET(Q3, RANDCLIP(Q0, b3diff));
-
-                    // same concept, budget across 4 pixels
-                    b3 -= b3diff = rnd() % FFMAX(b3, 1);
-                    SET(P2, RANDCLIP(P0, b3diff));
-                    b3 -= b3diff = rnd() % FFMAX(b3, 1);
-                    SET(Q2, RANDCLIP(Q0, b3diff));
-
-                    // extra reduced budget for weighted pixels
-                    b3 -= b3diff = rnd() % FFMAX(b3 - (1 << (bit_depth - 8)), 1);
-                    SET(P1, RANDCLIP(P0, b3diff));
-                    b3 -= b3diff = rnd() % FFMAX(b3 - (1 << (bit_depth - 8)), 1);
-                    SET(Q1, RANDCLIP(Q0, b3diff));
-
-                    buf += ystride;
-                }
-            }
-            memcpy(buf0, buf1, BUF_SIZE);
-
-            call_ref(buf0 + xstride * 5, xstride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
-            call_new(buf1 + xstride * 5, xstride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
-
-            if (memcmp(buf0, buf1, BUF_SIZE))
-                fail();
-
-            bench_new(buf0 + xstride * 5, xstride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
-        }
+        bench_new(buf0 + xstride * 5, xstride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
     }
-    report("chroma");
 }
 
 void checkasm_check_vvc_deblock(void)
 {
-    check_deblock_chroma_horizontal();
+    VVCDSPContext h;
+
+    for (int bit_depth = 8; bit_depth <= 12; bit_depth += 2) {
+        ff_vvc_dsp_init(&h, bit_depth);
+        check_deblock_chroma(&h, bit_depth);
+    }
+    report("chroma");
 }

--- a/tests/checkasm/vvc_deblock.c
+++ b/tests/checkasm/vvc_deblock.c
@@ -75,20 +75,20 @@ static void randomize_params(int32_t beta[4], int32_t tc[4], const int size)
 static void randomize_chroma_buffers(int type, int beta[4], int32_t tc[4],
    uint8_t *buf, ptrdiff_t xstride, ptrdiff_t ystride, const int shift, const int bit_depth)
 {
-    int i, j, b3, tc25, tc25diff, b3diff;
     const int size = shift ? 4 : 2;
     const int end = 8 / size;
 
     randomize_params(beta, tc, size);
-    for (j = 0; j < size; j++)
+    for (int j = 0; j < size; j++)
     {
-        tc25 = TC25(j) << (bit_depth - 10);
+        const int tc25 = TC25(j) << (bit_depth - 10);
 
-        tc25diff = FFMAX(tc25 - 1, 0);
+        const int tc25diff = FFMAX(tc25 - 1, 0);
         // 2 or 4 lines per tc
-        for (i = 0; i < end; i++)
+        for (int i = 0; i < end; i++)
         {
-            b3 = (beta[j] << (bit_depth - 8)) >> 3;
+            int b3diff;
+            int b3 = (beta[j] << (bit_depth - 8)) >> 3;
 
             SET(P0, rnd() % (1 << bit_depth));
             SET(Q0, RANDCLIP(P0, tc25diff));

--- a/tests/checkasm/vvc_deblock.c
+++ b/tests/checkasm/vvc_deblock.c
@@ -1,0 +1,92 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+
+#include "checkasm.h"
+#include "libavcodec/vvc/ctu.h"
+#include "libavcodec/vvc/data.h"
+#include "libavcodec/vvc/dsp.h"
+
+#include "libavutil/common.h"
+#include "libavutil/intreadwrite.h"
+#include "libavutil/mem_internal.h"
+
+static const uint32_t pixel_mask[3] = { 0xffffffff, 0x03ff03ff, 0x0fff0fff };
+
+#define SIZEOF_PIXEL ((bit_depth + 7) / 8)
+#define BUF_SIZE 16 * 16
+
+#define randomize_buffers(buf0, buf1, size)                 \
+    do {                                                    \
+        uint32_t mask = pixel_mask[(bit_depth - 8) >> 1];   \
+        int k;                                              \
+        for (k = 0; k < size; k += 2) {                     \
+            uint32_t r = rnd() & mask;                      \
+            AV_WN32A(buf0 + k, r);                          \
+            AV_WN32A(buf1 + k, r);                          \
+        }                                                   \
+    } while (0)
+
+static void check_deblock_chroma(VVCDSPContext *context, int bit_depth, int c)
+{
+    // see tctable[] in vvc_filter.c, we check full range
+
+    int32_t tc[2] = {  10, 10 };
+    uint8_t no_p[4] = {0, 0, 0, 0};
+    uint8_t no_q[4] = {0, 0, 0, 0};
+    uint8_t max_len_p[4] = {1, 1, 1, 1};
+    uint8_t max_len_q[4] = {1, 1, 1, 1};
+    int shift = 0;
+    int beta = 10;
+
+    LOCAL_ALIGNED_32(uint16_t, buf0, [BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint16_t, buf1, [BUF_SIZE]);
+
+
+
+    declare_func(void, uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
+        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
+
+    if (check_func(context->lf.filter_chroma_asm[0], "vvc_h_loop_filter_chroma%d", bit_depth))
+    {
+        randomize_buffers(buf0, buf1, BUF_SIZE);
+   
+        if(memcmp(buf0, buf1, BUF_SIZE))
+            fail();
+
+        context->lf.filter_chroma[0](buf1 + 8 * 5, 8 * 2, &beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
+        context->lf.filter_chroma_asm[0](buf0 + 8 * 5, 8 * 2, &beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
+        if (memcmp(buf0, buf1, BUF_SIZE))
+            fail();
+        bench_new(buf0 + 8, 8 * 5, &beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
+    }
+
+}
+
+void checkasm_check_vvc_deblock(void)
+{
+    VVCDSPContext c;
+    int bit_depth;
+
+    bit_depth = 10;
+        ff_vvc_dsp_init(&c, bit_depth);
+        check_deblock_chroma(&c, bit_depth, 1);
+    
+    report("chroma_full");
+}

--- a/tests/checkasm/vvc_deblock.c
+++ b/tests/checkasm/vvc_deblock.c
@@ -71,14 +71,14 @@ static const uint32_t pixel_mask[3] = {0xffffffff, 0x03ff03ff, 0x0fff0fff};
 #define Q3 buf[3 * xstride]
 
 static void check_deblock_chroma_horizontal()
-{
-    int32_t tc[4] = {(rnd() & 393) + 3, (rnd() & 393) + 3, (rnd() & 393) + 3, (rnd() & 393) + 3};
+{   
+    int32_t tc[4] = {(rnd() & 393) + 3, 600, (rnd() & 393) + 3, (rnd() & 393) + 3};
 
     uint8_t no_p[4] = {0, 0, 0, 0};
     uint8_t no_q[4] = {0, 0, 0, 0};
     uint8_t max_len_p[4] = {1, 1, 1, 1};
-    uint8_t max_len_q[4] = {3, 3, 3, 3};
-    int shift = 1;
+    uint8_t max_len_q[4] = {1, 3, 3, 1};
+    int shift = 0;
     int beta[4] = {(rnd() & 81) + 8, (rnd() & 81) + 8, (rnd() & 81) + 8, (rnd() & 81) + 8 };
 
     LOCAL_ALIGNED_32(uint8_t, buf0, [BUF_SIZE]);

--- a/tests/checkasm/vvc_deblock.c
+++ b/tests/checkasm/vvc_deblock.c
@@ -63,6 +63,15 @@ static const uint32_t pixel_mask[3] = {0xffffffff, 0x03ff03ff, 0x0fff0fff};
 } while (0)
 #define RANDCLIP(x, diff) av_clip(GET(x) - (diff), 0, \
     (1 << (bit_depth)) - 1) + rnd() % FFMAX(2 * (diff), 1)
+
+static void randomize_params(int32_t beta[4], int32_t tc[4], const int size)
+{
+    for (int i = 0; i < size; i++) {
+        beta[i] = rand() % 89;
+        tc[i] = rand() % 396;
+    }
+}
+
 static void randomize_chroma_buffers(int type, int beta[4], int32_t tc[4],
    uint8_t *buf, ptrdiff_t xstride, ptrdiff_t ystride, const int shift, const int bit_depth)
 {
@@ -70,6 +79,7 @@ static void randomize_chroma_buffers(int type, int beta[4], int32_t tc[4],
     const int size = shift ? 4 : 2;
     const int end = 8 / size;
 
+    randomize_params(beta, tc, size);
     for (j = 0; j < size; j++)
     {
         tc25 = TC25(j) << (bit_depth - 10);
@@ -109,14 +119,12 @@ static void randomize_chroma_buffers(int type, int beta[4], int32_t tc[4],
 
 static void check_deblock_chroma(const VVCDSPContext *h, int bit_depth)
 {
-    int32_t tc[4] = {(rnd() & 393) + 3, 600, (rnd() & 393) + 3, (rnd() & 393) + 3};
-
+    int32_t beta[4], tc[4];
     uint8_t no_p[4] = {0, 0, 0, 0};
     uint8_t no_q[4] = {0, 0, 0, 0};
     uint8_t max_len_p[4] = {1, 1, 1, 1};
     uint8_t max_len_q[4] = {1, 3, 3, 1};
     int shift = 0;
-    int beta[4] = {(rnd() & 81) + 8, (rnd() & 81) + 8, (rnd() & 81) + 8, (rnd() & 81) + 8 };
     int xstride = SIZEOF_PIXEL * 8; // bytes
     int ystride = 2;                // bytes
 

--- a/tests/checkasm/vvc_deblock.c
+++ b/tests/checkasm/vvc_deblock.c
@@ -27,66 +27,134 @@
 #include "libavutil/intreadwrite.h"
 #include "libavutil/mem_internal.h"
 
-static const uint32_t pixel_mask[3] = { 0xffffffff, 0x03ff03ff, 0x0fff0fff };
+static const uint32_t pixel_mask[3] = {0xffffffff, 0x03ff03ff, 0x0fff0fff};
 
 #define SIZEOF_PIXEL ((bit_depth + 7) / 8)
-#define BUF_SIZE 16 * 16
+#define BUF_SIZE 8 * 8
 
-#define randomize_buffers(buf0, buf1, size)                 \
-    do {                                                    \
-        uint32_t mask = pixel_mask[(bit_depth - 8) >> 1];   \
-        int k;                                              \
-        for (k = 0; k < size; k += 2) {                     \
-            uint32_t r = rnd() & mask;                      \
-            AV_WN32A(buf0 + k, r);                          \
-            AV_WN32A(buf1 + k, r);                          \
-        }                                                   \
+#define randomize_buffers(buf0, buf1, size)               \
+    do                                                    \
+    {                                                     \
+        uint32_t mask = pixel_mask[(bit_depth - 8) >> 1]; \
+        int k;                                            \
+        for (k = 0; k < size; k += 2)                     \
+        {                                                 \
+            uint32_t r = rnd() & mask;                    \
+            AV_WN32A(buf0 + k, r);                        \
+            AV_WN32A(buf1 + k, r);                        \
+        }                                                 \
     } while (0)
 
-static void check_deblock_chroma(VVCDSPContext *context, int bit_depth, int c)
-{
-    // see tctable[] in vvc_filter.c, we check full range
+#define TC25(x) ((tc[x] * 5 + 1) >> 1)
+#define MASK(x) (uint16_t)(x & ((1 << (bit_depth)) - 1))
+#define GET(x) ((SIZEOF_PIXEL == 1) ? *(uint8_t *)(&x) : *(uint16_t *)(&x))
+#define SET(x, y)                  \
+    do                             \
+    {                              \
+        uint16_t z = MASK(y);      \
+        if (SIZEOF_PIXEL == 1)     \
+            *(uint8_t *)(&x) = z;  \
+        else                       \
+            *(uint16_t *)(&x) = z; \
+    } while (0)
+#define RANDCLIP(x, diff) av_clip(GET(x) - (diff), 0,       \
+                                  (1 << (bit_depth)) - 1) + \
+                              rnd() % FFMAX(2 * (diff), 1)
 
-    int32_t tc[2] = {  10, 10 };
+#define P3 buf[-4 * xstride]
+#define P2 buf[-3 * xstride]
+#define P1 buf[-2 * xstride]
+#define P0 buf[-1 * xstride]
+#define Q0 buf[0 * xstride]
+#define Q1 buf[1 * xstride]
+#define Q2 buf[2 * xstride]
+#define Q3 buf[3 * xstride]
+
+static void check_deblock_chroma_horizontal()
+{
+    int32_t tc[4] = {(rnd() & 393) + 3, (rnd() & 393) + 3, (rnd() & 393) + 3, (rnd() & 393) + 3};
+
     uint8_t no_p[4] = {0, 0, 0, 0};
     uint8_t no_q[4] = {0, 0, 0, 0};
     uint8_t max_len_p[4] = {1, 1, 1, 1};
-    uint8_t max_len_q[4] = {1, 1, 1, 1};
-    int shift = 0;
-    int beta = 10;
+    uint8_t max_len_q[4] = {3, 3, 3, 3};
+    int shift = 1;
+    int beta[4] = {(rnd() & 81) + 8, (rnd() & 81) + 8, (rnd() & 81) + 8, (rnd() & 81) + 8 };
 
-    LOCAL_ALIGNED_32(uint16_t, buf0, [BUF_SIZE]);
-    LOCAL_ALIGNED_32(uint16_t, buf1, [BUF_SIZE]);
+    LOCAL_ALIGNED_32(uint8_t, buf0, [BUF_SIZE * 2]);
+    LOCAL_ALIGNED_32(uint8_t, buf1, [BUF_SIZE * 2]);
 
-
+    VVCDSPContext context;
+    int bit_depth;
 
     declare_func(void, uint8_t *pix, ptrdiff_t stride, const int32_t *beta, const int32_t *tc,
-        const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
+                 const uint8_t *no_p, const uint8_t *no_q, const uint8_t *max_len_p, const uint8_t *max_len_q, int shift);
 
-    if (check_func(context->lf.filter_chroma_asm[0], "vvc_h_loop_filter_chroma%d", bit_depth))
+    const int size = shift ? 4 : 2;
+    const int end = 8 / size;
+
+    for (bit_depth = 8; bit_depth <= 12; bit_depth += 2)
     {
-        randomize_buffers(buf0, buf1, BUF_SIZE);
-   
-        if(memcmp(buf0, buf1, BUF_SIZE))
-            fail();
+        int xstride = SIZEOF_PIXEL * 8; // bytes
+        int ystride = 2;                // bytes
+        uint8_t *buf = buf0 + xstride * 5;
 
-        context->lf.filter_chroma[0](buf1 + 8 * 5, 8 * 2, &beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
-        context->lf.filter_chroma_asm[0](buf0 + 8 * 5, 8 * 2, &beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
-        if (memcmp(buf0, buf1, BUF_SIZE))
-            fail();
-        bench_new(buf0 + 8, 8 * 5, &beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
+        ff_vvc_dsp_init(&context, bit_depth);
+        if (check_func(context.lf.filter_chroma[0], "vvc_h_loop_filter_chroma_%d", bit_depth))
+        {
+            int i, j, b3, tc25, tc25diff, b3diff;
+            randomize_buffers(buf0, buf1, BUF_SIZE);
+
+            for (j = 0; j < size; j++)
+            {
+                tc25 = TC25(j) << (bit_depth - 10);
+
+                tc25diff = FFMAX(tc25 - 1, 0);
+                // 2 or 4 lines per tc
+                for (i = 0; i < end; i++)
+                {
+                    b3 = (beta[j] << (bit_depth - 8)) >> 3;
+
+                    SET(P0, rnd() % (1 << bit_depth));
+                    SET(Q0, RANDCLIP(P0, tc25diff));
+
+                    // p3 - p0 up to beta3 budget
+                    b3diff = rnd() % b3;
+                    SET(P3, RANDCLIP(P0, b3diff));
+                    // q3 - q0, reduced budget
+                    b3diff = rnd() % FFMAX(b3 - b3diff, 1);
+                    SET(Q3, RANDCLIP(Q0, b3diff));
+
+                    // same concept, budget across 4 pixels
+                    b3 -= b3diff = rnd() % FFMAX(b3, 1);
+                    SET(P2, RANDCLIP(P0, b3diff));
+                    b3 -= b3diff = rnd() % FFMAX(b3, 1);
+                    SET(Q2, RANDCLIP(Q0, b3diff));
+
+                    // extra reduced budget for weighted pixels
+                    b3 -= b3diff = rnd() % FFMAX(b3 - (1 << (bit_depth - 8)), 1);
+                    SET(P1, RANDCLIP(P0, b3diff));
+                    b3 -= b3diff = rnd() % FFMAX(b3 - (1 << (bit_depth - 8)), 1);
+                    SET(Q1, RANDCLIP(Q0, b3diff));
+
+                    buf += ystride;
+                }
+            }
+            memcpy(buf1, buf0, BUF_SIZE * 2);
+
+            call_ref(buf1 + xstride * 5, xstride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
+            call_new(buf0 + xstride * 5, xstride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
+
+            if (memcmp(buf0, buf1, BUF_SIZE * 2))
+                fail();
+
+            bench_new(buf0 + xstride * 5, xstride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift);
+        }
     }
-
+    report("chroma");
 }
 
 void checkasm_check_vvc_deblock(void)
 {
-    VVCDSPContext c;
-    int bit_depth;
-
-    bit_depth = 10;
-        ff_vvc_dsp_init(&c, bit_depth);
-        check_deblock_chroma(&c, bit_depth, 1);
-    
-    report("chroma_full");
+    check_deblock_chroma_horizontal();
 }


### PR DESCRIPTION
Started taking some notes on the differences between the hevc and vvc implementation.

The current plan is to implement the loop_filter_luma_large as a separate asm chunk re-using bits of code for the hevc_deblock.asm

The hevc_deblock.asm hooks hevc_h_loop_filter_chroma which integrates the decision for filter selection and the calculation. This makes it a bit complicated since vvc has new decisions to make (large filter vs original small), the original small filter has slightly different inputs between hevc / vvc, hevc needs to be ported to avx2, and generally my lack of knowledge of deblocking.

Instead the idea is to start with just the loop_filter_luma_large and hook it directly first. I can re-use utility functions from the HEVC implementation (while porting to avx2) and it will be more easily testable. Once that's completed, I should have enough knowledge to work on integrating the original hevc code. 