### PR TITLE
vvc_deblock.asm: reduce stack usage

### DIFF
--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -112,8 +112,11 @@ ALIGN 16
 %endif
 
 %if %1 == 8
-    pand             m11, [rsp ]     ; strong & q
+    movlps           m14, [pixq + strideq]
+    movhps           m14, [pixq + 2 * strideq]
+    pand             m11, m14     ; strong & q
 %else
+    ; movu             m14, m11
     pand             m11, [pixq ]     ; strong & q
 %endif 
 
@@ -340,7 +343,9 @@ ALIGN 16
     CHROMA_FILTER  m3
 
 %if %1 == 8
-    pand         m11, [rsp]         ; no_q
+    movlps       m10, [pixq + strideq]
+    movhps       m10, [pixq + 2 * strideq]
+    pand         m11, m10         ; no_q
 %else
     movu         m10, m11
     pand         m11, [pixq]         ; no_q
@@ -366,8 +371,6 @@ ALIGN 16
     mov spatial_maskq, rsp
     sub rsp, 16
     mov tcptrq, rsp
-    sub rsp, 16  ; rsp + 16 = no_p
-    sub rsp, 16  ; rsp      = no_q
 
     ; no_p
     pxor            m10, m10
@@ -432,7 +435,8 @@ ALIGN 16
     SHUFFLE_ON_SHIFT   m13, m11
     pand               m13, m14
 %if %1 == 8
-    movu             [rsp], m13
+    movh             [pixq + strideq], m13
+    movhps           [pixq + 2 * strideq], m13
 %else
     movu             [pixq], m13
 %endif
@@ -507,16 +511,16 @@ ALIGN 16
 
     movu             m11, m12
 %if %1 == 8
-    movu             m14, m11
-    pand             m11, [rsp]
+    movlps           m14, [pixq + strideq]
+    movhps           m14, [pixq + 2 * strideq]
+    pand             m11, m14
 %else
     movu             m14, m11
     pand             m11, [pixq]
-    ; pand             m11, [rsp]
 %endif
     MASKED_COPY       m4, m15 ; need to mask the copy since we can have a mix of weak + others
 .end_weak_chroma:
-    add rsp, 64
+    add rsp, 32
 %endmacro
 
 %macro LOOP_FILTER_CHROMA 0

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -76,15 +76,6 @@ ALIGN 16
 
     cmp            no_pq, 0
     je      .end_p_calcs
-%if %1 == 8
-    movlps          m15, [pix0q + 2 * strideq]
-    movhps          m15, [pix0q + src3strideq]
-    pand            m11, m15 ; which p
-%else
-    pand            m11, [pix0q + 2 * strideq]
-%endif
-; m15
-
 
     ; P2
     paddw          m14, m0, m0       ; 2 * p3
@@ -104,20 +95,14 @@ ALIGN 16
     cmp            no_qq, 0
     je      .end_q_calcs
 
-%if %1 == 8
-    movlps          m11, [pix0q]
-    movhps          m11, [pix0q + strideq]
-%else
-    movu            m11, [pix0q]
-%endif
 
 %if %1 == 8
-    movlps           m14, [pixq + strideq]
-    movhps           m14, [pixq + 2 * strideq]
+    movlps           m14, [pix0q]
+    movhps           m14, [pix0q + strideq]
     pand             m11, m14     ; strong & q
 %else
     ; movu             m14, m11
-    pand             m11, [pixq ]     ; strong & q
+    pand             m11, [pix0q ]     ; strong & q
 %endif 
 
     ; Q0
@@ -343,12 +328,12 @@ ALIGN 16
     CHROMA_FILTER  m3
 
 %if %1 == 8
-    movlps       m10, [pixq + strideq]
-    movhps       m10, [pixq + 2 * strideq]
+    movlps       m10, [pix0q]
+    movhps       m10, [pix0q + strideq]
     pand         m11, m10         ; no_q
 %else
     movu         m10, m11
-    pand         m11, [pixq]         ; no_q
+    pand         m11, [pix0q]         ; no_q
 %endif
 
     ; Q0
@@ -371,6 +356,8 @@ ALIGN 16
     mov spatial_maskq, rsp
     sub rsp, 16
     mov tcptrq, rsp
