### PR TITLE
Share VVC/HEVC deblock code (weak chroma / chroma)

### DIFF
--- a/libavcodec/x86/hevc_deblock.asm
+++ b/libavcodec/x86/hevc_deblock.asm
@@ -46,34 +46,8 @@ INIT_XMM sse2
 
 ALIGN 16
 ; input in m0 ... m3 and tcs in r2. Output in m1 and m2
-%macro CHROMA_DEBLOCK_BODY 1
-    psubw            m4, m2, m1; q0 - p0
-    psubw            m5, m0, m3; p1 - q1
-    psllw            m4, 2; << 2
-    paddw            m5, m4;
-
-    ;tc calculations
-    movq             m6, [tcq]; tc0
-    punpcklwd        m6, m6
-    pshufd           m6, m6, 0xA0; tc0, tc1
-%if cpuflag(ssse3)
-    psignw           m4, m6, [pw_m1]; -tc0, -tc1
-%else
-    pmullw           m4, m6, [pw_m1]; -tc0, -tc1
-%endif
-    ;end tc calculations
-
-    paddw            m5, [pw_4]; +4
-    psraw            m5, 3; >> 3
-
-%if %1 > 8
-    psllw            m4, %1-8; << (BIT_DEPTH - 8)
-    psllw            m6, %1-8; << (BIT_DEPTH - 8)
-%endif
-    pmaxsw           m5, m4
-    pminsw           m5, m6
-    paddw            m1, m5; p0 + delta0
-    psubw            m2, m5; q0 - delta0
+%macro CHROMA_DEBLOCK_BODY 1    ; last four parameters (m0) unused by hevc
+    H2656_CHROMA_DEBLOCK %1, hevc, m1, m2, m4, m3, m0, m5, m6, m0, m0, m0, m0
 %endmacro
 
 ;-----------------------------------------------------------------------------

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -50,25 +50,7 @@ SECTION .text
 
 ALIGN 16
 %macro WEAK_CHROMA 1
-    psubw            m12, m4, m3 ; q0 - p0
-    psubw            m13, m2, m5 ; p1 - q1
-    psllw            m12, 2      ; << 2
-    paddw            m13, m12    ;
-
-    paddw            m13, [pw_4] ; +4
-    psraw            m13, 3      ; >> 3
-
-    CLIPW            m13, m8, m9
-    paddw            m14, m3, m13 ; p0 + delta0
-    psubw            m15, m4, m13 ; q0 - delta0
-
-    movu             m12, m11
-    pand             m11, [rsp + 16]
-    MASKED_COPY       m3, m14
-
-    movu             m11, m12
-    pand             m11, [rsp]
-    MASKED_COPY       m4, m15
+    H2656_CHROMA_DEBLOCK %1, vvc, m3, m4, m12, m5, m2, m13, m9, m14, m15, m8, m9
 %endmacro
 
 %macro CLIP_RESTORE 4  ; toclip, value, -tc, +tc
@@ -509,6 +491,14 @@ ALIGN 16
     je              .end_weak_chroma
 
     WEAK_CHROMA     %1
+
+    movu             m12, m11
+    pand             m11, [rsp + 16]
+    MASKED_COPY       m3, m14   ; need to mask the copy since we can have a mix of weak + others
+
+    movu             m11, m12
+    pand             m11, [rsp]
+    MASKED_COPY       m4, m15 ; need to mask the copy since we can have a mix of weak + others
 .end_weak_chroma:
     add rsp, 112
 %endmacro


### PR DESCRIPTION
Given that HEVC chroma deblock is just the weak subset of VVC chroma deblock, attempt to share code

* Attempt to replace WEAK_CHROMA (vvc) with CHROMA_DEBLOCK_BODY (vvc)