### PR TITLE
Use -Werror and -Wpedantic in CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -85,6 +85,10 @@ jobs:
       with:
         path: FFmpeg
 
+    - name: Patch source
+      if: ${{ matrix.compiler.name != 'msvc' }}
+      run: cd FFmpeg && git apply ./.github/workflows/patches/*
+
     - name: Configure
       run: cd FFmpeg && ./configure ${{ matrix.compiler.flags }} ${{ matrix.assembler.flags }} ${{ env.configure_flags }} || (tail ffbuild/config.log; false)
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,11 +20,11 @@ jobs:
           - { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4 }
           - { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
         compiler:
-          - { name: gcc, flags: --cc=gcc }
-          - { name: clang, flags: --cc=clang }
-          - { name: msvc, flags: --toolchain=msvc }
-          - { name: clang-usan, flags: '--toolchain=clang-usan' }
-          - { name: clang-asan, flags: '--toolchain=clang-asan' }
+          - { name: gcc, flags: '--cc=gcc --extra-cflags=-Wpedantic' }
+          - { name: clang, flags: '--cc=clang --extra-cflags=-Wpedantic' }
+          - { name: msvc, flags: '--toolchain=msvc' }
+          - { name: clang-usan, flags: '--toolchain=clang-usan --extra-cflags=-Wpedantic' }
+          - { name: clang-asan, flags: '--toolchain=clang-asan --extra-cflags=-Wpedantic' }
         assembler:
           - { name: no asm, flags: --disable-asm }
           - { name: yasm, flags: --as=yasm }
@@ -38,19 +38,19 @@ jobs:
           - os: { name: linux, runner: ubuntu-latest, shell: bash, runner_threads: 4 }
             assembler: { name: nasm, flags: --as=nasm }
           # Address sanitizer cannot be run with handwritten assembly.
-          - compiler: { name: clang-asan, flags: '--toolchain=clang-asan' }
+          - compiler: { name: clang-asan, flags: '--toolchain=clang-asan --extra-cflags=-Wpedantic' }
             assembler: { name: nasm, flags: --as=nasm }
-          - compiler: { name: clang-asan, flags: '--toolchain=clang-asan' }
+          - compiler: { name: clang-asan, flags: '--toolchain=clang-asan --extra-cflags=-Wpedantic' }
             assembler: { name: yasm, flags: --as=yasm }
           # Windows only supports MSVC.
           - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
-            compiler: { name: gcc, flags: --cc=gcc }
+            compiler: { name: gcc, flags: '--cc=gcc --extra-cflags=-Wpedantic' }
           - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
-            compiler: { name: clang, flags: --cc=clang }
+            compiler: { name: clang, flags: '--cc=clang --extra-cflags=-Wpedantic' }
           - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
-            compiler: { name: clang-usan, flags: '--toolchain=clang-usan' }
+            compiler: { name: clang-usan, flags: '--toolchain=clang-usan --extra-cflags=-Wpedantic' }
           - os: { name: windows, runner: windows-latest, shell: 'msys2 {0}', runner_threads: 1 }
-            compiler: { name: clang-asan, flags: '--toolchain=clang-asan' }
+            compiler: { name: clang-asan, flags: '--toolchain=clang-asan --extra-cflags=-Wpedantic' }
 
     runs-on: ${{ matrix.os.runner }}
     defaults:

--- a/.github/workflows/patches/20-vvc-werror.patch
+++ b/.github/workflows/patches/20-vvc-werror.patch
@@ -1,0 +1,23 @@
+diff --git a/libavcodec/vvc/Makefile b/libavcodec/vvc/Makefile
+index 6a28d32bc2..dc631897d4 100644
+--- a/libavcodec/vvc/Makefile
++++ b/libavcodec/vvc/Makefile
+@@ -15,3 +15,18 @@ OBJS-$(CONFIG_VVC_DECODER)          +=  vvc/dec.o           \
+                                         vvc/ps.o            \
+                                         vvc/refs.o          \
+                                         vvc/thread.o        \
++
++$(SUBDIR)vvc/dec.o: CFLAGS += -Werror
++$(SUBDIR)vvc/dsp.o: CFLAGS += -Werror
++$(SUBDIR)vvc/cabac.o: CFLAGS += -Werror
++$(SUBDIR)vvc/ctu.o: CFLAGS += -Werror
++$(SUBDIR)vvc/data.o: CFLAGS += -Werror
++$(SUBDIR)vvc/filter.o: CFLAGS += -Werror
++$(SUBDIR)vvc/inter.o: CFLAGS += -Werror
++$(SUBDIR)vvc/intra.o: CFLAGS += -Werror
++$(SUBDIR)vvc/intra_utils.o: CFLAGS += -Werror
++$(SUBDIR)vvc/itx_1d.o: CFLAGS += -Werror
++$(SUBDIR)vvc/mvs.o: CFLAGS += -Werror
++$(SUBDIR)vvc/ps.o: CFLAGS += -Werror
++$(SUBDIR)vvc/refs.o: CFLAGS += -Werror
++$(SUBDIR)vvc/thread.o: CFLAGS += -Werror

--- a/.github/workflows/patches/20-vvc-werror.patch
+++ b/.github/workflows/patches/20-vvc-werror.patch
@@ -1,23 +1,10 @@
 diff --git a/libavcodec/vvc/Makefile b/libavcodec/vvc/Makefile
-index 6a28d32bc2..dc631897d4 100644
+index 6a28d32bc2..5e7bea567c 100644
 --- a/libavcodec/vvc/Makefile
 +++ b/libavcodec/vvc/Makefile
-@@ -15,3 +15,18 @@ OBJS-$(CONFIG_VVC_DECODER)          +=  vvc/dec.o           \
+@@ -15,3 +15,5 @@ OBJS-$(CONFIG_VVC_DECODER)          +=  vvc/dec.o           \
                                          vvc/ps.o            \
                                          vvc/refs.o          \
                                          vvc/thread.o        \
 +
-+$(SUBDIR)vvc/dec.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/dsp.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/cabac.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/ctu.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/data.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/filter.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/inter.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/intra.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/intra_utils.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/itx_1d.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/mvs.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/ps.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/refs.o: CFLAGS += -Werror
-+$(SUBDIR)vvc/thread.o: CFLAGS += -Werror
++$(SUBDIR)vvc/%.o: CFLAGS += -Werror


### PR DESCRIPTION
This patchset does two things:
* Adds the `-Werror` flag for only the libavcodec/vvc/*.o objects.  This turns any compilation warnings for these files into CI failures.
* Adds the `-Wpedantic` flag, which adds warnings whenever non-standard C features are used.  This should help catch errors such as that fixed by https://github.com/FFmpeg/FFmpeg/commit/75e3b81f75b778286db7257a0ec4af74913ea67f

Note these stricter compilation settings fail with the current HEAD, due to the error:
```
libavcodec/vvc/intra_template.c:201:63: error: pointers to arrays with different qualifiers are incompatible in ISO C [-Werror=pedantic]
  201 |     FUNC(cclm_select_luma)(fc, x0, y0, avail_t, avail_l, cnt, pos, sel[LUMA]);
```
in this location and various others.