### PR TITLE
vvc_deblock: make b3 minimum 1

### DIFF
--- a/tests/checkasm/vvc_deblock.c
+++ b/tests/checkasm/vvc_deblock.c
@@ -98,7 +98,7 @@ static void randomize_chroma_buffers(int type, int beta[4], int32_t tc[4],
             SET(Q0, RANDCLIP(P0, tc25diff));
 
             // p3 - p0 up to beta3 budget
-            b3diff = rnd() % b3;
+            b3diff = rnd() % FFMAX(b3, 1);
             SET(P3, RANDCLIP(P0, b3diff));
             // q3 - q0, reduced budget
             b3diff = rnd() % FFMAX(b3 - b3diff, 1);


### PR DESCRIPTION
edit: this can be replaced with https://github.com/ffvvc/FFmpeg/pull/241

Otherwise % b3 can cause Exception: Integer Divide by Zero if beta is < 8

Fixes 
https://github.com/ffvvc/FFmpeg/actions/runs/9928111619

```bash
$ make -j16 checkasm && ./tests/checkasm/checkasm.exe --test=vvc_deblock 1678414289
LD      tests/checkasm/checkasm.exe
checkasm: using random seed 1678414289
AVX:
 - vvc_deblock.chroma [OK]
checkasm: all 3 tests passed
```

```bash
$ make -j16 checkasm && ./tests/checkasm/checkasm.exe --test=vvc_deblock 3219973734
make: Nothing to be done for 'checkasm'.
checkasm: using random seed 3219973734
AVX:
 - vvc_deblock.chroma [OK]
checkasm: all 3 tests passed
```