+
+    SPATIAL_ACTIVITY %1
 
     ; no_p
     pxor            m10, m10
@@ -435,14 +422,13 @@ ALIGN 16
     SHUFFLE_ON_SHIFT   m13, m11
     pand               m13, m14
 %if %1 == 8
-    movh             [pixq + strideq], m13
-    movhps           [pixq + 2 * strideq], m13
+    movh             [pix0q], m13
+    movhps           [pix0q + strideq], m13
 %else
-    movu             [pixq], m13
+    movu             [pix0q], m13
 %endif
     movmskps         no_qq, m13
 ; end q
-    SPATIAL_ACTIVITY %1
 
 
     movmskps         r14, m11
@@ -463,12 +449,6 @@ ALIGN 16
     cmp              r14, 0
     je              .end_strong_chroma
 
-%if %1 == 8
-    movh       [pix0q], m11
-    movhps     [pix0q + strideq], m11
-%else
-    movu       [pix0q], m11
-%endif
     STRONG_CHROMA %1
 
 .end_strong_chroma:
@@ -511,12 +491,12 @@ ALIGN 16
 
     movu             m11, m12
 %if %1 == 8
-    movlps           m14, [pixq + strideq]
-    movhps           m14, [pixq + 2 * strideq]
+    movlps           m14, [pix0q]
+    movhps           m14, [pix0q + strideq]
     pand             m11, m14
 %else
     movu             m14, m11
-    pand             m11, [pixq]
+    pand             m11, [pix0q]
 %endif
     MASKED_COPY       m4, m15 ; need to mask the copy since we can have a mix of weak + others
 .end_weak_chroma:

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -525,7 +525,7 @@ ALIGN 16
 %endmacro
 
 %macro LOOP_FILTER_CHROMA 0
-cglobal vvc_v_loop_filter_chroma_8, 9, 15, 16, 112, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride, spatial_mask, tcptr
+cglobal vvc_v_loop_filter_chroma_8, 9, 15, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift, pix0, q_len, src3stride
     sub            pixq, 4
     lea       src3strideq, [3*strideq]
     mov           pix0q, pixq
@@ -535,7 +535,7 @@ cglobal vvc_v_loop_filter_chroma_8, 9, 15, 16, 112, pix, stride, beta, tc, no_p,
     TRANSPOSE8x8B_STORE PASS8ROWS(pix0q, pixq, strideq, src3strideq)
     RET
 
-cglobal vvc_v_loop_filter_chroma_10, 9, 15, 16, 112, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride, spatial_mask, tcptr
+cglobal vvc_v_loop_filter_chroma_10, 9, 15, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift, pix0, q_len, src3stride
     sub            pixq, 8
     lea       src3strideq, [3*strideq]
     mov           pix0q, pixq
@@ -545,7 +545,7 @@ cglobal vvc_v_loop_filter_chroma_10, 9, 15, 16, 112, pix, stride, beta, tc, no_p
     TRANSPOSE8x8W_STORE PASS8ROWS(pix0q, pixq, strideq, src3strideq), [pw_pixel_max_10]
     RET
 
-cglobal vvc_v_loop_filter_chroma_12, 9, 15, 16, 112, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride, spatial_mask, tcptr
+cglobal vvc_v_loop_filter_chroma_12, 9, 15, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift, pix0, q_len, src3stride
     sub            pixq, 8
     lea       src3strideq, [3*strideq]
     mov           pix0q, pixq
@@ -555,7 +555,7 @@ cglobal vvc_v_loop_filter_chroma_12, 9, 15, 16, 112, pix, stride, beta, tc, no_p
     TRANSPOSE8x8W_STORE PASS8ROWS(pix0q, pixq, strideq, src3strideq), [pw_pixel_max_12]
     RET
 
-cglobal vvc_h_loop_filter_chroma_8, 9, 15, 16, 112, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride, spatial_mask, tcptr
+cglobal vvc_h_loop_filter_chroma_8, 9, 15, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
     lea     src3strideq, [3 * strideq]
     mov           pix0q, pixq
     sub           pix0q, src3strideq
