### PR TITLE
Deblocking skip optimizations / handle max_len_{p,q} = 0 case

### DIFF
--- a/libavcodec/vvc/filter.c
+++ b/libavcodec/vvc/filter.c
@@ -847,16 +847,7 @@ static void vvc_deblock(const VVCLocalContext *lc, int x0, int y0, const int rs,
                             fc->vvcdsp.lf.filter_luma[vertical](src, src_stride, beta, tc, no_p, no_q, max_len_p, max_len_q, horizontal_ctu_edge);
                         }
                     } else {
-                        int use_c = 0;      //always use c code only, since asm code is not ready
-                        for (int i = 0; i < DEBLOCK_STEP >> (2 - vs); i++) {
-                            if (!max_len_p[i] || !max_len_q[i])
-                                use_c = 1;
-                        }
-                        if (use_c) {
-                            fc->vvcdsp.lf.filter_chroma_c[vertical](src, src_stride, beta, tc, no_p, no_q, max_len_p, max_len_q, vs);
-                        } else {
-                            fc->vvcdsp.lf.filter_chroma[vertical](src, src_stride, beta, tc, no_p, no_q, max_len_p, max_len_q, vs);
-                        }
+                        fc->vvcdsp.lf.filter_chroma[vertical](src, src_stride, beta, tc, no_p, no_q, max_len_p, max_len_q, vs);
                     }
                 }
             }

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -431,8 +431,8 @@ ALIGN 16
     cmp           shiftd, 1
     je  .tc25_mask
 
-    pshufhw         m12, m12, q2222
-    pshuflw         m12, m12, q0000
+    pshufhw         m12, m12, q3300
+    pshuflw         m12, m12, q3300
     ; intentional fall through
 
 .tc25_mask:


### PR DESCRIPTION
Fixes performance regression after adding in Strong, One-sided & Weak + other checks.

Instead early exit spatial activity calculation if all max_len_q = 1, and jump straight to the weak calculation.

This also reduces coupling in the spatial activity calculation so that individual calculations (eg tc25 vs beta3) are re-arrangeable.