@@ -598,7 +598,7 @@ cglobal vvc_h_loop_filter_chroma_8, 9, 15, 16, 112, pix, stride, beta, tc, no_p,
 
 RET
 
-cglobal vvc_h_loop_filter_chroma_10, 9, 15, 16, 112, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride, spatial_mask, tcptr
+cglobal vvc_h_loop_filter_chroma_10, 9, 15, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
     lea    src3strideq, [3 * strideq]
     mov           pix0q, pixq
     sub           pix0q, src3strideq
@@ -635,7 +635,7 @@ cglobal vvc_h_loop_filter_chroma_10, 9, 15, 16, 112, pix, stride, beta, tc, no_p
 
 RET
 
-cglobal vvc_h_loop_filter_chroma_12, 9, 15, 16, 112, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride, spatial_mask, tcptr
+cglobal vvc_h_loop_filter_chroma_12, 9, 15, 16, pix, stride, beta, tc, no_p, no_q, max_len_p, max_len_q, shift , pix0, q_len, src3stride
     lea    src3strideq, [3 * strideq]
     mov           pix0q, pixq
     sub           pix0q, src3strideq

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -95,7 +95,14 @@ ALIGN 16
 
     cmp            no_qq, 0
     je      .end_q_calcs
-    movu             m11, [rsp + 32] ; strong
+
+%if %1 == 8
+    movlps          m11, [pix0q]
+    movhps          m11, [pix0q + strideq]
+%else
+    movu             m11, [pix0q]
+%endif
+
     pand             m11, [rsp ]     ; strong & q
 
     ; Q0
@@ -322,7 +329,12 @@ ALIGN 16
     paddw          m15, m2, m3      ; p1 + p0
     CHROMA_FILTER  m3
 
-    movu         m11, [rsp + 32]    ; strong mask
+%if %1 == 8
+    movlps          m11, [pix0q]
+    movhps          m11, [pix0q + strideq]
+%else
+    movu         m11, [pix0q]
+%endif
     pand         m11, [rsp]         ; no_q
 
     ; Q0
@@ -345,7 +357,6 @@ ALIGN 16
     mov spatial_maskq, rsp
     sub rsp, 16
     mov tcptrq, rsp
-    sub rsp, 16  ; rsp + 32 = strong mask
     sub rsp, 16  ; rsp + 16 = no_p
     sub rsp, 16  ; rsp      = no_q
 
@@ -424,7 +435,12 @@ ALIGN 16
     cmp              r14, 0
     je              .end_strong_chroma
 
-    movu       [rsp + 32], m11
+%if %1 == 8
+    movh       [pix0q], m11
+    movhps     [pix0q + strideq], m11
+%else
+    movu       [pix0q], m11
+%endif
     STRONG_CHROMA %1
 
 .end_strong_chroma:
@@ -439,7 +455,13 @@ ALIGN 16
     cmp              r14, 0
     je              .end_one_side_chroma
 
-    movu     [rsp + 32], m11
+%if %1 == 8
+    movh     [pix0q], m11
+    movhps    [pix0q + strideq], m11
+%else
+    movu     [pix0q], m11
+%endif
+
     ONE_SIDE_CHROMA %1
 .end_one_side_chroma:
 
@@ -464,7 +486,7 @@ ALIGN 16
     pand             m11, [rsp]
     MASKED_COPY       m4, m15 ; need to mask the copy since we can have a mix of weak + others
 .end_weak_chroma:
-    add rsp, 80
+    add rsp, 64
 %endmacro
 
 %macro LOOP_FILTER_CHROMA 0

--- a/libavcodec/x86/vvc/vvc_deblock.asm
+++ b/libavcodec/x86/vvc/vvc_deblock.asm
@@ -124,7 +124,6 @@ ALIGN 16
     movhps           m14, [pix0q + strideq]
     pand             m11, m14     ; strong & q
 %else
-    ; movu             m14, m11
     pand             m11, [pix0q ]     ; strong & q
 %endif 
 
@@ -152,7 +151,7 @@ ALIGN 16
 ; m11 strong mask, m8/m9 -tc, tc
 %macro SPATIAL_ACTIVITY 1
 
-    ; if p == 1, then p3, p2 are p1 for spatial calc
+    ; if p == 1, then p3, p2 replace p1 for spatial calc
     pxor              m10, m10
     movd              m11, [max_len_pq]
     punpcklbw         m11, m11, m10
@@ -163,7 +162,7 @@ ALIGN 16
     SHUFFLE_ON_SHIFT2 m11, m13
 
 %if %1 == 8
-    packuswb   m8,     m0, m1
+    packuswb       m8, m0, m1
     movh      [pix0q], m8
     movhps    [pix0q + strideq], m8
 %else
@@ -179,7 +178,6 @@ ALIGN 16
     LOAD_TC %1, m8
 
     ; if max_len_q == 3, compute spatial activity to determine final length
-    pxor               m10, m10
     movd               m11, [max_len_qq]
     punpcklbw          m11, m11, m10
     punpcklwd          m11, m11, m10
@@ -371,14 +369,9 @@ ALIGN 16
     movmskps      no_pq, m11
 
     SHUFFLE_ON_SHIFT m13, m11
-%if %1 == 8
     movu      m14, m13
-%else
-    movu      m14, m13
-%endif
 
     ; load max_len_q
-    pxor            m10, m10
     movd            m11, [max_len_pq]
     punpcklbw       m11, m11, m10
     punpcklwd       m11, m11, m10
@@ -389,18 +382,16 @@ ALIGN 16
 
     SHUFFLE_ON_SHIFT m13, m11
 
-%if %1 == 8
     pand             m13, m14
+%if %1 == 8
     movh             [pix0q + 2 * strideq], m13
     movhps           [pix0q + src3strideq], m13
 %else
-    pand             m13, m14
     movu             [pix0q + 2 * strideq], m13
 %endif
     movmskps         no_pq, m13
 
     ; no_q
-    pxor            m10, m10
     movd            m11, [no_qq]
     punpcklbw       m11, m11, m10
     punpcklwd       m11, m11, m10
@@ -411,14 +402,11 @@ ALIGN 16
     SHUFFLE_ON_SHIFT m13, m11
     movu             m14, m13
 
-    
-    pxor            m10, m10
     movd            m11, [max_len_qq]
     punpcklbw       m11, m11, m10
     punpcklwd       m11, m11, m10
 
     pcmpeqd         m11, m10 ; which are 0
-    pcmpeqd         m12, m12, m12
     pcmpeqd         m11, m10
 
     SHUFFLE_ON_SHIFT   m13, m11
@@ -432,12 +420,10 @@ ALIGN 16
     movmskps         no_qq, m13
 ; end q
 
-
     movmskps         r14, m11
     cmp              r14, 0
     je              .chroma_weak
 
-    pxor            m10, m10
     movd            m11, [max_len_pq]
     punpcklbw       m11, m11, m10
     punpcklwd       m11, m11, m10
@@ -517,7 +503,6 @@ ALIGN 16
     movhps           m14, [pix0q + strideq]
     pand             m11, m14
 %else
-    movu             m14, m11
     pand             m11, [pix0q]
 %endif
     MASKED_COPY       m4, m15 ; need to mask the copy since we can have a mix of weak + others

--- a/libavcodec/x86/vvc/vvcdsp_init.c
+++ b/libavcodec/x86/vvc/vvcdsp_init.c
@@ -367,6 +367,7 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
             AVG_INIT(8, avx2);
             MC_LINKS_AVX2(8);
             SAD_INIT();
+            DEBLOCK_INIT(8);
         }
         break;
     case 10:
@@ -382,7 +383,7 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
             MC_LINKS_AVX2(10);
             MC_LINKS_16BPC_AVX2(10);
             SAD_INIT();
-
+            DEBLOCK_INIT(10);
         }
         break;
     case 12:
@@ -398,7 +399,7 @@ void ff_vvc_dsp_init_x86(VVCDSPContext *const c, const int bd)
             MC_LINKS_AVX2(12);
             MC_LINKS_16BPC_AVX2(12);
             SAD_INIT();
-
+            DEBLOCK_INIT(12);
         }
         break;
     default:


### PR DESCRIPTION
Since we're storing the lines of the CTU in registers, we can use the CTU as additional storage (it gets overwritten at the very end with the correct values).

